### PR TITLE
Optimize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,7 @@ This repo is an optimization effort. For any perf change:
   exhaustive converged-window scan): +0.03% (worse). `SplitCost` minimizes a
   *greedy*-LZ77 proxy while output uses optimal LZ77; precise proxy-minimization
   overfits and diverges. The coarse 9-point search is intentional tuning.
+- Splitter histogram memoization: already done. `store->ll_counts`/`d_counts`
+  are maintained as incremental prefix sums, and `ZopfliLZ77GetHistogram`
+  computes any range by subtracting two cumulative snapshots (O(~320), not
+  O(range)). It's ~0.1% in the profile — not a bottleneck. Don't re-propose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,15 @@ Repo-specific guidance. General coding preferences live in the user-global
 CLAUDE.md; this file adds what's specific to this codebase.
 
 ## Language & style
-- **C89 / ANSI** — built with `-ansi -pedantic -W -Wall -Wextra`. No C99/C11:
-  - Declarations at the top of a block (no mixed declarations and statements).
+- **gnu99** — built with `-std=gnu99 -pedantic -W -Wall -Wextra` (C99 for
+  `<stdint.h>` fixed-width cost types, plus the GNU `__builtin_clz` the code
+  uses). Keep the conservative house style otherwise:
+  - Declarations at the top of a block (no mixed declarations and statements),
+    except short-lived locals in the few verbose-print blocks.
   - No VLAs. No `//` line comments — use `/* */` block comments.
-  - For `inline`, use a compiler-guarded macro (e.g. `__inline__` under
-    GCC/Clang), never bare `inline`.
+  - Fixed-width integers via `<stdint.h>` (`uint32_t`/`uint64_t`); avoid `size_t`
+    for fixed-width numeric values (it varies by platform). For `inline`, use a
+    compiler-guarded macro, never bare `inline`.
 - **80-column hard wrap** for source. Exception: Makefile flag lists, where
   breaking would harm grep/readability.
 - Comments concise, matching the existing files; explain *why*, not *what*.
@@ -51,8 +55,12 @@ This repo is an optimization effort. For any perf change:
 
 ## Architecture notes (hot path)
 - The cost model in `squeeze.c` is **fixed-point `int`** (`ZopfliCost`, per-block
-  shift from `ZopfliGetCostShift`). `ZopfliCalculateEntropy` and
-  `ZopfliCalculateBlockSize` remain floating-point on purpose.
+  shift from `ZopfliGetCostShift`). The whole core library is now **float-free
+  and deterministic across CPUs**: `ZopfliCalculateEntropy` uses an integer
+  fixed-point log2 (`IntLog2Fixed`, Q`shift`), and the block-size/splitter/cost
+  values are `uint32_t` (`IntLog2Fixed`'s mantissa square is `uint64_t`). Build
+  is gnu99 (`<stdint.h>`), no `-lm`. Keep it float-free (it targets FPU-less
+  devices and bit-reproducible output) — verify with the `-ffast-math` md5 test.
 - Nearly all time is in `ZopfliLZ77Optimal` → `LZ77OptimalRun` →
   `GetBestLengths` (forward DP: hash bookkeeping + `ZopfliFindLongestMatch` +
   cost DP). `FollowPath` no longer touches the hash — distances are carried
@@ -72,9 +80,6 @@ This repo is an optimization effort. For any perf change:
   the complexity.
 - One-step-ahead `__builtin_prefetch` in `ZopfliUpdateHash`: regressed ~8%
   (prefetch distance too short).
-- Making entropy fixed-point: ~0% (entropy is ~0.04% of runtime; its precision
-  is already discarded by `ScaleCost`). Only relevant for cross-platform
-  determinism, which would also require converting `ZopfliCalculateBlockSize`.
 - Ratio lever `ZOPFLI_MAX_CHAIN_HITS` 8192→32768: 0% size change on a mixed
   corpus and on constructed pathological input — the cap effectively never binds
   within the 32 KB window. Only costs speed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,13 @@ This repo is an optimization effort. For any perf change:
   forward in `dist_array` alongside `length_array`.
 - Regimes differ: default iterations are match-finding + katajainen bound; high
   iterations are squeeze-inner-loop + hash bound.
-- The remaining `GetBestLengths` per-byte `ZopfliUpdateHash` (~20% high-iter)
-  cannot be safely skipped: `ZopfliFindLongestMatch` can still miss the
-  longest-match cache (matches with >8 distinct sub-distances overflow the
-  8-entry sublen cache), and the `prev[]` chain is all-or-nothing per pass.
+- `ZopfliUpdateHash` now runs only in the greedy pass and DP iteration 0. The
+  LMC stores the *complete* sublen as variable-length runs (`cache.c`:
+  `run_off` + `pool`, `all_complete`), so once a block is fully cached the
+  squeeze DP serves every position from cache and `GetBestLengths` skips the
+  whole hash rebuild for iterations ≥2 (`build_hash` flag). Blocks using the
+  long-repetition shortcut or overflowing the pool budget keep `all_complete=0`
+  and rebuild the hash every iteration, as before.
 
 ## Tried and rejected (don't redo without new evidence)
 - `static inline` of `ZopfliUpdateHash`: measured ~3% but reverted — not worth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md — Zopfli
+
+Repo-specific guidance. General coding preferences live in the user-global
+CLAUDE.md; this file adds what's specific to this codebase.
+
+## Language & style
+- **C89 / ANSI** — built with `-ansi -pedantic -W -Wall -Wextra`. No C99/C11:
+  - Declarations at the top of a block (no mixed declarations and statements).
+  - No VLAs. No `//` line comments — use `/* */` block comments.
+  - For `inline`, use a compiler-guarded macro (e.g. `__inline__` under
+    GCC/Clang), never bare `inline`.
+- **80-column hard wrap** for source. Exception: Makefile flag lists, where
+  breaking would harm grep/readability.
+- Comments concise, matching the existing files; explain *why*, not *what*.
+- Public API is `Zopfli`-prefixed and declared in headers; internal helpers are
+  `static`.
+- When you modify a source file that carries an `Author:` block, append:
+  `Author: afalls@qvxlabs.com (Ardavon Falls)`
+
+## Build & test
+- **Two build systems:**
+  - `make` → the release build: `-O3 -DNDEBUG -fPIC`. `NDEBUG` strips asserts and
+    the `ZopfliVerifyLenDist` check. `make CFLAGS=-UNDEBUG` re-enables them.
+  - CMake → honors `CMAKE_BUILD_TYPE`. `Release`/`RelWithDebInfo`/`MinSizeRel`
+    auto-add `-DNDEBUG`; `Debug` keeps asserts. The project intentionally does
+    not default the build type.
+- **Tests:** `cmake-build-debug/` (Debug → asserts ON), C++11 / GoogleTest via
+  conan's GTest provider; run with `ctest`. Don't use `gtest_*` CMake helper
+  functions. Keep asserts enabled in the test build.
+
+## Performance-work discipline
+This repo is an optimization effort. For any perf change:
+- **Keep output byte-identical** to the pre-change baseline unless explicitly
+  agreed otherwise. Verify with `md5` of compressed output in **both regimes** —
+  default (`-i15`) and high-iteration (`--i200`) — on text and binary inputs.
+- Validate with **asserts ON** (build without `-DNDEBUG`): `ZopfliVerifyLenDist`
+  then checks every emitted match — a free per-match correctness net.
+- Run the `ctest` suite.
+- **Single-threaded only.** Never propose or add threads/OpenMP/parallelism,
+  even though blocks and iterations are independent. (Explicit project decision.)
+
+## Benchmarking on this machine
+- Wall-clock/user-CPU is dominated by background CPU contention (a `b2`/conan
+  build at 100%, CLion/Rider). The same binary has varied 26–53 s for one run.
+- Before timing: `ps -Ao pcpu,comm | sort -rn | head` and ensure no
+  `b2`/`cc`/`clang`/`ninja`/`cmake` is busy. Interleave runs (A/B/A/B…) and take
+  the **minimum**.
+- For small deltas, the `sample` profiler's **relative function shares** are more
+  reliable than wall-clock (load-independent). gprof is unavailable (clang
+  rejects `-pg` on macOS); use `sample`.
+
+## Architecture notes (hot path)
+- The cost model in `squeeze.c` is **fixed-point `int`** (`ZopfliCost`, per-block
+  shift from `ZopfliGetCostShift`). `ZopfliCalculateEntropy` and
+  `ZopfliCalculateBlockSize` remain floating-point on purpose.
+- Nearly all time is in `ZopfliLZ77Optimal` → `LZ77OptimalRun` →
+  `GetBestLengths` (forward DP: hash bookkeeping + `ZopfliFindLongestMatch` +
+  cost DP). `FollowPath` no longer touches the hash — distances are carried
+  forward in `dist_array` alongside `length_array`.
+- Regimes differ: default iterations are match-finding + katajainen bound; high
+  iterations are squeeze-inner-loop + hash bound.
+- The remaining `GetBestLengths` per-byte `ZopfliUpdateHash` (~20% high-iter)
+  cannot be safely skipped: `ZopfliFindLongestMatch` can still miss the
+  longest-match cache (matches with >8 distinct sub-distances overflow the
+  8-entry sublen cache), and the `prev[]` chain is all-or-nothing per pass.
+
+## Tried and rejected (don't redo without new evidence)
+- `static inline` of `ZopfliUpdateHash`: measured ~3% but reverted — not worth
+  the complexity.
+- One-step-ahead `__builtin_prefetch` in `ZopfliUpdateHash`: regressed ~8%
+  (prefetch distance too short).
+- Making entropy fixed-point: ~0% (entropy is ~0.04% of runtime; its precision
+  is already discarded by `ScaleCost`). Only relevant for cross-platform
+  determinism, which would also require converting `ZopfliCalculateBlockSize`.
+- Ratio lever `ZOPFLI_MAX_CHAIN_HITS` 8192→32768: 0% size change on a mixed
+  corpus and on constructed pathological input — the cap effectively never binds
+  within the 32 KB window. Only costs speed.
+- Ratio lever: making `FindMinimum`'s block-split search finer (more samples +
+  exhaustive converged-window scan): +0.03% (worse). `SplitCost` minimizes a
+  *greedy*-LZ77 proxy while output uses optimal LZ77; precise proxy-minimization
+  overfits and diverges. The coarse 9-point search is intentional tuning.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Zopfli VERSION 1.0.5 LANGUAGES C CXX)
 
+# C99 for <stdint.h> (fixed-width cost types). The default would usually be new
+# enough, but pin it so the dependency is explicit.
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
 #
 # Options
 #
@@ -57,9 +62,7 @@ set_target_properties(libzopfli PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
 )
-if(UNIX AND NOT (BEOS OR HAIKU))
-  target_link_libraries(libzopfli PUBLIC m)
-endif()
+# libzopfli is integer-only now; no libm needed.
 
 #
 # libzopflipng

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ if(BUILD_TESTING)
     test/blocksplitter_test.cc
     test/deflate_test.cc
     test/squeeze_test.cc
+    test/fixedpoint_range_test.cc
   )
   target_link_libraries(zopfli_tests PRIVATE libzopfli GTest::gtest_main)
   set_target_properties(zopfli_tests PROPERTIES
@@ -156,6 +157,14 @@ if(BUILD_TESTING)
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
   )
+
+  # Optional: link zlib to enable the fixed-point round-trip checks. When
+  # absent, those tests skip themselves.
+  find_package(ZLIB QUIET)
+  if(ZLIB_FOUND)
+    target_link_libraries(zopfli_tests PRIVATE ZLIB::ZLIB)
+    target_compile_definitions(zopfli_tests PRIVATE ZOPFLI_TEST_HAVE_ZLIB)
+  endif()
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,38 @@ if(MSVC)
   target_compile_definitions(zopflipng PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
+#
+# Warnings as errors (always on; first-party code only, vendored LodePNG is
+# exempted). MSVC uses /WX; GCC/Clang use -Werror plus the same warning set as
+# the Makefile so the policy matches across build systems.
+#
+if(MSVC)
+  foreach(zopfli_target libzopfli libzopflipng zopfli zopflipng)
+    target_compile_options(${zopfli_target} PRIVATE /WX)
+  endforeach()
+  # Keep LodePNG's warnings non-fatal.
+  set_source_files_properties(
+    src/zopflipng/lodepng/lodepng.cpp
+    src/zopflipng/lodepng/lodepng_util.cpp
+    PROPERTIES COMPILE_OPTIONS "/WX-"
+  )
+else()
+  set(zopfli_c_warn -Wall -Wextra -pedantic -Werror)
+  set(zopfli_cxx_warn -Wall -Wextra -pedantic -Werror)
+  foreach(zopfli_target libzopfli libzopflipng zopfli zopflipng)
+    target_compile_options(${zopfli_target} PRIVATE
+      $<$<COMPILE_LANGUAGE:C>:${zopfli_c_warn}>
+      $<$<COMPILE_LANGUAGE:CXX>:${zopfli_cxx_warn}>
+    )
+  endforeach()
+  # Silence vendored LodePNG entirely (third-party; we don't lint it).
+  set_source_files_properties(
+    src/zopflipng/lodepng/lodepng.cpp
+    src/zopflipng/lodepng/lodepng_util.cpp
+    PROPERTIES COMPILE_OPTIONS "-w"
+  )
+endif()
+
 # Create aliases
 #
 # Makes targets available to projects using Zopfli as a subproject using the

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ else
   shared_soname = lib$(1).so.$(VERSION_MAJOR)
 endif
 
-override CFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -Wno-unused-function -fPIC $(CFLAGS)
-override CXXFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -fPIC $(CXXFLAGS)
+# NDEBUG strips asserts and the ZopfliVerifyLenDist check for the release build.
+# User CFLAGS are appended after, so `make CFLAGS=-UNDEBUG` re-enables them.
+override CFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -DNDEBUG -Wno-unused-function -fPIC $(CFLAGS)
+override CXXFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -DNDEBUG -fPIC $(CXXFLAGS)
 LDLIBS := -lm $(LDLIBS)
 
 ZOPFLILIB_SRC = src/zopfli/blocksplitter.c src/zopfli/cache.c\

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 # NDEBUG strips asserts and the ZopfliVerifyLenDist check for the release build.
 # User CFLAGS are appended after, so `make CFLAGS=-UNDEBUG` re-enables them.
 # C99 (for <stdint.h>) plus the GNU builtins the code uses (__builtin_clz).
-override CFLAGS := -W -Wall -Wextra -std=gnu99 -pedantic -O3 -DNDEBUG -Wno-unused-function -fPIC $(CFLAGS)
+override CFLAGS := -W -Wall -Wextra -std=gnu99 -pedantic -O3 -DNDEBUG -fPIC $(CFLAGS)
 override CXXFLAGS := -W -Wall -Wextra -std=gnu++11 -pedantic -O3 -DNDEBUG -fPIC $(CXXFLAGS)
 LDLIBS := $(LDLIBS)
 
@@ -48,12 +48,13 @@ all: zopfli libzopfli libzopfli.a zopflipng libzopflipng libzopflipng.a
 
 obj/%.o: %.c
 	@mkdir -p `dirname $@`
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -Werror -c $< -o $@
 
 obj/%.o: %.cc
 	@mkdir -p `dirname $@`
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -Werror -c $< -o $@
 
+# Vendored LodePNG: no -Werror so upstream's warnings don't break the build.
 obj/%.o: %.cpp
 	@mkdir -p `dirname $@`
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,10 @@ endif
 
 # NDEBUG strips asserts and the ZopfliVerifyLenDist check for the release build.
 # User CFLAGS are appended after, so `make CFLAGS=-UNDEBUG` re-enables them.
-override CFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -DNDEBUG -Wno-unused-function -fPIC $(CFLAGS)
-override CXXFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -DNDEBUG -fPIC $(CXXFLAGS)
-LDLIBS := -lm $(LDLIBS)
+# C99 (for <stdint.h>) plus the GNU builtins the code uses (__builtin_clz).
+override CFLAGS := -W -Wall -Wextra -std=gnu99 -pedantic -O3 -DNDEBUG -Wno-unused-function -fPIC $(CFLAGS)
+override CXXFLAGS := -W -Wall -Wextra -std=gnu++11 -pedantic -O3 -DNDEBUG -fPIC $(CXXFLAGS)
+LDLIBS := $(LDLIBS)
 
 ZOPFLILIB_SRC = src/zopfli/blocksplitter.c src/zopfli/cache.c\
                 src/zopfli/deflate.c src/zopfli/gzip_container.c\

--- a/README.md
+++ b/README.md
@@ -31,6 +31,64 @@ The source code of Zopfli is under `src/zopfli`. `zopfli_bin.c` is separate from
 the library and contains an example program to create very well compressed gzip
 files.
 
+## Compression options
+
+Compression is controlled by `ZopfliOptions` (set defaults with
+`ZopfliInitOptions`); the `zopfli` binary exposes the main knobs as flags. Every
+setting produces standard DEFLATE that any zlib/gzip decoder can read — they only
+trade encoder time for output size. Zopfli already operates near the practical
+DEFLATE size limit, so the gains are small in absolute terms.
+
+### Iterations — `numiterations` / `--i#` (default 15)
+
+The dominant quality/speed knob. Each iteration reruns the optimal LZ77 parse
+with a cost model refined from the previous pass, converging toward a smaller
+encoding. Runtime is roughly **linear** in the count; ratio gains have steep
+**diminishing returns**.
+
+The table below compresses ~415 KB of text and reports the output size at each
+setting, relative to the default of 15:
+
+| Iterations (`--i`) | Compressed size | Reduction vs default | Relative runtime |
+|:------------------:|----------------:|:--------------------:|:----------------:|
+| 5                  |   101,950 bytes | −0.06% (**worse**)   |       ~0.3×       |
+| **15** (default)   |   101,886 bytes | —                    |        1×        |
+| 30                 |   101,857 bytes | 0.03%                |        ~2×        |
+| 50                 |   101,854 bytes | 0.03%                |        ~3×        |
+| 100                |   101,796 bytes | 0.09%                |        ~7×        |
+| 200                |   101,704 bytes | 0.18%                |       ~13×        |
+| 500                |   101,674 bytes | 0.21%                |       ~33×        |
+| 1000               |   101,661 bytes | 0.22%                |       ~67×        |
+
+Takeaways: the default 15 already captures ~99.8% of what `--i1000` achieves;
+the *entire* remaining headroom from iterations is ~0.22%. Don't go below the
+default (at `--i5` the parse hasn't converged and output is larger). `--i200`–
+`--i500` is the knee if you want "smaller at reasonable cost"; for very large
+files keep it low to bound runtime. Highly compressible (text-like) data
+benefits most — incompressible or binary data converges flatter.
+
+### Block splitting — `blocksplitting`, `blocksplittingmax`, `blocksplittinglast`
+
+DEFLATE lets each block carry its own Huffman trees, so splitting the input into
+well-chosen blocks lets the trees fit each region better. This usually shrinks
+output, so `blocksplitting` defaults to on.
+
+- `blocksplittingmax` (default 15) caps the number of blocks. `0` means
+  unlimited, which can *hurt* compression on some files (per-block tree overhead
+  outweighs the gain) — the cap exists on purpose.
+- `blocksplittinglast` (default off) chooses *when* split points are picked: the
+  default picks them from a fast initial pass, which — perhaps unintuitively —
+  yields better boundaries than splitting after the expensive optimal parse.
+  Leave it off unless experimenting.
+
+### Output format and verbosity
+
+The container (`--deflate` / `--zlib` / `--gzip`, or the `ZopfliCompress` format
+argument) does **not** change the compressed payload — only the few header/footer
+bytes and the checksum (gzip uses CRC-32, zlib Adler-32, raw DEFLATE none).
+Choose by what the consumer expects, not for ratio. `verbose` / `-v` only prints
+progress to stderr and has no effect on the output.
+
 ## Getting started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ The source code of Zopfli is under `src/zopfli`. `zopfli_bin.c` is separate from
 the library and contains an example program to create very well compressed gzip
 files.
 
+## Deterministic, floating-point-free
+
+This fork's core library (`src/zopfli`) contains **no floating point**. The cost
+model that drives the optimal parse — including the entropy / `-log2`
+computation — is computed entirely in **integer fixed point** (`IntLog2Fixed`,
+with the precision derived from the per-block cost shift; block sizes and costs
+are `uint32_t`). Two consequences:
+
+- **Bit-identical output on every CPU.** Upstream zopfli computes symbol costs
+  with `libm`'s `log()`, whose result varies by platform, compiler, and FP mode
+  (x87 vs SSE, FMA contraction, `-ffast-math`); that can change which parse is
+  chosen and therefore the output bytes. Here the output is reproducible across
+  all of those — verified by building at `-O0`, `-O3`, and
+  `-O3 -ffast-math -ffp-contract=fast` and checking the compressed `md5` is
+  identical (with no FP in the code, these flags cannot change the result).
+- **Runs well on devices without an FPU.** No soft-float emulation and no `libm`
+  dependency, so the library is smaller and faster on embedded / microcontroller
+  targets. The build uses `-std=gnu99` (for `<stdint.h>`) and links no `-lm`.
+
+Compression ratio is within ~0.02% of the floating-point version (sometimes
+better). Note the output is **not** byte-identical to upstream zopfli — it
+defines a new, canonical, platform-independent encoding.
+
 ## Compression options
 
 Compression is controlled by `ZopfliOptions` (set defaults with

--- a/README.md
+++ b/README.md
@@ -39,20 +39,28 @@ setting produces standard DEFLATE that any zlib/gzip decoder can read — they o
 trade encoder time for output size. Zopfli already operates near the practical
 DEFLATE size limit, so the gains are small in absolute terms.
 
-### Iterations — `numiterations` / `--i#` (default 15)
+### Iterations — `numiterations` / `--i#` (default: `0` = auto)
 
 The dominant quality/speed knob. Each iteration reruns the optimal LZ77 parse
 with a cost model refined from the previous pass, converging toward a smaller
 encoding. Runtime is roughly **linear** in the count; ratio gains have steep
 **diminishing returns**.
 
-The table below compresses ~415 KB of text and reports the output size at each
-setting, relative to the default of 15:
+**Default is auto** (`numiterations == 0`, or `--i0`): the count scales with
+input size — `10 + 12·floor(log2(size/1KB))` (size quantized to a power of two),
+clamped to `[15, 400]`. Small inputs saturate in a few iterations, while larger
+inputs have a longer tail of gains, so they get more passes (e.g. 15 at ≤1 KB,
+58 at 16 KB, 106 at 256 KB, 130 at 1 MB). Because runtime scales with
+`size × iterations`, large inputs in auto mode are intentionally slow; pass an
+explicit `--i#` to force a fixed count (e.g. `--i15` for the old default's speed).
 
-| Iterations (`--i`) | Compressed size | Reduction vs default | Relative runtime |
+The table below compresses ~415 KB of text at various **fixed** `--i#` counts
+(relative to `--i15`):
+
+| Iterations (`--i`) | Compressed size | Reduction vs `--i15` | Relative runtime |
 |:------------------:|----------------:|:--------------------:|:----------------:|
 | 5                  |   101,950 bytes | −0.06% (**worse**)   |       ~0.3×       |
-| **15** (default)   |   101,886 bytes | —                    |        1×        |
+| 15                 |   101,886 bytes | —                    |        1×        |
 | 30                 |   101,857 bytes | 0.03%                |        ~2×        |
 | 50                 |   101,854 bytes | 0.03%                |        ~3×        |
 | 100                |   101,796 bytes | 0.09%                |        ~7×        |
@@ -60,11 +68,11 @@ setting, relative to the default of 15:
 | 500                |   101,674 bytes | 0.21%                |       ~33×        |
 | 1000               |   101,661 bytes | 0.22%                |       ~67×        |
 
-Takeaways: the default 15 already captures ~99.8% of what `--i1000` achieves;
-the *entire* remaining headroom from iterations is ~0.22%. Don't go below the
-default (at `--i5` the parse hasn't converged and output is larger). `--i200`–
-`--i500` is the knee if you want "smaller at reasonable cost"; for very large
-files keep it low to bound runtime. Highly compressible (text-like) data
+Takeaways: `--i15` already captures ~99.8% of what `--i1000` achieves; the
+*entire* remaining headroom from iterations is ~0.22%, and most of it is in the
+first ~8 passes. `--i5` hasn't converged (output is larger). The auto default
+spends more passes on larger inputs, where that thin tail is worth chasing;
+force a fixed `--i#` to cap runtime. Highly compressible (text-like) data
 benefits most — incompressible or binary data converges flatter.
 
 ### Block splitting — `blocksplitting`, `blocksplittingmax`, `blocksplittinglast`

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -173,11 +173,11 @@ static void PrintBlockSplitPoints(const ZopfliLZ77Store* lz77,
 
   fprintf(stderr, "block split points: ");
   for (i = 0; i < npoints; i++) {
-    fprintf(stderr, "%d ", (int)splitpoints[i]);
+    fprintf(stderr, "%zu ", splitpoints[i]);
   }
   fprintf(stderr, "(hex:");
   for (i = 0; i < npoints; i++) {
-    fprintf(stderr, " %x", (int)splitpoints[i]);
+    fprintf(stderr, " %zx", splitpoints[i]);
   }
   fprintf(stderr, ")\n");
 

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -21,6 +21,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include "blocksplitter.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -34,21 +35,21 @@ The "f" for the FindMinimum function below.
 i: the current parameter of f(i)
 context: for your implementation
 */
-typedef double FindMinimumFun(size_t i, void* context);
+typedef uint32_t FindMinimumFun(size_t i, void* context);
 
 /*
-Finds minimum of function f(i) where is is of type size_t, f(i) is of type
-double, i is in range start-end (excluding end).
+Finds minimum of function f(i) where i is of type size_t, f(i) is of type
+uint32_t, i is in range start-end (excluding end).
 Outputs the minimum value in *smallest and returns the index of this value.
 */
 static size_t FindMinimum(FindMinimumFun f, void* context,
-                          size_t start, size_t end, double* smallest) {
+                          size_t start, size_t end, uint32_t* smallest) {
   if (end - start < 1024) {
-    double best = ZOPFLI_LARGE_FLOAT;
+    uint32_t best = ZOPFLI_LARGE_COST;
     size_t result = start;
     size_t i;
     for (i = start; i < end; i++) {
-      double v = f(i, context);
+      uint32_t v = f(i, context);
       if (v < best) {
         best = v;
         result = i;
@@ -61,10 +62,10 @@ static size_t FindMinimum(FindMinimumFun f, void* context,
 #define NUM 9  /* Good value: 9. */
     size_t i;
     size_t p[NUM];
-    double vp[NUM];
+    uint32_t vp[NUM];
     size_t besti;
-    double best;
-    double lastbest = ZOPFLI_LARGE_FLOAT;
+    uint32_t best;
+    uint32_t lastbest = ZOPFLI_LARGE_COST;
     size_t pos = start;
 
     for (;;) {
@@ -106,7 +107,7 @@ dists: ll77 distances
 lstart: start of block
 lend: end of block (not inclusive)
 */
-static double EstimateCost(ZopfliKatajainenScratch* scratch,
+static uint32_t EstimateCost(ZopfliKatajainenScratch* scratch,
                            const ZopfliLZ77Store* lz77,
                            size_t lstart, size_t lend) {
   return ZopfliCalculateBlockSizeAutoTypeScratch(scratch, lz77, lstart, lend);
@@ -125,7 +126,7 @@ Gets the cost which is the sum of the cost of the left and the right section
 of the data.
 type: FindMinimumFun
 */
-static double SplitCost(size_t i, void* context) {
+static uint32_t SplitCost(size_t i, void* context) {
   SplitCostContext* c = (SplitCostContext*)context;
   return EstimateCost(c->scratch, c->lz77, c->start, i)
       + EstimateCost(c->scratch, c->lz77, i, c->end);
@@ -224,7 +225,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   size_t llpos = 0;
   size_t numblocks = 1;
   unsigned char* done;
-  double splitcost, origcost;
+  uint32_t splitcost, origcost;
   /* Reused across all block-size evaluations of this split. */
   ZopfliKatajainenScratch scratch;
 

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "blocksplitter.h"

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -105,13 +105,15 @@ dists: ll77 distances
 lstart: start of block
 lend: end of block (not inclusive)
 */
-static double EstimateCost(const ZopfliLZ77Store* lz77,
+static double EstimateCost(ZopfliKatajainenScratch* scratch,
+                           const ZopfliLZ77Store* lz77,
                            size_t lstart, size_t lend) {
-  return ZopfliCalculateBlockSizeAutoType(lz77, lstart, lend);
+  return ZopfliCalculateBlockSizeAutoTypeScratch(scratch, lz77, lstart, lend);
 }
 
 typedef struct SplitCostContext {
   const ZopfliLZ77Store* lz77;
+  ZopfliKatajainenScratch* scratch;
   size_t start;
   size_t end;
 } SplitCostContext;
@@ -124,7 +126,8 @@ type: FindMinimumFun
 */
 static double SplitCost(size_t i, void* context) {
   SplitCostContext* c = (SplitCostContext*)context;
-  return EstimateCost(c->lz77, c->start, i) + EstimateCost(c->lz77, i, c->end);
+  return EstimateCost(c->scratch, c->lz77, c->start, i)
+      + EstimateCost(c->scratch, c->lz77, i, c->end);
 }
 
 static void AddSorted(size_t value, size_t** out, size_t* outsize) {
@@ -221,8 +224,12 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   size_t numblocks = 1;
   unsigned char* done;
   double splitcost, origcost;
+  /* Reused across all block-size evaluations of this split. */
+  ZopfliKatajainenScratch scratch;
 
   if (lz77->size < 10) return;  /* This code fails on tiny files. */
+
+  ZopfliInitKatajainenScratch(&scratch);
 
   done = (unsigned char*)malloc(lz77->size);
   if (!done) exit(-1); /* Allocation failed. */
@@ -238,6 +245,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
     }
 
     c.lz77 = lz77;
+    c.scratch = &scratch;
     c.start = lstart;
     c.end = lend;
     assert(lstart < lend);
@@ -246,7 +254,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
     assert(llpos > lstart);
     assert(llpos < lend);
 
-    origcost = EstimateCost(lz77, lstart, lend);
+    origcost = EstimateCost(&scratch, lz77, lstart, lend);
 
     if (splitcost > origcost || llpos == lstart + 1 || llpos == lend) {
       done[lstart] = 1;
@@ -269,6 +277,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
     PrintBlockSplitPoints(lz77, *splitpoints, *npoints);
   }
 
+  ZopfliCleanKatajainenScratch(&scratch);
   free(done);
 }
 

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -115,7 +115,7 @@ void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
   for (;;) {
     unsigned runlen = run[0] + 3;
     unsigned dist = run[1] + 256 * run[2];
-    unsigned hi = runlen < length ? runlen : (unsigned)length;
+    unsigned hi = ZOPFLI_MIN(runlen, (unsigned)length);
     for (i = prevlength; i <= hi; i++) {
       sublen[i] = dist;
     }

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -26,24 +26,31 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
 
+/* run_off sentinel: this position has no full sublen stored (pool overflow). */
+#define LMC_NO_SUBLEN ((unsigned)-1)
+
 void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   size_t i;
   lmc->length = (unsigned short*)malloc(sizeof(unsigned short) * blocksize);
   lmc->dist = (unsigned short*)malloc(sizeof(unsigned short) * blocksize);
-  /* Rather large amount of memory. */
-  lmc->sublen = (unsigned char*)malloc(ZOPFLI_CACHE_LENGTH * 3 * blocksize);
-  if(lmc->sublen == NULL) {
+  lmc->run_off = (unsigned*)malloc(sizeof(unsigned) * blocksize);
+  /* Same byte budget as the old fixed cache, used now as a shared run pool. */
+  lmc->pool_cap = (size_t)ZOPFLI_CACHE_LENGTH * blocksize;
+  lmc->pool_used = 0;
+  lmc->all_complete = 1;
+  lmc->pool = (unsigned char*)malloc(3 * lmc->pool_cap);
+  if (lmc->pool == NULL || lmc->run_off == NULL) {
     fprintf(stderr,
         "Error: Out of memory. Tried allocating %lu bytes of memory.\n",
-        (unsigned long)ZOPFLI_CACHE_LENGTH * 3 * blocksize);
+        (unsigned long)(3 * lmc->pool_cap));
     exit (EXIT_FAILURE);
   }
 
   /* length > 0 and dist 0 is invalid combination, which indicates on purpose
-  that this cache value is not filled in yet. sublen is intentionally left
-  uninitialized: ZopfliMaxCachedSublen keys off length == 0 (no match cached),
-  and the entries read for a real match are always written by ZopfliSublenToCache
-  before they are read back. */
+  that this cache value is not filled in yet. pool and run_off are intentionally
+  left uninitialized: ZopfliMaxCachedSublen keys off length == 0 (no match
+  cached), and run_off is only read for a real match, always written by
+  ZopfliSublenToCache before being read back. */
   for (i = 0; i < blocksize; i++) lmc->length[i] = 1;
   for (i = 0; i < blocksize; i++) lmc->dist[i] = 0;
 }
@@ -51,86 +58,71 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
 void ZopfliCleanCache(ZopfliLongestMatchCache* lmc) {
   free(lmc->length);
   free(lmc->dist);
-  free(lmc->sublen);
+  free(lmc->pool);
+  free(lmc->run_off);
 }
 
 void ZopfliSublenToCache(const unsigned short* sublen,
                          size_t pos, size_t length,
                          ZopfliLongestMatchCache* lmc) {
   size_t i;
-  size_t j = 0;
-  unsigned bestlength = 0;
-  unsigned char* cache;
+  size_t nruns = 0;
+  unsigned char* run;
 
 #if ZOPFLI_CACHE_LENGTH == 0
   return;
 #endif
 
-  cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
   if (length < 3) return;
+
+  /* Count the distinct-distance runs this position needs. */
+  for (i = 3; i <= length; i++) {
+    if (i == length || sublen[i] != sublen[i + 1]) nruns++;
+  }
+
+  /* Overflow: keep within the pool budget. Mark incomplete and fall back to
+  recomputation for this position (as an over-cap position did before). */
+  if (lmc->pool_used + nruns > lmc->pool_cap) {
+    lmc->all_complete = 0;
+    lmc->run_off[pos] = LMC_NO_SUBLEN;
+    return;
+  }
+
+  lmc->run_off[pos] = (unsigned)lmc->pool_used;
+  run = &lmc->pool[lmc->pool_used * 3];
   for (i = 3; i <= length; i++) {
     if (i == length || sublen[i] != sublen[i + 1]) {
-      cache[j * 3] = i - 3;
-      cache[j * 3 + 1] = sublen[i] % 256;
-      cache[j * 3 + 2] = (sublen[i] >> 8) % 256;
-      bestlength = i;
-      j++;
-      if (j >= ZOPFLI_CACHE_LENGTH) break;
+      run[0] = (unsigned char)(i - 3);
+      run[1] = sublen[i] % 256;
+      run[2] = (sublen[i] >> 8) % 256;
+      run += 3;
     }
   }
-  if (j < ZOPFLI_CACHE_LENGTH) {
-    assert(bestlength == length);
-    cache[(ZOPFLI_CACHE_LENGTH - 1) * 3] = bestlength - 3;
-  } else {
-    assert(bestlength <= length);
-  }
-  assert(bestlength == ZopfliMaxCachedSublen(lmc, pos, length));
+  lmc->pool_used += nruns;
 }
 
 void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
                          size_t pos, size_t length,
                          unsigned short* sublen) {
-  size_t i, j;
-  unsigned maxlength = ZopfliMaxCachedSublen(lmc, pos, length);
+  size_t i;
   unsigned prevlength = 0;
-  unsigned char* cache;
+  unsigned char* run;
 #if ZOPFLI_CACHE_LENGTH == 0
   return;
 #endif
   if (length < 3) return;
-  cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
-  for (j = 0; j < ZOPFLI_CACHE_LENGTH; j++) {
-    unsigned length = cache[j * 3] + 3;
-    unsigned dist = cache[j * 3 + 1] + 256 * cache[j * 3 + 2];
-    for (i = prevlength; i <= length; i++) {
+  run = &lmc->pool[(size_t)lmc->run_off[pos] * 3];
+  for (;;) {
+    unsigned runlen = run[0] + 3;
+    unsigned dist = run[1] + 256 * run[2];
+    unsigned hi = runlen < length ? runlen : (unsigned)length;
+    for (i = prevlength; i <= hi; i++) {
       sublen[i] = dist;
     }
-    if (length == maxlength) break;
-    prevlength = length + 1;
+    if (runlen >= length) break;
+    prevlength = runlen + 1;
+    run += 3;
   }
-}
-
-int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
-                          size_t pos, unsigned maxlen,
-                          unsigned short* run_maxlen,
-                          unsigned short* run_dist) {
-  unsigned char* cache;
-  size_t j;
-  int n = 0;
-#if ZOPFLI_CACHE_LENGTH == 0
-  return 0;
-#endif
-  if (maxlen < 3) return 0;
-  cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
-  for (j = 0; j < ZOPFLI_CACHE_LENGTH; j++) {
-    unsigned len = cache[j * 3] + 3;
-    unsigned dist = cache[j * 3 + 1] + 256 * cache[j * 3 + 2];
-    run_maxlen[n] = (unsigned short)len;
-    run_dist[n] = (unsigned short)dist;
-    n++;
-    if (len == maxlen) break;
-  }
-  return n;
 }
 
 /*
@@ -138,16 +130,15 @@ Returns the length up to which could be stored in the cache.
 */
 unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,
                                size_t pos, size_t length) {
-  unsigned char* cache;
 #if ZOPFLI_CACHE_LENGTH == 0
   return 0;
 #endif
-  /* length == 0 means no match is cached at this position, hence no sublen.
-  This replaces a sublen[1]==0 && sublen[2]==0 test so the sublen buffer no
-  longer needs zero-initializing (callers pass the cached length). */
+  /* length == 0 means no match is cached; LMC_NO_SUBLEN means the position
+  overflowed the pool and has no full sublen. Otherwise the stored runs cover
+  the whole match, so the max cached sublen is exactly length. */
   if (length == 0) return 0;
-  cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
-  return cache[(ZOPFLI_CACHE_LENGTH - 1) * 3] + 3;
+  if (lmc->run_off[pos] == LMC_NO_SUBLEN) return 0;
+  return (unsigned)length;
 }
 
 #endif  /* ZOPFLI_LONGEST_MATCH_CACHE */

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -40,10 +40,12 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   }
 
   /* length > 0 and dist 0 is invalid combination, which indicates on purpose
-  that this cache value is not filled in yet. */
+  that this cache value is not filled in yet. sublen is intentionally left
+  uninitialized: ZopfliMaxCachedSublen keys off length == 0 (no match cached),
+  and the entries read for a real match are always written by ZopfliSublenToCache
+  before they are read back. */
   for (i = 0; i < blocksize; i++) lmc->length[i] = 1;
   for (i = 0; i < blocksize; i++) lmc->dist[i] = 0;
-  for (i = 0; i < ZOPFLI_CACHE_LENGTH * blocksize * 3; i++) lmc->sublen[i] = 0;
 }
 
 void ZopfliCleanCache(ZopfliLongestMatchCache* lmc) {
@@ -109,17 +111,16 @@ void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
 }
 
 int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
-                          size_t pos, size_t length,
+                          size_t pos, unsigned maxlen,
                           unsigned short* run_maxlen,
                           unsigned short* run_dist) {
-  unsigned maxlength = ZopfliMaxCachedSublen(lmc, pos, length);
   unsigned char* cache;
   size_t j;
   int n = 0;
 #if ZOPFLI_CACHE_LENGTH == 0
   return 0;
 #endif
-  if (length < 3) return 0;
+  if (maxlen < 3) return 0;
   cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
   for (j = 0; j < ZOPFLI_CACHE_LENGTH; j++) {
     unsigned len = cache[j * 3] + 3;
@@ -127,7 +128,7 @@ int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
     run_maxlen[n] = (unsigned short)len;
     run_dist[n] = (unsigned short)dist;
     n++;
-    if (len == maxlength) break;
+    if (len == maxlen) break;
   }
   return n;
 }
@@ -141,9 +142,11 @@ unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,
 #if ZOPFLI_CACHE_LENGTH == 0
   return 0;
 #endif
+  /* length == 0 means no match is cached at this position, hence no sublen.
+  This replaces a sublen[1]==0 && sublen[2]==0 test so the sublen buffer no
+  longer needs zero-initializing (callers pass the cached length). */
+  if (length == 0) return 0;
   cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
-  (void)length;
-  if (cache[1] == 0 && cache[2] == 0) return 0;  /* No sublen cached. */
   return cache[(ZOPFLI_CACHE_LENGTH - 1) * 3] + 3;
 }
 

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -39,10 +39,14 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   lmc->pool_used = 0;
   lmc->all_complete = 1;
   lmc->pool = (unsigned char*)malloc(3 * lmc->pool_cap);
-  if (lmc->pool == NULL || lmc->run_off == NULL) {
+  /* blocksize == 0 makes every malloc above a malloc(0), which may return NULL
+  without being an error; nothing below is read for an empty block. Otherwise
+  any NULL is a real allocation failure (length/dist are written just below). */
+  if (blocksize != 0 && (lmc->length == NULL || lmc->dist == NULL ||
+                         lmc->run_off == NULL || lmc->pool == NULL)) {
     fprintf(stderr,
-        "Error: Out of memory. Tried allocating %lu bytes of memory.\n",
-        (unsigned long)(3 * lmc->pool_cap));
+        "Error: Out of memory. Tried allocating %zu bytes of memory.\n",
+        3 * lmc->pool_cap);
     exit (EXIT_FAILURE);
   }
 

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "cache.h"
@@ -105,6 +106,30 @@ void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
     if (length == maxlength) break;
     prevlength = length + 1;
   }
+}
+
+int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
+                          size_t pos, size_t length,
+                          unsigned short* run_maxlen,
+                          unsigned short* run_dist) {
+  unsigned maxlength = ZopfliMaxCachedSublen(lmc, pos, length);
+  unsigned char* cache;
+  size_t j;
+  int n = 0;
+#if ZOPFLI_CACHE_LENGTH == 0
+  return 0;
+#endif
+  if (length < 3) return 0;
+  cache = &lmc->sublen[ZOPFLI_CACHE_LENGTH * pos * 3];
+  for (j = 0; j < ZOPFLI_CACHE_LENGTH; j++) {
+    unsigned len = cache[j * 3] + 3;
+    unsigned dist = cache[j * 3 + 1] + 256 * cache[j * 3 + 2];
+    run_maxlen[n] = (unsigned short)len;
+    run_dist[n] = (unsigned short)dist;
+    n++;
+    if (len == maxlength) break;
+  }
+  return n;
 }
 
 /*

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -31,16 +31,22 @@ The cache that speeds up ZopfliFindLongestMatch of lz77.c.
 
 /*
 Cache used by ZopfliFindLongestMatch to remember previously found length/dist
-values.
-This is needed because the squeeze runs will ask these values multiple times for
-the same position.
-Uses large amounts of memory, since it has to remember the distance belonging
-to every possible shorter-than-the-best length (the so called "sublen" array).
+values. The sublen (best distance per shorter-than-best length) is stored as
+variable-length 3-byte runs (length-3, dist-lo, dist-hi) in a shared pool;
+run_off[pos] is a position's first run, ending at the run whose threshold equals
+length[pos]. Storing the complete sublen lets the squeeze DP serve every
+position from cache and skip rebuilding the hash after iteration 1.
+all_complete clears if a position overflows the pool budget (pathological
+input); those positions fall back to recomputation as over-cap ones did before.
 */
 typedef struct ZopfliLongestMatchCache {
   unsigned short* length;
   unsigned short* dist;
-  unsigned char* sublen;
+  unsigned char* pool;  /* Shared run pool, 3 bytes per run. */
+  unsigned* run_off;  /* Per pos: first run index in pool, or LMC_NO_SUBLEN. */
+  size_t pool_used;  /* Next free run slot. */
+  size_t pool_cap;  /* Pool capacity in runs. */
+  int all_complete;  /* 1 while every cached position has its full sublen. */
 } ZopfliLongestMatchCache;
 
 /* Initializes the ZopfliLongestMatchCache. */
@@ -58,18 +64,6 @@ void ZopfliSublenToCache(const unsigned short* sublen,
 void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
                          size_t pos, size_t length,
                          unsigned short* sublen);
-
-/*
-Extracts the cached sublen as compact runs instead of a full array: run r covers
-lengths up to and including run_maxlen[r] at distance run_dist[r] (the lower
-bound is the previous run's max + 1, or 3 for the first run). maxlen is the
-already-computed ZopfliMaxCachedSublen for this position. Returns the run count
-(<= ZOPFLI_CACHE_LENGTH). Lets callers consume the cache without materializing
-all sublen entries. run_maxlen/run_dist must hold ZOPFLI_CACHE_LENGTH entries.
-*/
-int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
-                          size_t pos, unsigned maxlen,
-                          unsigned short* run_maxlen, unsigned short* run_dist);
 
 /* Returns the length up to which could be stored in the cache. */
 unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*
@@ -57,6 +58,19 @@ void ZopfliSublenToCache(const unsigned short* sublen,
 void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
                          size_t pos, size_t length,
                          unsigned short* sublen);
+
+/*
+Extracts the cached sublen as compact runs instead of a full array: run r covers
+lengths up to and including run_maxlen[r] at distance run_dist[r] (the lower
+bound is the previous run's max + 1, or 3 for the first run). Returns the run
+count (<= ZOPFLI_CACHE_LENGTH). Lets callers consume the cache without
+materializing all sublen entries. run_maxlen/run_dist must hold
+ZOPFLI_CACHE_LENGTH entries.
+*/
+int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
+                          size_t pos, size_t length,
+                          unsigned short* run_maxlen, unsigned short* run_dist);
+
 /* Returns the length up to which could be stored in the cache. */
 unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,
                                size_t pos, size_t length);

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -62,13 +62,13 @@ void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
 /*
 Extracts the cached sublen as compact runs instead of a full array: run r covers
 lengths up to and including run_maxlen[r] at distance run_dist[r] (the lower
-bound is the previous run's max + 1, or 3 for the first run). Returns the run
-count (<= ZOPFLI_CACHE_LENGTH). Lets callers consume the cache without
-materializing all sublen entries. run_maxlen/run_dist must hold
-ZOPFLI_CACHE_LENGTH entries.
+bound is the previous run's max + 1, or 3 for the first run). maxlen is the
+already-computed ZopfliMaxCachedSublen for this position. Returns the run count
+(<= ZOPFLI_CACHE_LENGTH). Lets callers consume the cache without materializing
+all sublen entries. run_maxlen/run_dist must hold ZOPFLI_CACHE_LENGTH entries.
 */
 int ZopfliCacheSublenRuns(const ZopfliLongestMatchCache* lmc,
-                          size_t pos, size_t length,
+                          size_t pos, unsigned maxlen,
                           unsigned short* run_maxlen, unsigned short* run_dist);
 
 /* Returns the length up to which could be stored in the cache. */

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "deflate.h"

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -792,10 +792,9 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
 
   /* Whether to perform the expensive calculation of creating an optimal block
-  with fixed huffman tree to check if smaller. Only do this for small blocks or
-  blocks which already are pretty good with fixed huffman tree. fixedcost <=
-  dyncost * 1.1 done in integer (x10 <= x11). */
-  int expensivefixed = (lz77->size < 1000) || fixedcost * 10 <= dyncost * 11;
+  with fixed huffman tree to check if it is smaller. */
+  int expensivefixed =
+      ZopfliUseExpensiveFixed(lz77->size, fixedcost, dyncost);
 
   ZopfliLZ77Store fixedstore;
   if (lstart == lend) {
@@ -991,9 +990,10 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
     /* Percent removed with 2 decimals, integer-only (basis points). */
     long bp = insize ? (long)(((long long)insize - (long long)comp) * 10000
                               / (long long)insize) : 0;
+    long abp = bp < 0 ? -bp : bp;  /* keep the sign for small negatives */
     fprintf(stderr,
-            "Original Size: %lu, Deflate: %lu, Compression: %ld.%02ld%% Removed\n",
+            "Original Size: %lu, Deflate: %lu, Compression: %s%ld.%02ld%% Removed\n",
             (unsigned long)insize, (unsigned long)comp,
-            bp / 100, (bp < 0 ? -bp : bp) % 100);
+            bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
 }

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -21,6 +21,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include "deflate.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -526,7 +527,7 @@ Tries out OptimizeHuffmanForRle for this block, if the result is smaller,
 uses it, otherwise keeps the original. Returns size of encoded tree and data in
 bits, not including the 3-bit block header.
 */
-static double TryOptimizeHuffmanForRle(
+static uint32_t TryOptimizeHuffmanForRle(
     ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend,
     const size_t* ll_counts, const size_t* d_counts,
@@ -535,10 +536,10 @@ static double TryOptimizeHuffmanForRle(
   size_t d_counts2[ZOPFLI_NUM_D];
   unsigned ll_lengths2[ZOPFLI_NUM_LL];
   unsigned d_lengths2[ZOPFLI_NUM_D];
-  double treesize;
-  double datasize;
-  double treesize2;
-  double datasize2;
+  uint32_t treesize;
+  uint32_t datasize;
+  uint32_t treesize2;
+  uint32_t datasize2;
 
   treesize = CalculateTreeSize(scratch, ll_lengths, d_lengths);
   datasize = CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
@@ -573,7 +574,7 @@ symbols to have smallest output size. This are not necessarily the ideal Huffman
 bit lengths. Returns size of encoded tree and data in bits, not including the
 3-bit block header.
 */
-static double GetDynamicLengths(ZopfliKatajainenScratch* scratch,
+static uint32_t GetDynamicLengths(ZopfliKatajainenScratch* scratch,
                                 const ZopfliLZ77Store* lz77,
                                 size_t lstart, size_t lend,
                                 unsigned* ll_lengths, unsigned* d_lengths) {
@@ -591,13 +592,13 @@ static double GetDynamicLengths(ZopfliKatajainenScratch* scratch,
       scratch, lz77, lstart, lend, ll_counts, d_counts, ll_lengths, d_lengths);
 }
 
-double ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
+uint32_t ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
                                        const ZopfliLZ77Store* lz77,
                                        size_t lstart, size_t lend, int btype) {
   unsigned ll_lengths[ZOPFLI_NUM_LL];
   unsigned d_lengths[ZOPFLI_NUM_D];
 
-  double result = 3; /* bfinal and btype bits */
+  uint32_t result = 3; /* bfinal and btype bits */
 
   if (btype == 0) {
     size_t length = ZopfliLZ77GetByteRange(lz77, lstart, lend);
@@ -606,7 +607,7 @@ double ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
     /* An uncompressed block must actually be split into multiple blocks if it's
        larger than 65535 bytes long. Eeach block header is 5 bytes: 3 bits,
        padding, LEN and NLEN (potential less padding for first one ignored). */
-    return blocks * 5 * 8 + length * 8;
+    return (uint32_t)(blocks * 5 * 8 + length * 8);
   } if (btype == 1) {
     GetFixedTree(ll_lengths, d_lengths);
     result += CalculateBlockSymbolSize(
@@ -619,36 +620,36 @@ double ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
   return result;
 }
 
-double ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
+uint32_t ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
                                 size_t lstart, size_t lend, int btype) {
   ZopfliKatajainenScratch scratch;
-  double result;
+  uint32_t result;
   ZopfliInitKatajainenScratch(&scratch);
   result = ZopfliCalculateBlockSizeScratch(&scratch, lz77, lstart, lend, btype);
   ZopfliCleanKatajainenScratch(&scratch);
   return result;
 }
 
-double ZopfliCalculateBlockSizeAutoTypeScratch(
+uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
     ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend) {
-  double uncompressedcost =
+  uint32_t uncompressedcost =
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
   /* Don't do the expensive fixed cost calculation for larger blocks that are
      unlikely to use it. */
-  double fixedcost = (lz77->size > 1000) ? uncompressedcost :
+  uint32_t fixedcost = (lz77->size > 1000) ? uncompressedcost :
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 1);
-  double dyncost =
+  uint32_t dyncost =
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
   return (uncompressedcost < fixedcost && uncompressedcost < dyncost)
       ? uncompressedcost
       : (fixedcost < dyncost ? fixedcost : dyncost);
 }
 
-double ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
+uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
                                         size_t lstart, size_t lend) {
   ZopfliKatajainenScratch scratch;
-  double result;
+  uint32_t result;
   ZopfliInitKatajainenScratch(&scratch);
   result = ZopfliCalculateBlockSizeAutoTypeScratch(&scratch, lz77, lstart, lend);
   ZopfliCleanKatajainenScratch(&scratch);
@@ -787,17 +788,18 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
                                  size_t expected_data_size,
                                  unsigned char* bp,
                                  unsigned char** out, size_t* outsize) {
-  double uncompressedcost =
+  uint32_t uncompressedcost =
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
-  double fixedcost =
+  uint32_t fixedcost =
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 1);
-  double dyncost =
+  uint32_t dyncost =
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
 
   /* Whether to perform the expensive calculation of creating an optimal block
   with fixed huffman tree to check if smaller. Only do this for small blocks or
-  blocks which already are pretty good with fixed huffman tree. */
-  int expensivefixed = (lz77->size < 1000) || fixedcost <= dyncost * 1.1;
+  blocks which already are pretty good with fixed huffman tree. fixedcost <=
+  dyncost * 1.1 done in integer (x10 <= x11). */
+  int expensivefixed = (lz77->size < 1000) || fixedcost * 10 <= dyncost * 11;
 
   ZopfliLZ77Store fixedstore;
   if (lstart == lend) {
@@ -858,7 +860,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
   size_t* splitpoints_uncompressed = 0;
   size_t npoints = 0;
   size_t* splitpoints = 0;
-  double totalcost = 0;
+  uint32_t totalcost = 0;
   ZopfliLZ77Store lz77;
   /* Reused across this part's block-size evaluations and final encoding. */
   ZopfliKatajainenScratch katascratch;
@@ -917,7 +919,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
   if (options->blocksplitting && npoints > 1) {
     size_t* splitpoints2 = 0;
     size_t npoints2 = 0;
-    double totalcost2 = 0;
+    uint32_t totalcost2 = 0;
 
     ZopfliBlockSplitLZ77(options, &lz77,
                          options->blocksplittingmax, &splitpoints2, &npoints2);
@@ -989,9 +991,13 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
   }
 #endif
   if (options->verbose) {
+    size_t comp = *outsize - offset;
+    /* Percent removed with 2 decimals, integer-only (basis points). */
+    long bp = insize ? (long)(((long long)insize - (long long)comp) * 10000
+                              / (long long)insize) : 0;
     fprintf(stderr,
-            "Original Size: %lu, Deflate: %lu, Compression: %f%% Removed\n",
-            (unsigned long)insize, (unsigned long)(*outsize - offset),
-            100.0 * (double)(insize - (*outsize - offset)) / (double)insize);
+            "Original Size: %lu, Deflate: %lu, Compression: %ld.%02ld%% Removed\n",
+            (unsigned long)insize, (unsigned long)comp,
+            bp / 100, (bp < 0 ? -bp : bp) % 100);
   }
 }

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -156,7 +156,7 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
     if (symbol == 0 && count >= 3) {
       if (use_18) {
         while (count >= 11) {
-          unsigned count2 = count > 138 ? 138 : count;
+          unsigned count2 = ZOPFLI_MIN(count, 138u);
           if (!size_only) {
             ZOPFLI_APPEND_DATA(18, &rle, &rle_size);
             ZOPFLI_APPEND_DATA(count2 - 11, &rle_bits, &rle_bits_size);
@@ -167,7 +167,7 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
       }
       if (use_17) {
         while (count >= 3) {
-          unsigned count2 = count > 10 ? 10 : count;
+          unsigned count2 = ZOPFLI_MIN(count, 10u);
           if (!size_only) {
             ZOPFLI_APPEND_DATA(17, &rle, &rle_size);
             ZOPFLI_APPEND_DATA(count2 - 3, &rle_bits, &rle_bits_size);
@@ -187,7 +187,7 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
         ZOPFLI_APPEND_DATA(0, &rle_bits, &rle_bits_size);
       }
       while (count >= 3) {
-        unsigned count2 = count > 6 ? 6 : count;
+        unsigned count2 = ZOPFLI_MIN(count, 6u);
         if (!size_only) {
           ZOPFLI_APPEND_DATA(16, &rle, &rle_size);
           ZOPFLI_APPEND_DATA(count2 - 3, &rle_bits, &rle_bits_size);
@@ -335,6 +335,9 @@ static void AddLZ77Data(const ZopfliLZ77Store* lz77,
     }
   }
   assert(expected_data_size == 0 || testlength == expected_data_size);
+  /* Read only by the assert above, which NDEBUG strips. */
+  (void)expected_data_size;
+  (void)testlength;
 }
 
 static void GetFixedTree(unsigned* ll_lengths, unsigned* d_lengths) {
@@ -424,13 +427,6 @@ static size_t CalculateBlockSymbolSize(const unsigned* ll_lengths,
   }
 }
 
-static size_t AbsDiff(size_t x, size_t y) {
-  if (x > y)
-    return x - y;
-  else
-    return y - x;
-}
-
 /*
 Changes the population counts in a way that the consequent Huffman tree
 compression, especially its rle-part, will be more likely to compress this data
@@ -485,7 +481,7 @@ void OptimizeHuffmanForRle(int length, size_t* counts) {
   for (i = 0; i < length + 1; ++i) {
     if (i == length || good_for_rle[i]
         /* Heuristic for selecting the stride ranges to collapse. */
-        || AbsDiff(counts[i], limit) >= 4) {
+        || ZOPFLI_ABS_DIFF(counts[i], limit) >= 4) {
       if (stride >= 4 || (stride >= 3 && sum == 0)) {
         /* The stride must end, collapse what we have, if we have enough (4). */
         int count = (sum + stride / 2) / stride;

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -102,7 +102,8 @@ static void PatchDistanceCodesForBuggyDecoders(unsigned* d_lengths) {
 Encodes the Huffman tree and returns how many bits its encoding takes. If out
 is a null pointer, only returns the size and runs faster.
 */
-static size_t EncodeTree(const unsigned* ll_lengths,
+static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
+                         const unsigned* ll_lengths,
                          const unsigned* d_lengths,
                          int use_16, int use_17, int use_18,
                          unsigned char* bp,
@@ -205,7 +206,7 @@ static size_t EncodeTree(const unsigned* ll_lengths,
     }
   }
 
-  ZopfliCalculateBitLengths(clcounts, 19, 7, clcl);
+  ZopfliCalculateBitLengthsScratch(scratch, clcounts, 19, 7, clcl);
   if (!size_only) ZopfliLengthsToSymbols(clcl, 19, 7, clsymbols);
 
   hclen = 15;
@@ -248,7 +249,8 @@ static size_t EncodeTree(const unsigned* ll_lengths,
   return result_size;
 }
 
-static void AddDynamicTree(const unsigned* ll_lengths,
+static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
+                           const unsigned* ll_lengths,
                            const unsigned* d_lengths,
                            unsigned char* bp,
                            unsigned char** out, size_t* outsize) {
@@ -257,7 +259,7 @@ static void AddDynamicTree(const unsigned* ll_lengths,
   size_t bestsize = 0;
 
   for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(ll_lengths, d_lengths,
+    size_t size = EncodeTree(scratch, ll_lengths, d_lengths,
                              i & 1, i & 2, i & 4,
                              0, 0, 0);
     if (bestsize == 0 || size < bestsize) {
@@ -266,7 +268,7 @@ static void AddDynamicTree(const unsigned* ll_lengths,
     }
   }
 
-  EncodeTree(ll_lengths, d_lengths,
+  EncodeTree(scratch, ll_lengths, d_lengths,
              best & 1, best & 2, best & 4,
              bp, out, outsize);
 }
@@ -274,13 +276,14 @@ static void AddDynamicTree(const unsigned* ll_lengths,
 /*
 Gives the exact size of the tree, in bits, as it will be encoded in DEFLATE.
 */
-static size_t CalculateTreeSize(const unsigned* ll_lengths,
+static size_t CalculateTreeSize(ZopfliKatajainenScratch* scratch,
+                                const unsigned* ll_lengths,
                                 const unsigned* d_lengths) {
   size_t result = 0;
   int i;
 
   for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(ll_lengths, d_lengths,
+    size_t size = EncodeTree(scratch, ll_lengths, d_lengths,
                              i & 1, i & 2, i & 4,
                              0, 0, 0);
     if (result == 0 || size < result) result = size;
@@ -523,6 +526,7 @@ uses it, otherwise keeps the original. Returns size of encoded tree and data in
 bits, not including the 3-bit block header.
 */
 static double TryOptimizeHuffmanForRle(
+    ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend,
     const size_t* ll_counts, const size_t* d_counts,
     unsigned* ll_lengths, unsigned* d_lengths) {
@@ -535,7 +539,7 @@ static double TryOptimizeHuffmanForRle(
   double treesize2;
   double datasize2;
 
-  treesize = CalculateTreeSize(ll_lengths, d_lengths);
+  treesize = CalculateTreeSize(scratch, ll_lengths, d_lengths);
   datasize = CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
       ll_lengths, d_lengths, lz77, lstart, lend);
 
@@ -543,11 +547,13 @@ static double TryOptimizeHuffmanForRle(
   memcpy(d_counts2, d_counts, sizeof(d_counts2));
   OptimizeHuffmanForRle(ZOPFLI_NUM_LL, ll_counts2);
   OptimizeHuffmanForRle(ZOPFLI_NUM_D, d_counts2);
-  ZopfliCalculateBitLengths(ll_counts2, ZOPFLI_NUM_LL, 15, ll_lengths2);
-  ZopfliCalculateBitLengths(d_counts2, ZOPFLI_NUM_D, 15, d_lengths2);
+  ZopfliCalculateBitLengthsScratch(scratch, ll_counts2, ZOPFLI_NUM_LL, 15,
+                                   ll_lengths2);
+  ZopfliCalculateBitLengthsScratch(scratch, d_counts2, ZOPFLI_NUM_D, 15,
+                                   d_lengths2);
   PatchDistanceCodesForBuggyDecoders(d_lengths2);
 
-  treesize2 = CalculateTreeSize(ll_lengths2, d_lengths2);
+  treesize2 = CalculateTreeSize(scratch, ll_lengths2, d_lengths2);
   datasize2 = CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
       ll_lengths2, d_lengths2, lz77, lstart, lend);
 
@@ -566,7 +572,8 @@ symbols to have smallest output size. This are not necessarily the ideal Huffman
 bit lengths. Returns size of encoded tree and data in bits, not including the
 3-bit block header.
 */
-static double GetDynamicLengths(const ZopfliLZ77Store* lz77,
+static double GetDynamicLengths(ZopfliKatajainenScratch* scratch,
+                                const ZopfliLZ77Store* lz77,
                                 size_t lstart, size_t lend,
                                 unsigned* ll_lengths, unsigned* d_lengths) {
   size_t ll_counts[ZOPFLI_NUM_LL];
@@ -574,15 +581,18 @@ static double GetDynamicLengths(const ZopfliLZ77Store* lz77,
 
   ZopfliLZ77GetHistogram(lz77, lstart, lend, ll_counts, d_counts);
   ll_counts[256] = 1;  /* End symbol. */
-  ZopfliCalculateBitLengths(ll_counts, ZOPFLI_NUM_LL, 15, ll_lengths);
-  ZopfliCalculateBitLengths(d_counts, ZOPFLI_NUM_D, 15, d_lengths);
+  ZopfliCalculateBitLengthsScratch(scratch, ll_counts, ZOPFLI_NUM_LL, 15,
+                                   ll_lengths);
+  ZopfliCalculateBitLengthsScratch(scratch, d_counts, ZOPFLI_NUM_D, 15,
+                                   d_lengths);
   PatchDistanceCodesForBuggyDecoders(d_lengths);
   return TryOptimizeHuffmanForRle(
-      lz77, lstart, lend, ll_counts, d_counts, ll_lengths, d_lengths);
+      scratch, lz77, lstart, lend, ll_counts, d_counts, ll_lengths, d_lengths);
 }
 
-double ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
-                                size_t lstart, size_t lend, int btype) {
+double ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
+                                       const ZopfliLZ77Store* lz77,
+                                       size_t lstart, size_t lend, int btype) {
   unsigned ll_lengths[ZOPFLI_NUM_LL];
   unsigned d_lengths[ZOPFLI_NUM_D];
 
@@ -601,23 +611,47 @@ double ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
     result += CalculateBlockSymbolSize(
         ll_lengths, d_lengths, lz77, lstart, lend);
   } else {
-    result += GetDynamicLengths(lz77, lstart, lend, ll_lengths, d_lengths);
+    result += GetDynamicLengths(scratch, lz77, lstart, lend,
+                                ll_lengths, d_lengths);
   }
 
   return result;
 }
 
-double ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
-                                        size_t lstart, size_t lend) {
-  double uncompressedcost = ZopfliCalculateBlockSize(lz77, lstart, lend, 0);
+double ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
+                                size_t lstart, size_t lend, int btype) {
+  ZopfliKatajainenScratch scratch;
+  double result;
+  ZopfliInitKatajainenScratch(&scratch);
+  result = ZopfliCalculateBlockSizeScratch(&scratch, lz77, lstart, lend, btype);
+  ZopfliCleanKatajainenScratch(&scratch);
+  return result;
+}
+
+double ZopfliCalculateBlockSizeAutoTypeScratch(
+    ZopfliKatajainenScratch* scratch,
+    const ZopfliLZ77Store* lz77, size_t lstart, size_t lend) {
+  double uncompressedcost =
+      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
   /* Don't do the expensive fixed cost calculation for larger blocks that are
      unlikely to use it. */
-  double fixedcost = (lz77->size > 1000) ?
-      uncompressedcost : ZopfliCalculateBlockSize(lz77, lstart, lend, 1);
-  double dyncost = ZopfliCalculateBlockSize(lz77, lstart, lend, 2);
+  double fixedcost = (lz77->size > 1000) ? uncompressedcost :
+      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 1);
+  double dyncost =
+      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
   return (uncompressedcost < fixedcost && uncompressedcost < dyncost)
       ? uncompressedcost
       : (fixedcost < dyncost ? fixedcost : dyncost);
+}
+
+double ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
+                                        size_t lstart, size_t lend) {
+  ZopfliKatajainenScratch scratch;
+  double result;
+  ZopfliInitKatajainenScratch(&scratch);
+  result = ZopfliCalculateBlockSizeAutoTypeScratch(&scratch, lz77, lstart, lend);
+  ZopfliCleanKatajainenScratch(&scratch);
+  return result;
 }
 
 /* Since an uncompressed block can be max 65535 in size, it actually adds
@@ -679,7 +713,8 @@ bp: output bit pointer
 out: dynamic output array to append to
 outsize: dynamic output array size
 */
-static void AddLZ77Block(const ZopfliOptions* options, int btype, int final,
+static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
+                         const ZopfliOptions* options, int btype, int final,
                          const ZopfliLZ77Store* lz77,
                          size_t lstart, size_t lend,
                          size_t expected_data_size,
@@ -714,10 +749,10 @@ static void AddLZ77Block(const ZopfliOptions* options, int btype, int final,
     unsigned detect_tree_size;
     assert(btype == 2);
 
-    GetDynamicLengths(lz77, lstart, lend, ll_lengths, d_lengths);
+    GetDynamicLengths(scratch, lz77, lstart, lend, ll_lengths, d_lengths);
 
     detect_tree_size = *outsize;
-    AddDynamicTree(ll_lengths, d_lengths, bp, out, outsize);
+    AddDynamicTree(scratch, ll_lengths, d_lengths, bp, out, outsize);
     if (options->verbose) {
       fprintf(stderr, "treesize: %d\n", (int)(*outsize - detect_tree_size));
     }
@@ -744,15 +779,19 @@ static void AddLZ77Block(const ZopfliOptions* options, int btype, int final,
   }
 }
 
-static void AddLZ77BlockAutoType(const ZopfliOptions* options, int final,
+static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
+                                 const ZopfliOptions* options, int final,
                                  const ZopfliLZ77Store* lz77,
                                  size_t lstart, size_t lend,
                                  size_t expected_data_size,
                                  unsigned char* bp,
                                  unsigned char** out, size_t* outsize) {
-  double uncompressedcost = ZopfliCalculateBlockSize(lz77, lstart, lend, 0);
-  double fixedcost = ZopfliCalculateBlockSize(lz77, lstart, lend, 1);
-  double dyncost = ZopfliCalculateBlockSize(lz77, lstart, lend, 2);
+  double uncompressedcost =
+      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
+  double fixedcost =
+      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 1);
+  double dyncost =
+      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
 
   /* Whether to perform the expensive calculation of creating an optimal block
   with fixed huffman tree to check if smaller. Only do this for small blocks or
@@ -776,23 +815,24 @@ static void AddLZ77BlockAutoType(const ZopfliOptions* options, int final,
     ZopfliBlockState s;
     ZopfliInitBlockState(options, instart, inend, 1, &s);
     ZopfliLZ77OptimalFixed(&s, lz77->data, instart, inend, &fixedstore);
-    fixedcost = ZopfliCalculateBlockSize(&fixedstore, 0, fixedstore.size, 1);
+    fixedcost = ZopfliCalculateBlockSizeScratch(scratch, &fixedstore, 0,
+                                                fixedstore.size, 1);
     ZopfliCleanBlockState(&s);
   }
 
   if (uncompressedcost < fixedcost && uncompressedcost < dyncost) {
-    AddLZ77Block(options, 0, final, lz77, lstart, lend,
+    AddLZ77Block(scratch, options, 0, final, lz77, lstart, lend,
                  expected_data_size, bp, out, outsize);
   } else if (fixedcost < dyncost) {
     if (expensivefixed) {
-      AddLZ77Block(options, 1, final, &fixedstore, 0, fixedstore.size,
+      AddLZ77Block(scratch, options, 1, final, &fixedstore, 0, fixedstore.size,
                    expected_data_size, bp, out, outsize);
     } else {
-      AddLZ77Block(options, 1, final, lz77, lstart, lend,
+      AddLZ77Block(scratch, options, 1, final, lz77, lstart, lend,
                    expected_data_size, bp, out, outsize);
     }
   } else {
-    AddLZ77Block(options, 2, final, lz77, lstart, lend,
+    AddLZ77Block(scratch, options, 2, final, lz77, lstart, lend,
                  expected_data_size, bp, out, outsize);
   }
 
@@ -819,6 +859,8 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
   size_t* splitpoints = 0;
   double totalcost = 0;
   ZopfliLZ77Store lz77;
+  /* Reused across this part's block-size evaluations and final encoding. */
+  ZopfliKatajainenScratch katascratch;
 
   /* If btype=2 is specified, it tries all block types. If a lesser btype is
   given, then however it forces that one. Neither of the lesser types needs
@@ -833,7 +875,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     ZopfliInitBlockState(options, instart, inend, 1, &s);
 
     ZopfliLZ77OptimalFixed(&s, in, instart, inend, &store);
-    AddLZ77Block(options, btype, final, &store, 0, store.size, 0,
+    AddLZ77Block(&s.katascratch, options, btype, final, &store, 0, store.size, 0,
                  bp, out, outsize);
 
     ZopfliCleanBlockState(&s);
@@ -841,6 +883,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     return;
   }
 
+  ZopfliInitKatajainenScratch(&katascratch);
 
   if (options->blocksplitting) {
     ZopfliBlockSplit(options, in, instart, inend,
@@ -859,7 +902,8 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     ZopfliInitLZ77Store(in, &store);
     ZopfliInitBlockState(options, start, end, 1, &s);
     ZopfliLZ77Optimal(&s, in, start, end, options->numiterations, &store);
-    totalcost += ZopfliCalculateBlockSizeAutoType(&store, 0, store.size);
+    totalcost += ZopfliCalculateBlockSizeAutoTypeScratch(&katascratch, &store,
+                                                         0, store.size);
 
     ZopfliAppendLZ77Store(&store, &lz77);
     if (i < npoints) splitpoints[i] = lz77.size;
@@ -880,7 +924,8 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     for (i = 0; i <= npoints2; i++) {
       size_t start = i == 0 ? 0 : splitpoints2[i - 1];
       size_t end = i == npoints2 ? lz77.size : splitpoints2[i];
-      totalcost2 += ZopfliCalculateBlockSizeAutoType(&lz77, start, end);
+      totalcost2 += ZopfliCalculateBlockSizeAutoTypeScratch(&katascratch, &lz77,
+                                                            start, end);
     }
 
     if (totalcost2 < totalcost) {
@@ -895,11 +940,12 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
   for (i = 0; i <= npoints; i++) {
     size_t start = i == 0 ? 0 : splitpoints[i - 1];
     size_t end = i == npoints ? lz77.size : splitpoints[i];
-    AddLZ77BlockAutoType(options, i == npoints && final,
+    AddLZ77BlockAutoType(&katascratch, options, i == npoints && final,
                          &lz77, start, end, 0,
                          bp, out, outsize);
   }
 
+  ZopfliCleanKatajainenScratch(&katascratch);
   ZopfliCleanLZ77Store(&lz77);
   free(splitpoints);
   free(splitpoints_uncompressed);

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -952,22 +952,41 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
   free(splitpoints_uncompressed);
 }
 
+/* Iteration count for auto mode (numiterations == 0): 10 + 12 per size-doubling
+above 1 KB, clamped to [15, 400]. Larger inputs have a longer tail of gains;
+runtime is size * iterations, so they are intentionally slow. */
+static int AutoIterations(size_t insize) {
+  int d = 0, iters;
+  size_t k = insize >> 10;  /* doublings above 1 KB = floor(log2(k)). */
+  while (k > 1) { k >>= 1; d++; }
+  iters = 10 + 12 * d;
+  return iters < 15 ? 15 : iters > 400 ? 400 : iters;
+}
+
 void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
                    const unsigned char* in, size_t insize,
                    unsigned char* bp, unsigned char** out, size_t* outsize) {
  size_t offset = *outsize;
+ ZopfliOptions opts = *options;
+ if (opts.numiterations <= 0) opts.numiterations = AutoIterations(insize);
+ if (opts.verbose && options->numiterations <= 0) {
+   fprintf(stderr, "Auto iterations: %d (input %lu bytes)\n",
+           opts.numiterations, (unsigned long)insize);
+ }
 #if ZOPFLI_MASTER_BLOCK_SIZE == 0
-  ZopfliDeflatePart(options, btype, final, in, 0, insize, bp, out, outsize);
+  ZopfliDeflatePart(&opts, btype, final, in, 0, insize, bp, out, outsize);
 #else
+  {
   size_t i = 0;
   do {
     int masterfinal = (i + ZOPFLI_MASTER_BLOCK_SIZE >= insize);
     int final2 = final && masterfinal;
     size_t size = masterfinal ? insize - i : ZOPFLI_MASTER_BLOCK_SIZE;
-    ZopfliDeflatePart(options, btype, final2,
+    ZopfliDeflatePart(&opts, btype, final2,
                       in, i, i + size, bp, out, outsize);
     i += size;
   } while (i < insize);
+  }
 #endif
   if (options->verbose) {
     fprintf(stderr,

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -970,21 +970,25 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
    fprintf(stderr, "Auto iterations: %d (input %lu bytes)\n",
            opts.numiterations, (unsigned long)insize);
  }
-#if ZOPFLI_MASTER_BLOCK_SIZE == 0
-  ZopfliDeflatePart(&opts, btype, final, in, 0, insize, bp, out, outsize);
-#else
   {
+  /* Effective master block size. Clamp to ZOPFLI_COST_MAX_BLOCK_SIZE (and use
+  it when master blocks are disabled) so a part never exceeds what the 32-bit
+  optimal-parse cost model can represent, regardless of the configured value. */
+#if ZOPFLI_MASTER_BLOCK_SIZE == 0 || ZOPFLI_MASTER_BLOCK_SIZE > (1 << 24)
+  size_t mbs = ZOPFLI_COST_MAX_BLOCK_SIZE;
+#else
+  size_t mbs = ZOPFLI_MASTER_BLOCK_SIZE;
+#endif
   size_t i = 0;
   do {
-    int masterfinal = (i + ZOPFLI_MASTER_BLOCK_SIZE >= insize);
+    int masterfinal = (i + mbs >= insize);
     int final2 = final && masterfinal;
-    size_t size = masterfinal ? insize - i : ZOPFLI_MASTER_BLOCK_SIZE;
+    size_t size = masterfinal ? insize - i : mbs;
     ZopfliDeflatePart(&opts, btype, final2,
                       in, i, i + size, bp, out, outsize);
     i += size;
   } while (i < insize);
   }
-#endif
   if (options->verbose) {
     size_t comp = *outsize - offset;
     /* Percent removed with 2 decimals, integer-only (basis points). */

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -397,11 +397,11 @@ static size_t CalculateBlockSymbolSizeGivenCounts(const size_t* ll_counts,
     }
     for (i = 257; i < 286; i++) {
       result += ll_lengths[i] * ll_counts[i];
-      result += ZopfliGetLengthSymbolExtraBits(i) * ll_counts[i];
+      result += ZopfliGetLengthSymbolExtraBits((int)i) * ll_counts[i];
     }
     for (i = 0; i < 30; i++) {
       result += d_lengths[i] * d_counts[i];
-      result += ZopfliGetDistSymbolExtraBits(i) * d_counts[i];
+      result += ZopfliGetDistSymbolExtraBits((int)i) * d_counts[i];
     }
     result += ll_lengths[256]; /*end symbol*/
     return result;
@@ -484,7 +484,7 @@ void OptimizeHuffmanForRle(int length, size_t* counts) {
         || ZOPFLI_ABS_DIFF(counts[i], limit) >= 4) {
       if (stride >= 4 || (stride >= 3 && sum == 0)) {
         /* The stride must end, collapse what we have, if we have enough (4). */
-        int count = (sum + stride / 2) / stride;
+        int count = (int)((sum + stride / 2) / stride);
         if (count < 1) count = 1;
         if (sum == 0) {
           /* Don't make an all zeros stride to be upgraded to ones. */
@@ -537,8 +537,8 @@ static uint32_t TryOptimizeHuffmanForRle(
   uint32_t treesize2;
   uint32_t datasize2;
 
-  treesize = CalculateTreeSize(scratch, ll_lengths, d_lengths);
-  datasize = CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
+  treesize = (uint32_t)CalculateTreeSize(scratch, ll_lengths, d_lengths);
+  datasize = (uint32_t)CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
       ll_lengths, d_lengths, lz77, lstart, lend);
 
   memcpy(ll_counts2, ll_counts, sizeof(ll_counts2));
@@ -551,8 +551,8 @@ static uint32_t TryOptimizeHuffmanForRle(
                                    d_lengths2);
   PatchDistanceCodesForBuggyDecoders(d_lengths2);
 
-  treesize2 = CalculateTreeSize(scratch, ll_lengths2, d_lengths2);
-  datasize2 = CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
+  treesize2 = (uint32_t)CalculateTreeSize(scratch, ll_lengths2, d_lengths2);
+  datasize2 = (uint32_t)CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
       ll_lengths2, d_lengths2, lz77, lstart, lend);
 
   if (treesize2 + datasize2 < treesize + datasize) {
@@ -606,7 +606,7 @@ uint32_t ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
     return (uint32_t)(blocks * 5 * 8 + length * 8);
   } if (btype == 1) {
     GetFixedTree(ll_lengths, d_lengths);
-    result += CalculateBlockSymbolSize(
+    result += (uint32_t)CalculateBlockSymbolSize(
         ll_lengths, d_lengths, lz77, lstart, lend);
   } else {
     result += GetDynamicLengths(scratch, lz77, lstart, lend,
@@ -667,7 +667,7 @@ static void AddNonCompressedBlock(const ZopfliOptions* options, int final,
     unsigned short nlen;
     int currentfinal;
 
-    if (pos + blocksize > inend) blocksize = inend - pos;
+    if (pos + blocksize > inend) blocksize = (unsigned short)(inend - pos);
     currentfinal = pos + blocksize >= inend;
 
     nlen = ~blocksize;
@@ -744,7 +744,7 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
     GetFixedTree(ll_lengths, d_lengths);
   } else {
     /* Dynamic block. */
-    unsigned detect_tree_size;
+    size_t detect_tree_size;
     assert(btype == 2);
 
     GetDynamicLengths(scratch, lz77, lstart, lend, ll_lengths, d_lengths);

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -752,7 +752,7 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
     detect_tree_size = *outsize;
     AddDynamicTree(scratch, ll_lengths, d_lengths, bp, out, outsize);
     if (options->verbose) {
-      fprintf(stderr, "treesize: %d\n", (int)(*outsize - detect_tree_size));
+      fprintf(stderr, "treesize: %zu\n", *outsize - detect_tree_size);
     }
   }
 
@@ -771,9 +771,8 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
   }
   compressed_size = *outsize - detect_block_size;
   if (options->verbose) {
-    fprintf(stderr, "compressed block size: %d (%dk) (unc: %d)\n",
-           (int)compressed_size, (int)(compressed_size / 1024),
-           (int)(uncompressed_size));
+    fprintf(stderr, "compressed block size: %zu (%zuk) (unc: %zu)\n",
+           compressed_size, compressed_size / 1024, uncompressed_size);
   }
 }
 
@@ -963,7 +962,6 @@ static int AutoIterations(size_t insize) {
 void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
                    const unsigned char* in, size_t insize,
                    unsigned char* bp, unsigned char** out, size_t* outsize) {
- size_t offset = *outsize;
   size_t offset = *outsize;
   ZopfliOptions opts = *options;
   assert(opts.numiterations >= 0);
@@ -972,8 +970,6 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
     fprintf(stderr, "Auto iterations: %d (input %zu bytes)\n",
             opts.numiterations, insize);
   }
-           opts.numiterations, (unsigned long)insize);
- }
   {
   /* Effective master block size. Clamp to ZOPFLI_COST_MAX_BLOCK_SIZE (and use
   it when master blocks are disabled) so a part never exceeds what the 32-bit
@@ -1000,8 +996,8 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
                               / (long long)insize) : 0;
     long abp = bp < 0 ? -bp : bp;  /* keep the sign for small negatives */
     fprintf(stderr,
-            "Original Size: %lu, Deflate: %lu, Compression: %s%ld.%02ld%% Removed\n",
-            (unsigned long)insize, (unsigned long)comp,
+            "Original Size: %zu, Deflate: %zu, Compression: %s%ld.%02ld%% Removed\n",
+            insize, comp,
             bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
 }

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -964,10 +964,14 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
                    const unsigned char* in, size_t insize,
                    unsigned char* bp, unsigned char** out, size_t* outsize) {
  size_t offset = *outsize;
- ZopfliOptions opts = *options;
- if (opts.numiterations <= 0) opts.numiterations = AutoIterations(insize);
- if (opts.verbose && options->numiterations <= 0) {
-   fprintf(stderr, "Auto iterations: %d (input %lu bytes)\n",
+  size_t offset = *outsize;
+  ZopfliOptions opts = *options;
+  assert(opts.numiterations >= 0);
+  if (opts.numiterations == 0) opts.numiterations = AutoIterations(insize);
+  if (opts.verbose && options->numiterations == 0) {
+    fprintf(stderr, "Auto iterations: %d (input %zu bytes)\n",
+            opts.numiterations, insize);
+  }
            opts.numiterations, (unsigned long)insize);
  }
   {

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -29,6 +29,7 @@ Functions to compress according to the DEFLATE specification, using the
 #include <stdint.h>
 
 #include "lz77.h"
+#include "util.h"
 #include "zopfli.h"
 
 #ifdef __cplusplus
@@ -105,12 +106,27 @@ uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
 
 /*
 Heuristic used by the auto-type block writer: whether to run the expensive
-optimal-fixed-tree exploration for a block, given its symbol count and the
-fixed/dynamic costs in bits. The cost comparison is done in 64-bit to avoid
-overflow. Exposed for testing.
+optimal-fixed-tree exploration for a block. Worth it for small blocks, or blocks
+already pretty good with a fixed tree (fixedcost <= dyncost * 1.1, as x10 <=
+x11). Uses a 32-bit compare when the master block size bounds costs so the x10
+and x11 products fit in uint32_t, and widens to 64-bit otherwise. Inline
+(header) so it is testable without an external symbol the optimizer/LTO could
+inline away.
 */
-int ZopfliUseExpensiveFixed(size_t blocksize, uint32_t fixedcost,
-                            uint32_t dyncost);
+ZOPFLI_INLINE int ZopfliUseExpensiveFixed(size_t blocksize, uint32_t fixedcost,
+                                          uint32_t dyncost) {
+#if ZOPFLI_MASTER_BLOCK_SIZE != 0 && \
+    (ZOPFLI_MASTER_BLOCK_SIZE * 32 * 11 <= 0xFFFFFFFF)
+  /* A block's cost is < 32 * blocksize bits and blocksize <= the master block
+  size, so dyncost * 11 fits in uint32_t here: the 32-bit compare is exact. */
+  return blocksize < 1000 || fixedcost * 10 <= dyncost * 11;
+#else
+  /* Master blocks disabled or large enough that the products (costs are < 2^31
+  bits, so * 11 is ~2^35) could exceed uint32_t; widen to 64-bit. */
+  return blocksize < 1000 ||
+      (uint64_t)fixedcost * 10 <= (uint64_t)dyncost * 11;
+#endif
+}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -26,6 +26,8 @@ Functions to compress according to the DEFLATE specification, using the
 "squeeze" LZ77 compression backend.
 */
 
+#include <stdint.h>
+
 #include "lz77.h"
 #include "zopfli.h"
 
@@ -77,27 +79,27 @@ dists: ll77 distances
 lstart: start of block
 lend: end of block (not inclusive)
 */
-double ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
-                                size_t lstart, size_t lend, int btype);
+uint32_t ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
+                                  size_t lstart, size_t lend, int btype);
 
 /*
 As ZopfliCalculateBlockSize, but reuses caller-owned scratch (thread-safe when
 each thread passes its own).
 */
-double ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
-                                       const ZopfliLZ77Store* lz77,
-                                       size_t lstart, size_t lend, int btype);
+uint32_t ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
+                                         const ZopfliLZ77Store* lz77,
+                                         size_t lstart, size_t lend, int btype);
 
 /*
 Calculates block size in bits, automatically using the best btype.
 */
-double ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
-                                        size_t lstart, size_t lend);
+uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
+                                          size_t lstart, size_t lend);
 
 /*
 As ZopfliCalculateBlockSizeAutoType, but reuses caller-owned scratch.
 */
-double ZopfliCalculateBlockSizeAutoTypeScratch(
+uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
     ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend);
 

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -103,6 +103,15 @@ uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
     ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend);
 
+/*
+Heuristic used by the auto-type block writer: whether to run the expensive
+optimal-fixed-tree exploration for a block, given its symbol count and the
+fixed/dynamic costs in bits. The cost comparison is done in 64-bit to avoid
+overflow. Exposed for testing.
+*/
+int ZopfliUseExpensiveFixed(size_t blocksize, uint32_t fixedcost,
+                            uint32_t dyncost);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #ifndef ZOPFLI_DEFLATE_H_

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -80,10 +80,25 @@ double ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
                                 size_t lstart, size_t lend, int btype);
 
 /*
+As ZopfliCalculateBlockSize, but reuses caller-owned scratch (thread-safe when
+each thread passes its own).
+*/
+double ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
+                                       const ZopfliLZ77Store* lz77,
+                                       size_t lstart, size_t lend, int btype);
+
+/*
 Calculates block size in bits, automatically using the best btype.
 */
 double ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
                                         size_t lstart, size_t lend);
+
+/*
+As ZopfliCalculateBlockSizeAutoType, but reuses caller-owned scratch.
+*/
+double ZopfliCalculateBlockSizeAutoTypeScratch(
+    ZopfliKatajainenScratch* scratch,
+    const ZopfliLZ77Store* lz77, size_t lstart, size_t lend);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -120,8 +120,9 @@ void ZopfliGzipCompress(const ZopfliOptions* options,
     /* Percent removed with 2 decimals, integer-only (basis points). */
     long bp = insize ? (long)(((long long)insize - (long long)*outsize) * 10000
                               / (long long)insize) : 0;
+    long abp = bp < 0 ? -bp : bp;  /* keep the sign for small negatives */
     fprintf(stderr,
-            "Original Size: %d, Gzip: %d, Compression: %ld.%02ld%% Removed\n",
-            (int)insize, (int)*outsize, bp / 100, (bp < 0 ? -bp : bp) % 100);
+            "Original Size: %d, Gzip: %d, Compression: %s%ld.%02ld%% Removed\n",
+            (int)insize, (int)*outsize, bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
 }

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "gzip_container.h"
@@ -116,9 +117,11 @@ void ZopfliGzipCompress(const ZopfliOptions* options,
   ZOPFLI_APPEND_DATA((insize >> 24) % 256, out, outsize);
 
   if (options->verbose) {
+    /* Percent removed with 2 decimals, integer-only (basis points). */
+    long bp = insize ? (long)(((long long)insize - (long long)*outsize) * 10000
+                              / (long long)insize) : 0;
     fprintf(stderr,
-            "Original Size: %d, Gzip: %d, Compression: %f%% Removed\n",
-            (int)insize, (int)*outsize,
-            100.0 * (double)(insize - *outsize) / (double)insize);
+            "Original Size: %d, Gzip: %d, Compression: %ld.%02ld%% Removed\n",
+            (int)insize, (int)*outsize, bp / 100, (bp < 0 ? -bp : bp) % 100);
   }
 }

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -122,7 +122,7 @@ void ZopfliGzipCompress(const ZopfliOptions* options,
                               / (long long)insize) : 0;
     long abp = bp < 0 ? -bp : bp;  /* keep the sign for small negatives */
     fprintf(stderr,
-            "Original Size: %d, Gzip: %d, Compression: %s%ld.%02ld%% Removed\n",
-            (int)insize, (int)*outsize, bp < 0 ? "-" : "", abp / 100, abp % 100);
+            "Original Size: %zu, Gzip: %zu, Compression: %s%ld.%02ld%% Removed\n",
+            insize, *outsize, bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
 }

--- a/src/zopfli/hash.c
+++ b/src/zopfli/hash.c
@@ -50,7 +50,8 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
     h->head[i] = -1;  /* -1 indicates no head so far. */
   }
   for (i = 0; i < window_size; i++) {
-    h->prev[i] = i;  /* If prev[j] == j, then prev[j] is uninitialized. */
+    /* If prev[j] == j, then prev[j] is uninitialized. */
+    h->prev[i] = (unsigned short)i;
     h->hashval[i] = -1;
   }
 
@@ -66,7 +67,7 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
     h->head2[i] = -1;
   }
   for (i = 0; i < window_size; i++) {
-    h->prev2[i] = i;
+    h->prev2[i] = (unsigned short)i;
     h->hashval2[i] = -1;
   }
 #endif
@@ -122,7 +123,7 @@ void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
       array[pos] == array[pos + amount + 1] && amount < (unsigned short)(-1)) {
     amount++;
   }
-  h->same[hpos] = amount;
+  h->same[hpos] = (unsigned short)amount;
 #endif
 
 #ifdef ZOPFLI_HASH_SAME_HASH

--- a/src/zopfli/katajainen.c
+++ b/src/zopfli/katajainen.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*
@@ -163,10 +164,28 @@ static void ExtractBitLengths(Node* chain, Node* leaves, unsigned* bitlengths) {
 }
 
 /*
-Comparator for sorting the leaves. Has the function signature for qsort.
+Sorts leaves ascending by weight. The symbol index is packed into the low bits
+of weight, so all keys are distinct and the order is unique. Inlined shell sort
+(in-place, no recursion) avoids qsort's per-comparison indirect call.
 */
-static int LeafComparator(const void* a, const void* b) {
-  return ((const Node*)a)->weight - ((const Node*)b)->weight;
+static void SortLeaves(Node* leaves, int num) {
+  /* Knuth gaps ((3^k - 1) / 2). Capped at 121: the start gap is < num and num
+     <= 288 (ZOPFLI_NUM_LL), so larger gaps never apply. Still correct if not. */
+  static const int kGaps[] = { 1, 4, 13, 40, 121 };
+  int g = (int)(sizeof(kGaps) / sizeof(kGaps[0])) - 1;
+  /* Start at the largest gap smaller than num. */
+  for (; g > 0 && kGaps[g] >= num; g--) { }
+  for (; g >= 0; g--) {
+    int i, gap = kGaps[g];
+    for (i = gap; i < num; i++) {
+      Node tmp = leaves[i];
+      int j;
+      for (j = i; j >= gap && leaves[j - gap].weight > tmp.weight; j -= gap) {
+        leaves[j] = leaves[j - gap];
+      }
+      leaves[j] = tmp;
+    }
+  }
 }
 
 int ZopfliLengthLimitedCodeLengths(
@@ -229,7 +248,7 @@ int ZopfliLengthLimitedCodeLengths(
     }
     leaves[i].weight = (leaves[i].weight << 9) | leaves[i].count;
   }
-  qsort(leaves, numsymbols, sizeof(Node), LeafComparator);
+  SortLeaves(leaves, numsymbols);
   for (i = 0; i < numsymbols; i++) {
     leaves[i].weight >>= 9;
   }

--- a/src/zopfli/katajainen.c
+++ b/src/zopfli/katajainen.c
@@ -188,7 +188,33 @@ static void SortLeaves(Node* leaves, int num) {
   }
 }
 
-int ZopfliLengthLimitedCodeLengths(
+void ZopfliInitKatajainenScratch(ZopfliKatajainenScratch* scratch) {
+  scratch->leaves = 0;
+  scratch->leaves_cap = 0;
+  scratch->nodes = 0;
+  scratch->nodes_cap = 0;
+  scratch->lists = 0;
+  scratch->lists_cap = 0;
+}
+
+void ZopfliCleanKatajainenScratch(ZopfliKatajainenScratch* scratch) {
+  free(scratch->leaves);
+  free(scratch->nodes);
+  free(scratch->lists);
+}
+
+/* Grows *buf to hold at least 'need' Nodes, reusing it across calls. */
+static Node* EnsureNodes(void** buf, size_t* cap, size_t need) {
+  if (need > *cap) {
+    free(*buf);
+    *buf = malloc(need * sizeof(Node));
+    *cap = *buf ? need : 0;
+  }
+  return (Node*)*buf;
+}
+
+int ZopfliLengthLimitedCodeLengthsScratch(
+    ZopfliKatajainenScratch* scratch,
     const size_t* frequencies, int n, int maxbits, unsigned* bitlengths) {
   NodePool pool;
   int i;
@@ -201,7 +227,7 @@ int ZopfliLengthLimitedCodeLengths(
   Node* (*lists)[2];
 
   /* One leaf per symbol. Only numsymbols leaves will be used. */
-  Node* leaves = (Node*)malloc(n * sizeof(*leaves));
+  Node* leaves = EnsureNodes(&scratch->leaves, &scratch->leaves_cap, (size_t)n);
 
   /* Initialize all bitlengths at 0. */
   for (i = 0; i < n; i++) {
@@ -217,24 +243,21 @@ int ZopfliLengthLimitedCodeLengths(
     }
   }
 
-  /* Check special cases and error conditions. */
+  /* Check special cases and error conditions. Scratch is caller-owned, so these
+  just return. */
   if ((1 << maxbits) < numsymbols) {
-    free(leaves);
     return 1;  /* Error, too few maxbits to represent symbols. */
   }
   if (numsymbols == 0) {
-    free(leaves);
     return 0;  /* No symbols at all. OK. */
   }
   if (numsymbols == 1) {
     bitlengths[leaves[0].count] = 1;
-    free(leaves);
     return 0;  /* Only one symbol, give it bitlength 1, not 0. OK. */
   }
   if (numsymbols == 2) {
     bitlengths[leaves[0].count]++;
     bitlengths[leaves[1].count]++;
-    free(leaves);
     return 0;
   }
 
@@ -243,7 +266,6 @@ int ZopfliLengthLimitedCodeLengths(
   for (i = 0; i < numsymbols; i++) {
     if (leaves[i].weight >=
         ((size_t)1 << (sizeof(leaves[0].weight) * CHAR_BIT - 9))) {
-      free(leaves);
       return 1;  /* Error, we need 9 bits for the count. */
     }
     leaves[i].weight = (leaves[i].weight << 9) | leaves[i].count;
@@ -258,10 +280,16 @@ int ZopfliLengthLimitedCodeLengths(
   }
 
   /* Initialize node memory pool. */
-  nodes = (Node*)malloc(maxbits * 2 * numsymbols * sizeof(Node));
+  nodes = EnsureNodes(&scratch->nodes, &scratch->nodes_cap,
+                      (size_t)maxbits * 2 * (size_t)numsymbols);
   pool.next = nodes;
 
-  lists = (Node* (*)[2])malloc(maxbits * sizeof(*lists));
+  if ((size_t)maxbits > scratch->lists_cap) {
+    free(scratch->lists);
+    scratch->lists = malloc((size_t)maxbits * 2 * sizeof(Node*));
+    scratch->lists_cap = scratch->lists ? (size_t)maxbits : 0;
+  }
+  lists = (Node* (*)[2])scratch->lists;
   InitLists(&pool, leaves, maxbits, lists);
 
   /* In the last list, 2 * numsymbols - 2 active chains need to be created. Two
@@ -274,8 +302,16 @@ int ZopfliLengthLimitedCodeLengths(
 
   ExtractBitLengths(lists[maxbits - 1][1], leaves, bitlengths);
 
-  free(lists);
-  free(leaves);
-  free(nodes);
   return 0;  /* OK. */
+}
+
+int ZopfliLengthLimitedCodeLengths(
+    const size_t* frequencies, int n, int maxbits, unsigned* bitlengths) {
+  ZopfliKatajainenScratch scratch;
+  int result;
+  ZopfliInitKatajainenScratch(&scratch);
+  result = ZopfliLengthLimitedCodeLengthsScratch(
+      &scratch, frequencies, n, maxbits, bitlengths);
+  ZopfliCleanKatajainenScratch(&scratch);
+  return result;
 }

--- a/src/zopfli/katajainen.c
+++ b/src/zopfli/katajainen.c
@@ -203,12 +203,12 @@ void ZopfliCleanKatajainenScratch(ZopfliKatajainenScratch* scratch) {
   free(scratch->lists);
 }
 
-/* Grows *buf to hold at least 'need' Nodes, reusing it across calls. */
 static Node* EnsureNodes(void** buf, size_t* cap, size_t need) {
   if (need > *cap) {
-    free(*buf);
-    *buf = malloc(need * sizeof(Node));
-    *cap = *buf ? need : 0;
+    void* p = realloc(*buf, need * sizeof(Node));
+    if (!p) exit(EXIT_FAILURE);
+    *buf = p;
+    *cap = need;
   }
   return (Node*)*buf;
 }

--- a/src/zopfli/katajainen.h
+++ b/src/zopfli/katajainen.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #ifndef ZOPFLI_KATAJAINEN_H_

--- a/src/zopfli/katajainen.h
+++ b/src/zopfli/katajainen.h
@@ -23,6 +23,25 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #include <string.h>
 
 /*
+Reusable scratch buffers for ZopfliLengthLimitedCodeLengths, so the hot
+per-block-evaluation path does not malloc/free on every call. Owned by the
+caller (one per thread / compression), making reuse thread-safe. The buffers are
+void* to keep the internal node type private; they grow on demand. Zero-fill a
+fresh instance with ZopfliInitKatajainenScratch (or `= {0}`).
+*/
+typedef struct ZopfliKatajainenScratch {
+  void* leaves;
+  size_t leaves_cap;  /* capacity in nodes */
+  void* nodes;
+  size_t nodes_cap;   /* capacity in nodes */
+  void* lists;        /* array of Node*[2] */
+  size_t lists_cap;   /* capacity in list entries */
+} ZopfliKatajainenScratch;
+
+void ZopfliInitKatajainenScratch(ZopfliKatajainenScratch* scratch);
+void ZopfliCleanKatajainenScratch(ZopfliKatajainenScratch* scratch);
+
+/*
 Outputs minimum-redundancy length-limited code bitlengths for symbols with the
 given counts. The bitlengths are limited by maxbits.
 
@@ -37,6 +56,15 @@ bitlengths: Output, the bitlengths for the symbol prefix codes.
 return: 0 for OK, non-0 for error.
 */
 int ZopfliLengthLimitedCodeLengths(
+    const size_t* frequencies, int n, int maxbits, unsigned* bitlengths);
+
+/*
+As ZopfliLengthLimitedCodeLengths, but reuses caller-owned scratch buffers
+instead of allocating per call. Thread-safe as long as each thread passes its
+own scratch.
+*/
+int ZopfliLengthLimitedCodeLengthsScratch(
+    ZopfliKatajainenScratch* scratch,
     const size_t* frequencies, int n, int maxbits, unsigned* bitlengths);
 
 #endif  /* ZOPFLI_KATAJAINEN_H_ */

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -222,6 +222,7 @@ void ZopfliInitBlockState(const ZopfliOptions* options,
   s->options = options;
   s->blockstart = blockstart;
   s->blockend = blockend;
+  ZopfliInitKatajainenScratch(&s->katascratch);
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (add_lmc) {
     s->lmc = (ZopfliLongestMatchCache*)malloc(sizeof(ZopfliLongestMatchCache));
@@ -233,6 +234,7 @@ void ZopfliInitBlockState(const ZopfliOptions* options,
 }
 
 void ZopfliCleanBlockState(ZopfliBlockState* s) {
+  ZopfliCleanKatajainenScratch(&s->katascratch);
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (s->lmc) {
     ZopfliCleanCache(s->lmc);

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -28,6 +28,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store) {
   store->size = 0;
+  store->cap = 0;
   store->litlens = 0;
   store->dists = 0;
   store->pos = 0;
@@ -50,6 +51,42 @@ void ZopfliCleanLZ77Store(ZopfliLZ77Store* store) {
 
 static size_t CeilDiv(size_t a, size_t b) {
   return (a + b - 1) / b;
+}
+
+/*
+Grows the store's arrays to hold at least 'need' lz77 symbols, reusing the
+existing allocation (geometric growth). The ll_counts/d_counts lengths are
+deterministic functions of the symbol capacity, so one capacity covers all
+seven arrays.
+*/
+static void ZopfliReserveLZ77Store(ZopfliLZ77Store* store, size_t need) {
+  size_t newcap, llc, dc;
+  if (need <= store->cap) return;
+  newcap = store->cap ? store->cap : 16;
+  while (newcap < need) newcap *= 2;
+  llc = ZOPFLI_NUM_LL * CeilDiv(newcap, ZOPFLI_NUM_LL);
+  dc = ZOPFLI_NUM_D * CeilDiv(newcap, ZOPFLI_NUM_D);
+  store->litlens = (unsigned short*)realloc(
+      store->litlens, sizeof(*store->litlens) * newcap);
+  store->dists = (unsigned short*)realloc(
+      store->dists, sizeof(*store->dists) * newcap);
+  store->pos = (size_t*)realloc(store->pos, sizeof(*store->pos) * newcap);
+  store->ll_symbol = (unsigned short*)realloc(
+      store->ll_symbol, sizeof(*store->ll_symbol) * newcap);
+  store->d_symbol = (unsigned short*)realloc(
+      store->d_symbol, sizeof(*store->d_symbol) * newcap);
+  store->ll_counts = (size_t*)realloc(
+      store->ll_counts, sizeof(*store->ll_counts) * llc);
+  store->d_counts = (size_t*)realloc(
+      store->d_counts, sizeof(*store->d_counts) * dc);
+  if (!store->litlens || !store->dists || !store->pos) exit(-1);
+  if (!store->ll_symbol || !store->d_symbol) exit(-1);
+  if (!store->ll_counts || !store->d_counts) exit(-1);
+  store->cap = newcap;
+}
+
+void ZopfliResetLZ77Store(ZopfliLZ77Store* store) {
+  store->size = 0;
 }
 
 void ZopfliCopyLZ77Store(
@@ -77,6 +114,7 @@ void ZopfliCopyLZ77Store(
   if (!dest->ll_counts || !dest->d_counts) exit(-1);
 
   dest->size = source->size;
+  dest->cap = source->size;
   for (i = 0; i < source->size; i++) {
     dest->litlens[i] = source->litlens[i];
     dest->dists[i] = source->dists[i];
@@ -99,54 +137,46 @@ context must be a ZopfliLZ77Store*.
 void ZopfliStoreLitLenDist(unsigned short length, unsigned short dist,
                            size_t pos, ZopfliLZ77Store* store) {
   size_t i;
-  /* Needed for using ZOPFLI_APPEND_DATA multiple times. */
   size_t origsize = store->size;
   size_t llstart = ZOPFLI_NUM_LL * (origsize / ZOPFLI_NUM_LL);
   size_t dstart = ZOPFLI_NUM_D * (origsize / ZOPFLI_NUM_D);
 
+  ZopfliReserveLZ77Store(store, origsize + 1);
+
   /* Everytime the index wraps around, a new cumulative histogram is made: we're
   keeping one histogram value per LZ77 symbol rather than a full histogram for
-  each to save memory. */
+  each to save memory. The new chunk copies the previous chunk's totals (or
+  zeros for the first chunk). */
   if (origsize % ZOPFLI_NUM_LL == 0) {
-    size_t llsize = origsize;
     for (i = 0; i < ZOPFLI_NUM_LL; i++) {
-      ZOPFLI_APPEND_DATA(
-          origsize == 0 ? 0 : store->ll_counts[origsize - ZOPFLI_NUM_LL + i],
-          &store->ll_counts, &llsize);
+      store->ll_counts[origsize + i] =
+          origsize == 0 ? 0 : store->ll_counts[origsize - ZOPFLI_NUM_LL + i];
     }
   }
   if (origsize % ZOPFLI_NUM_D == 0) {
-    size_t dsize = origsize;
     for (i = 0; i < ZOPFLI_NUM_D; i++) {
-      ZOPFLI_APPEND_DATA(
-          origsize == 0 ? 0 : store->d_counts[origsize - ZOPFLI_NUM_D + i],
-          &store->d_counts, &dsize);
+      store->d_counts[origsize + i] =
+          origsize == 0 ? 0 : store->d_counts[origsize - ZOPFLI_NUM_D + i];
     }
   }
 
-  ZOPFLI_APPEND_DATA(length, &store->litlens, &store->size);
-  store->size = origsize;
-  ZOPFLI_APPEND_DATA(dist, &store->dists, &store->size);
-  store->size = origsize;
-  ZOPFLI_APPEND_DATA(pos, &store->pos, &store->size);
+  store->litlens[origsize] = length;
+  store->dists[origsize] = dist;
+  store->pos[origsize] = pos;
   assert(length < 259);
 
   if (dist == 0) {
-    store->size = origsize;
-    ZOPFLI_APPEND_DATA(length, &store->ll_symbol, &store->size);
-    store->size = origsize;
-    ZOPFLI_APPEND_DATA(0, &store->d_symbol, &store->size);
+    store->ll_symbol[origsize] = length;
+    store->d_symbol[origsize] = 0;
     store->ll_counts[llstart + length]++;
   } else {
-    store->size = origsize;
-    ZOPFLI_APPEND_DATA(ZopfliGetLengthSymbol(length),
-                       &store->ll_symbol, &store->size);
-    store->size = origsize;
-    ZOPFLI_APPEND_DATA(ZopfliGetDistSymbol(dist),
-                       &store->d_symbol, &store->size);
+    store->ll_symbol[origsize] = ZopfliGetLengthSymbol(length);
+    store->d_symbol[origsize] = ZopfliGetDistSymbol(dist);
     store->ll_counts[llstart + ZopfliGetLengthSymbol(length)]++;
     store->d_counts[dstart + ZopfliGetDistSymbol(dist)]++;
   }
+
+  store->size = origsize + 1;
 }
 
 void ZopfliAppendLZ77Store(const ZopfliLZ77Store* store,

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -415,7 +415,7 @@ Stores the found sublen, distance and length in the longest match cache, if
 possible.
 */
 static void StoreInLongestMatchCache(ZopfliBlockState* s,
-    size_t pos, size_t limit,
+    size_t pos, size_t limit, size_t size,
     const unsigned short* sublen,
     unsigned short distance, unsigned short length) {
   /* The LMC cache starts at the beginning of the block rather than the
@@ -427,7 +427,12 @@ static void StoreInLongestMatchCache(ZopfliBlockState* s,
   unsigned char cache_available = s->lmc && (s->lmc->length[lmcpos] == 0 ||
       s->lmc->dist[lmcpos] != 0);
 
-  if (s->lmc && limit == ZOPFLI_MAX_MATCH && sublen && !cache_available) {
+  /* Cache full-limit matches, and also end-of-block positions where the limit
+     was clamped to size - pos: there the stored match is the true maximum (it
+     physically can't be longer), so the sublen is complete. Caching these lets
+     the squeeze DP serve every position and skip the hash after iteration 1. */
+  if (s->lmc && (limit == ZOPFLI_MAX_MATCH || pos + limit >= size)
+      && sublen && !cache_available) {
     assert(s->lmc->length[lmcpos] == 1 && s->lmc->dist[lmcpos] == 0);
     s->lmc->dist[lmcpos] = length < ZOPFLI_MIN_MATCH ? 0 : distance;
     s->lmc->length[lmcpos] = length < ZOPFLI_MIN_MATCH ? 0 : length;
@@ -475,6 +480,10 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
        try. */
     *length = 0;
     *distance = 0;
+#ifdef ZOPFLI_LONGEST_MATCH_CACHE
+    /* Cache the no-match so the squeeze DP can serve this position too. */
+    StoreInLongestMatchCache(s, pos, limit, size, sublen, 0, 0);
+#endif
     return;
   }
 
@@ -564,7 +573,7 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
   }
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
-  StoreInLongestMatchCache(s, pos, limit, sublen, bestdist, bestlength);
+  StoreInLongestMatchCache(s, pos, limit, size, sublen, bestdist, bestlength);
 #endif
 
   assert(bestlength <= limit);

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "lz77.h"

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -393,7 +393,7 @@ static int TryGetFromLongestMatchCache(ZopfliBlockState* s,
     if (!sublen || s->lmc->length[lmcpos]
         <= ZopfliMaxCachedSublen(s->lmc, lmcpos, s->lmc->length[lmcpos])) {
       *length = s->lmc->length[lmcpos];
-      if (*length > *limit) *length = *limit;
+      if (*length > *limit) *length = (unsigned short)*limit;
       if (sublen) {
         ZopfliCacheToSublen(s->lmc, lmcpos, *length, sublen);
         *distance = sublen[*length];
@@ -530,13 +530,13 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
         if (same0 > 2 && *scan == *match) {
           unsigned short same1 = h->same[(pos - dist) & ZOPFLI_WINDOW_MASK];
           unsigned short same = ZOPFLI_MIN(same0, same1);
-          same = ZOPFLI_MIN(same, limit);
+          same = (unsigned short)ZOPFLI_MIN(same, limit);
           scan += same;
           match += same;
         }
 #endif
         scan = GetMatch(scan, match, arrayend, arrayend_safe);
-        currentlength = scan - &array[pos];  /* The found length. */
+        currentlength = (unsigned short)(scan - &array[pos]);  /* found len. */
       }
 
       if (currentlength > bestlength) {

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -309,6 +309,9 @@ void ZopfliVerifyLenDist(const unsigned char* data, size_t datasize, size_t pos,
   /* TODO(lode): make this only run in a debug compile, it's for assert only. */
   size_t i;
 
+  /* Read only by the assert below, which NDEBUG strips. */
+  (void)datasize;
+
   assert(pos + length <= datasize);
   for (i = 0; i < length; i++) {
     if (data[pos - dist + i] != data[pos + i]) {
@@ -463,6 +466,8 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
   unsigned short* hprev = h->prev;
   int* hhashval = h->hashval;
   int hval = h->val;
+  /* hhashval is read only by asserts (line ~511), which NDEBUG strips. */
+  (void)hhashval;
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (TryGetFromLongestMatchCache(s, pos, &limit, sublen, distance, length)) {
@@ -524,8 +529,8 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
         unsigned short same0 = h->same[pos & ZOPFLI_WINDOW_MASK];
         if (same0 > 2 && *scan == *match) {
           unsigned short same1 = h->same[(pos - dist) & ZOPFLI_WINDOW_MASK];
-          unsigned short same = same0 < same1 ? same0 : same1;
-          if (same > limit) same = limit;
+          unsigned short same = ZOPFLI_MIN(same0, same1);
+          same = ZOPFLI_MIN(same, limit);
           scan += same;
           match += same;
         }

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -29,6 +29,7 @@ compression.
 
 #include "cache.h"
 #include "hash.h"
+#include "katajainen.h"
 #include "zopfli.h"
 
 /*
@@ -94,6 +95,11 @@ typedef struct ZopfliBlockState {
   /* The start (inclusive) and end (not inclusive) of the current block. */
   size_t blockstart;
   size_t blockend;
+
+  /* Reused scratch for length-limited Huffman code construction, so the hot
+  block-size evaluations don't malloc/free per call. Per block state, so
+  thread-safe. */
+  ZopfliKatajainenScratch katascratch;
 } ZopfliBlockState;
 
 void ZopfliInitBlockState(const ZopfliOptions* options,

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -48,6 +48,7 @@ typedef struct ZopfliLZ77Store {
   unsigned short* dists;  /* If 0: indicates literal in corresponding litlens,
       if > 0: length in corresponding litlens, this is the distance. */
   size_t size;
+  size_t cap;  /* Allocated capacity in lz77 symbols, for reuse across runs. */
 
   const unsigned char* data;  /* original data */
   size_t* pos;  /* position in data where this LZ77 command begins */
@@ -65,6 +66,9 @@ typedef struct ZopfliLZ77Store {
 
 void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store);
 void ZopfliCleanLZ77Store(ZopfliLZ77Store* store);
+/* Empties the store (size 0) but keeps its allocation, so it can be refilled
+without reallocating. */
+void ZopfliResetLZ77Store(ZopfliLZ77Store* store);
 void ZopfliCopyLZ77Store(const ZopfliLZ77Store* source, ZopfliLZ77Store* dest);
 void ZopfliStoreLitLenDist(unsigned short length, unsigned short dist,
                            size_t pos, ZopfliLZ77Store* store);

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -29,6 +29,13 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #include "tree.h"
 #include "util.h"
 
+/*
+Cost stored for a byte position that has not been reached yet. Larger than any
+real accumulated cost (the shift in ZopfliGetCostShift keeps real costs below
+2^29) and below the type's maximum, so it never participates in arithmetic.
+*/
+#define ZOPFLI_COST_SENTINEL ((ZopfliCost)1 << 30)
+
 typedef struct SymbolStats {
   /* The literal and length symbols. */
   size_t litlens[ZOPFLI_NUM_LL];
@@ -113,88 +120,93 @@ static void ClearStatFreqs(SymbolStats* stats) {
 }
 
 /*
-Function that calculates a cost based on a model for the given LZ77 symbol.
-litlen: means literal symbol if dist is 0, length otherwise.
+Fixed-point cost model for the optimal parse. Costs are bit lengths scaled by
+2^shift. The tables are precomputed once per forward pass so the hot inner loop
+is a couple of integer lookups and an add instead of a function call. Length and
+distance contributions are kept separate because a match's distance is only
+known per candidate length.
 */
-typedef double CostModelFun(unsigned litlen, unsigned dist, void* context);
+typedef struct CostCache {
+  /* Cost of a literal byte, indexed by the byte value. */
+  ZopfliCost lit_cost[256];
+  /* Cost of a match's length, indexed by the length (3..ZOPFLI_MAX_MATCH). */
+  ZopfliCost ll_cost[ZOPFLI_MAX_MATCH + 1];
+  /* Cost of a match's distance, indexed by its distance symbol (0..29). */
+  ZopfliCost d_cost[ZOPFLI_NUM_D];
+  /* Smallest cost any match can have; lets the inner loop skip work. */
+  ZopfliCost mincost;
+} CostCache;
 
-/*
-Cost model which should exactly match fixed tree.
-type: CostModelFun
-*/
-static double GetCostFixed(unsigned litlen, unsigned dist, void* unused) {
-  (void)unused;
-  if (dist == 0) {
-    if (litlen <= 143) return 8;
-    else return 9;
-  } else {
-    int dbits = ZopfliGetDistExtraBits(dist);
-    int lbits = ZopfliGetLengthExtraBits(litlen);
-    int lsym = ZopfliGetLengthSymbol(litlen);
-    int cost = 0;
-    if (lsym <= 279) cost += 7;
-    else cost += 8;
-    cost += 5;  /* Every dist symbol has length 5. */
-    return cost + dbits + lbits;
+int ZopfliGetCostShift(size_t blocksize) {
+  /* A single position costs at most ~32 bits, so a whole block costs less than
+  32 * blocksize bits. Pick the largest shift keeping the scaled total below
+  2^29, which leaves headroom below the 2^30 sentinel and the type maximum.
+  Smaller blocks get more fractional bits. */
+  int shift = 16;
+  while (shift > 3 && (size_t)32 * blocksize > ((size_t)1 << (29 - shift))) {
+    shift--;
   }
+  return shift;
 }
 
-/*
-Cost model based on symbol statistics.
-type: CostModelFun
-*/
-static double GetCostStat(unsigned litlen, unsigned dist, void* context) {
-  SymbolStats* stats = (SymbolStats*)context;
-  if (dist == 0) {
-    return stats->ll_symbols[litlen];
-  } else {
-    int lsym = ZopfliGetLengthSymbol(litlen);
-    int lbits = ZopfliGetLengthExtraBits(litlen);
-    int dsym = ZopfliGetDistSymbol(dist);
-    int dbits = ZopfliGetDistExtraBits(dist);
-    return lbits + dbits + stats->ll_symbols[lsym] + stats->d_symbols[dsym];
-  }
+/* Rounds a non-negative bit cost to fixed point with the given shift. */
+static ZopfliCost ScaleCost(double cost, int shift) {
+  return (ZopfliCost)(cost * (double)((size_t)1 << shift) + 0.5);
 }
 
-/*
-Finds the minimum possible cost this cost model can return for valid length and
-distance symbols.
-*/
-static double GetCostModelMinCost(CostModelFun* costmodel, void* costcontext) {
-  double mincost;
-  int bestlength = 0; /* length that has lowest cost in the cost model */
-  int bestdist = 0; /* distance that has lowest cost in the cost model */
+/* Fills in mincost: the cheapest cost any valid match can have. Only the 30
+real distance symbols are considered, matching the deflate spec. */
+static void SetMinMatchCost(CostCache* c) {
   int i;
-  /*
-  Table of distances that have a different distance symbol in the deflate
-  specification. Each value is the first distance that has a new symbol. Only
-  different symbols affect the cost model so only these need to be checked.
-  See RFC 1951 section 3.2.5. Compressed blocks (length and distance codes).
-  */
-  static const int dsymbols[30] = {
-    1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513,
-    769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577
-  };
-
-  mincost = ZOPFLI_LARGE_FLOAT;
-  for (i = 3; i < 259; i++) {
-    double c = costmodel(i, 1, costcontext);
-    if (c < mincost) {
-      bestlength = i;
-      mincost = c;
-    }
+  ZopfliCost minll = c->ll_cost[ZOPFLI_MIN_MATCH];
+  ZopfliCost mind = c->d_cost[0];
+  for (i = ZOPFLI_MIN_MATCH + 1; i <= ZOPFLI_MAX_MATCH; i++) {
+    if (c->ll_cost[i] < minll) minll = c->ll_cost[i];
   }
+  for (i = 1; i < 30; i++) {
+    if (c->d_cost[i] < mind) mind = c->d_cost[i];
+  }
+  c->mincost = minll + mind;
+}
 
-  mincost = ZOPFLI_LARGE_FLOAT;
+/* Builds the cache from symbol statistics (the per-iteration cost model). */
+static void BuildStatCostCache(const SymbolStats* stats, int shift,
+                               CostCache* c) {
+  int i;
+  for (i = 0; i < 256; i++) {
+    c->lit_cost[i] = ScaleCost(stats->ll_symbols[i], shift);
+  }
+  for (i = ZOPFLI_MIN_MATCH; i <= ZOPFLI_MAX_MATCH; i++) {
+    c->ll_cost[i] = ScaleCost(stats->ll_symbols[ZopfliGetLengthSymbol(i)],
+                              shift)
+        + ((ZopfliCost)ZopfliGetLengthExtraBits(i) << shift);
+  }
   for (i = 0; i < 30; i++) {
-    double c = costmodel(3, dsymbols[i], costcontext);
-    if (c < mincost) {
-      bestdist = dsymbols[i];
-      mincost = c;
-    }
+    c->d_cost[i] = ScaleCost(stats->d_symbols[i], shift)
+        + ((ZopfliCost)ZopfliGetDistSymbolExtraBits(i) << shift);
   }
+  SetMinMatchCost(c);
+}
 
-  return costmodel(bestlength, bestdist, costcontext);
+/* Builds the cache that exactly matches the deflate fixed tree. The costs are
+whole bit counts, so the shift is an exact multiply with no rounding. */
+static void BuildFixedCostCache(int shift, CostCache* c) {
+  int i;
+  for (i = 0; i < 256; i++) {
+    c->lit_cost[i] = (ZopfliCost)(i <= 143 ? 8 : 9) << shift;
+  }
+  for (i = ZOPFLI_MIN_MATCH; i <= ZOPFLI_MAX_MATCH; i++) {
+    /* 7 or 8 bits for the length symbol, plus its extra bits. */
+    int base = (ZopfliGetLengthSymbol(i) <= 279 ? 7 : 8)
+        + ZopfliGetLengthExtraBits(i);
+    c->ll_cost[i] = (ZopfliCost)base << shift;
+  }
+  for (i = 0; i < 30; i++) {
+    /* Every dist symbol has length 5, plus its extra bits. */
+    int base = 5 + ZopfliGetDistSymbolExtraBits(i);
+    c->d_cost[i] = (ZopfliCost)base << shift;
+  }
+  SetMinMatchCost(c);
 }
 
 static size_t zopfli_min(size_t a, size_t b) {
@@ -208,18 +220,17 @@ s: the ZopfliBlockState
 in: the input data array
 instart: where to start
 inend: where to stop (not inclusive)
-costmodel: function to calculate the cost of some lit/len/dist pair.
-costcontext: abstract context for the costmodel function
+cache: precomputed fixed-point costs of each lit/len/dist symbol.
 length_array: output array of size (inend - instart) which will receive the best
     length to reach this byte from a previous byte.
-returns the cost that was, according to the costmodel, needed to get to the end.
+returns the cost that was, according to the cost model, needed to get to the end.
 */
-static double GetBestLengths(ZopfliBlockState *s,
-                             const unsigned char* in,
-                             size_t instart, size_t inend,
-                             CostModelFun* costmodel, void* costcontext,
-                             unsigned short* length_array,
-                             ZopfliHash* h, float* costs) {
+static ZopfliCost GetBestLengths(ZopfliBlockState *s,
+                                    const unsigned char* in,
+                                    size_t instart, size_t inend,
+                                    const CostCache* cache,
+                                    unsigned short* length_array,
+                                    ZopfliHash* h, ZopfliCost* costs) {
   /* Best cost to get here so far. */
   size_t blocksize = inend - instart;
   size_t i = 0, k, kend;
@@ -228,9 +239,9 @@ static double GetBestLengths(ZopfliBlockState *s,
   unsigned short sublen[259];
   size_t windowstart = instart > ZOPFLI_WINDOW_SIZE
       ? instart - ZOPFLI_WINDOW_SIZE : 0;
-  double result;
-  double mincost = GetCostModelMinCost(costmodel, costcontext);
-  double mincostaddcostj;
+  ZopfliCost result;
+  ZopfliCost mincost = cache->mincost;
+  ZopfliCost mincostaddcostj;
 
   if (instart == inend) return 0;
 
@@ -240,7 +251,7 @@ static double GetBestLengths(ZopfliBlockState *s,
     ZopfliUpdateHash(in, i, inend, h);
   }
 
-  for (i = 1; i < blocksize + 1; i++) costs[i] = ZOPFLI_LARGE_FLOAT;
+  for (i = 1; i < blocksize + 1; i++) costs[i] = ZOPFLI_COST_SENTINEL;
   costs[0] = 0;  /* Because it's the start. */
   length_array[0] = 0;
 
@@ -256,7 +267,9 @@ static double GetBestLengths(ZopfliBlockState *s,
         && i + ZOPFLI_MAX_MATCH * 2 + 1 < inend
         && h->same[(i - ZOPFLI_MAX_MATCH) & ZOPFLI_WINDOW_MASK]
             > ZOPFLI_MAX_MATCH) {
-      double symbolcost = costmodel(ZOPFLI_MAX_MATCH, 1, costcontext);
+      /* Cost of a ZOPFLI_MAX_MATCH match at distance 1 (dist symbol 0). */
+      ZopfliCost symbolcost = cache->ll_cost[ZOPFLI_MAX_MATCH]
+          + cache->d_cost[0];
       /* Set the length to reach each one to ZOPFLI_MAX_MATCH, and the cost to
       the cost corresponding to that length. Doing this, we skip
       ZOPFLI_MAX_MATCH values to avoid calling ZopfliFindLongestMatch. */
@@ -275,7 +288,7 @@ static double GetBestLengths(ZopfliBlockState *s,
 
     /* Literal. */
     if (i + 1 <= inend) {
-      double newCost = costmodel(in[i], 0, costcontext) + costs[j];
+      ZopfliCost newCost = cache->lit_cost[in[i]] + costs[j];
       assert(newCost >= 0);
       if (newCost < costs[j + 1]) {
         costs[j + 1] = newCost;
@@ -286,13 +299,13 @@ static double GetBestLengths(ZopfliBlockState *s,
     kend = zopfli_min(leng, inend-i);
     mincostaddcostj = mincost + costs[j];
     for (k = 3; k <= kend; k++) {
-      double newCost;
+      ZopfliCost newCost;
 
-      /* Calling the cost model is expensive, avoid this if we are already at
-      the minimum possible cost that it can return. */
+      /* The cheapest a match can be is mincost; skip if we already beat it. */
      if (costs[j + k] <= mincostaddcostj) continue;
 
-      newCost = costmodel(k, sublen[k], costcontext) + costs[j];
+      newCost = cache->ll_cost[k]
+          + cache->d_cost[ZopfliGetDistSymbol(sublen[k])] + costs[j];
       assert(newCost >= 0);
       if (newCost < costs[j + k]) {
         assert(k <= ZOPFLI_MAX_MATCH);
@@ -420,26 +433,25 @@ inend: where to stop (not inclusive)
 path: pointer to dynamically allocated memory to store the path
 pathsize: pointer to the size of the dynamic path array
 length_array: array of size (inend - instart) used to store lengths
-costmodel: function to use as the cost model for this squeeze run
-costcontext: abstract context for the costmodel function
+cache: precomputed fixed-point cost model for this squeeze run
 store: place to output the LZ77 data
-returns the cost that was, according to the costmodel, needed to get to the end.
+returns the cost that was, according to the cost model, needed to get to the end.
     This is not the actual cost.
 */
-static double LZ77OptimalRun(ZopfliBlockState* s,
+static ZopfliCost LZ77OptimalRun(ZopfliBlockState* s,
     const unsigned char* in, size_t instart, size_t inend,
     unsigned short** path, size_t* pathsize,
-    unsigned short* length_array, CostModelFun* costmodel,
-    void* costcontext, ZopfliLZ77Store* store,
-    ZopfliHash* h, float* costs) {
-  double cost = GetBestLengths(s, in, instart, inend, costmodel,
-                costcontext, length_array, h, costs);
+    unsigned short* length_array, const CostCache* cache,
+    ZopfliLZ77Store* store,
+    ZopfliHash* h, ZopfliCost* costs) {
+  ZopfliCost cost = GetBestLengths(s, in, instart, inend, cache,
+                length_array, h, costs);
   free(*path);
   *path = 0;
   *pathsize = 0;
   TraceBackwards(inend - instart, length_array, path, pathsize);
   FollowPath(s, in, instart, inend, *path, *pathsize, store, h);
-  assert(cost < ZOPFLI_LARGE_FLOAT);
+  assert(cost < ZOPFLI_COST_SENTINEL);
   return cost;
 }
 
@@ -458,7 +470,10 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   ZopfliHash* h = &hash;
   SymbolStats stats, beststats, laststats;
   int i;
-  float* costs = (float*)malloc(sizeof(float) * (blocksize + 1));
+  ZopfliCost* costs =
+      (ZopfliCost*)malloc(sizeof(*costs) * (blocksize + 1));
+  int shift = ZopfliGetCostShift(blocksize);
+  CostCache cache;
   double cost;
   double bestcost = ZOPFLI_LARGE_FLOAT;
   double lastcost = 0;
@@ -486,9 +501,9 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   for (i = 0; i < numiterations; i++) {
     ZopfliCleanLZ77Store(&currentstore);
     ZopfliInitLZ77Store(in, &currentstore);
+    BuildStatCostCache(&stats, shift, &cache);
     LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
-                   length_array, GetCostStat, (void*)&stats,
-                   &currentstore, h, costs);
+                   length_array, &cache, &currentstore, h, costs);
     cost = ZopfliCalculateBlockSize(&currentstore, 0, currentstore.size, 2);
     if (s->options->verbose_more || (s->options->verbose && cost < bestcost)) {
       fprintf(stderr, "Iteration %d: %d bit\n", i, (int) cost);
@@ -538,7 +553,9 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   size_t pathsize = 0;
   ZopfliHash hash;
   ZopfliHash* h = &hash;
-  float* costs = (float*)malloc(sizeof(float) * (blocksize + 1));
+  ZopfliCost* costs =
+      (ZopfliCost*)malloc(sizeof(*costs) * (blocksize + 1));
+  CostCache cache;
 
   if (!costs) exit(-1); /* Allocation failed. */
   if (!length_array) exit(-1); /* Allocation failed. */
@@ -550,8 +567,9 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
 
   /* Shortest path for fixed tree This one should give the shortest possible
   result for fixed tree, no repeated runs are needed since the tree is known. */
+  BuildFixedCostCache(ZopfliGetCostShift(blocksize), &cache);
   LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
-                 length_array, GetCostFixed, 0, store, h, costs);
+                 length_array, &cache, store, h, costs);
 
   free(length_array);
   free(path);

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -256,7 +256,8 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
                                     const CostCache* cache,
                                     unsigned short* length_array,
                                     unsigned short* dist_array,
-                                    ZopfliHash* h, ZopfliCost* costs) {
+                                    ZopfliHash* h, ZopfliCost* costs,
+                                    int build_hash) {
   /* Best cost to get here so far. */
   size_t blocksize = inend - instart;
   size_t i = 0, k, kend;
@@ -271,10 +272,16 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
 
   if (instart == inend) return 0;
 
-  ZopfliResetHash(ZOPFLI_WINDOW_SIZE, h);
-  ZopfliWarmupHash(in, windowstart, inend, h);
-  for (i = windowstart; i < instart; i++) {
-    ZopfliUpdateHash(in, i, inend, h);
+  /* The hash is a pure function of the input, so once the longest-match cache
+  holds every position's full sublen (all_complete), later iterations serve
+  every position from cache and never read the hash. build_hash is then 0 and
+  the whole rebuild is skipped. */
+  if (build_hash) {
+    ZopfliResetHash(ZOPFLI_WINDOW_SIZE, h);
+    ZopfliWarmupHash(in, windowstart, inend, h);
+    for (i = windowstart; i < instart; i++) {
+      ZopfliUpdateHash(in, i, inend, h);
+    }
   }
 
   for (i = 1; i < blocksize + 1; i++) costs[i] = ZOPFLI_COST_SENTINEL;
@@ -284,12 +291,14 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
 
   for (i = instart; i < inend; i++) {
     size_t j = i - instart;  /* Index in the costs array and length_array. */
-    ZopfliUpdateHash(in, i, inend, h);
+    if (build_hash) ZopfliUpdateHash(in, i, inend, h);
 
 #ifdef ZOPFLI_SHORTCUT_LONG_REPETITIONS
     /* If we're in a long repetition of the same character and have more than
-    ZOPFLI_MAX_MATCH characters before and after our position. */
-    if (h->same[i & ZOPFLI_WINDOW_MASK] > ZOPFLI_MAX_MATCH * 2
+    ZOPFLI_MAX_MATCH characters before and after our position. Skipped when the
+    hash isn't built; the cache fast path produces identical costs for these. */
+    if (build_hash
+        && h->same[i & ZOPFLI_WINDOW_MASK] > ZOPFLI_MAX_MATCH * 2
         && i > instart + ZOPFLI_MAX_MATCH + 1
         && i + ZOPFLI_MAX_MATCH * 2 + 1 < inend
         && h->same[(i - ZOPFLI_MAX_MATCH) & ZOPFLI_WINDOW_MASK]
@@ -297,6 +306,9 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       /* Cost of a ZOPFLI_MAX_MATCH match at distance 1 (dist symbol 0). */
       ZopfliCost symbolcost = cache->ll_cost[ZOPFLI_MAX_MATCH]
           + cache->d_cost[0];
+      /* The skipped positions are never stored in the cache, so this block is
+      not fully cacheable: keep building the hash on every iteration. */
+      if (s->lmc) s->lmc->all_complete = 0;
       /* Set the length to reach each one to ZOPFLI_MAX_MATCH, and the cost to
       the cost corresponding to that length. Doing this, we skip
       ZOPFLI_MAX_MATCH values to avoid calling ZopfliFindLongestMatch. */
@@ -339,29 +351,35 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       unsigned maxsub = avail ?
           ZopfliMaxCachedSublen(s->lmc, lmcpos, cachedlen) : 0;
       if (avail && cachedlen <= maxsub) {
-        unsigned short run_maxlen[ZOPFLI_CACHE_LENGTH];
-        unsigned short run_dist[ZOPFLI_CACHE_LENGTH];
-        int nruns = ZopfliCacheSublenRuns(s->lmc, lmcpos, maxsub,
-                                          run_maxlen, run_dist);
-        size_t klo = 3;
-        int r;
-        kend = zopfli_min((size_t)cachedlen, inend - i);
-        for (r = 0; r < nruns && klo <= kend; r++) {
-          size_t khi = run_maxlen[r];
-          if (khi > kend) khi = kend;
-          if (klo <= khi) {
-            ZopfliCost dcost = cache->d_cost[ZopfliGetDistSymbol(run_dist[r])];
-            UpdateCostForRange(costs, length_array, dist_array, j, klo, khi,
-                               run_dist[r], dcost, cache, costs[j],
-                               mincostaddcostj);
+        /* Walk this position's runs straight from the shared pool. The last
+        run's threshold is cachedlen, so the klo > kend test always terminates
+        before reading past it. */
+        if (cachedlen >= ZOPFLI_MIN_MATCH) {
+          const unsigned char* run =
+              &s->lmc->pool[(size_t)s->lmc->run_off[lmcpos] * 3];
+          size_t klo;
+          kend = zopfli_min((size_t)cachedlen, inend - i);
+          for (klo = 3; klo <= kend; run += 3) {
+            size_t runlen = (size_t)run[0] + 3;
+            unsigned short rundist = (unsigned short)(run[1] + 256 * run[2]);
+            size_t khi = runlen > kend ? kend : runlen;
+            if (klo <= khi) {
+              ZopfliCost dcost = cache->d_cost[ZopfliGetDistSymbol(rundist)];
+              UpdateCostForRange(costs, length_array, dist_array, j, klo, khi,
+                                 rundist, dcost, cache, costs[j],
+                                 mincostaddcostj);
+            }
+            klo = runlen + 1;
           }
-          klo = (size_t)run_maxlen[r] + 1;
         }
         continue;
       }
     }
 #endif
 
+    /* Reaching the slow path means this position wasn't fully cached, so the
+    hash must have been built this pass. */
+    assert(build_hash);
     ZopfliFindLongestMatch(s, h, in, i, inend, ZOPFLI_MAX_MATCH, sublen,
                            &dist, &leng);
 
@@ -487,9 +505,9 @@ static ZopfliCost LZ77OptimalRun(ZopfliBlockState* s,
     unsigned short** path, size_t* pathsize,
     unsigned short* length_array, unsigned short* dist_array,
     const CostCache* cache, ZopfliLZ77Store* store,
-    ZopfliHash* h, ZopfliCost* costs) {
+    ZopfliHash* h, ZopfliCost* costs, int build_hash) {
   ZopfliCost cost = GetBestLengths(s, in, instart, inend, cache,
-                length_array, dist_array, h, costs);
+                length_array, dist_array, h, costs, build_hash);
   free(*path);
   *path = 0;
   *pathsize = 0;
@@ -526,6 +544,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   /* Try randomizing the costs a bit once the size stabilizes. */
   RanState ran_state;
   int lastrandomstep = -1;
+  int build_hash;
 
   if (!costs) exit(-1); /* Allocation failed. */
   if (!length_array) exit(-1); /* Allocation failed. */
@@ -544,12 +563,15 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   GetStatistics(&currentstore, &stats);
 
   /* Repeat statistics with each time the cost model from the previous stat
-  run. */
+  run. Iteration 0 fills the cache gaps the greedy pass left, so it needs the
+  hash; later iterations skip it once the cache holds every position. */
+  build_hash = 1;
   for (i = 0; i < numiterations; i++) {
     ZopfliResetLZ77Store(&currentstore);
     BuildStatCostCache(&stats, shift, &cache);
-    LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
-                   length_array, dist_array, &cache, &currentstore, h, costs);
+    LZ77OptimalRun(s, in, instart, inend, &path, &pathsize, length_array,
+                   dist_array, &cache, &currentstore, h, costs, build_hash);
+    if (i == 0) build_hash = !(s->lmc && s->lmc->all_complete);
     cost = ZopfliCalculateBlockSizeScratch(&s->katascratch, &currentstore, 0,
                                            currentstore.size, 2);
     if (s->options->verbose_more || (s->options->verbose && cost < bestcost)) {
@@ -620,7 +642,7 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   result for fixed tree, no repeated runs are needed since the tree is known. */
   BuildFixedCostCache(ZopfliGetCostShift(blocksize), &cache);
   LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
-                 length_array, dist_array, &cache, store, h, costs);
+                 length_array, dist_array, &cache, store, h, costs, 1);
 
   free(length_array);
   free(dist_array);

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -21,7 +21,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include "squeeze.h"
 
 #include <assert.h>
-#include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "blocksplitter.h"
@@ -43,10 +43,10 @@ typedef struct SymbolStats {
   /* The 32 unique dist symbols, not the 32768 possible dists. */
   size_t dists[ZOPFLI_NUM_D];
 
-  /* Length of each lit/len symbol in bits. */
-  double ll_symbols[ZOPFLI_NUM_LL];
-  /* Length of each dist symbol in bits. */
-  double d_symbols[ZOPFLI_NUM_D];
+  /* Entropy bit-length of each symbol, Q(shift) fixed point (the per-block cost
+  shift), i.e. ideal bits scaled by 2^shift. Feeds the cost model directly. */
+  uint32_t ll_symbols[ZOPFLI_NUM_LL];
+  uint32_t d_symbols[ZOPFLI_NUM_D];
 } SymbolStats;
 
 /* Sets everything to 0. */
@@ -69,18 +69,16 @@ static void CopyStats(SymbolStats* source, SymbolStats* dest) {
          ZOPFLI_NUM_D * sizeof(dest->d_symbols[0]));
 }
 
-/* Adds the bit lengths. */
-static void AddWeighedStatFreqs(const SymbolStats* stats1, double w1,
-                                const SymbolStats* stats2, double w2,
-                                SymbolStats* result) {
+/* result = stats1 + stats2/2 (the b/2 truncates identically to the old
+(size_t)(a*1.0 + b*0.5), so this is the same blend, integer-only). */
+static void AddStatFreqsHalf(const SymbolStats* stats1,
+                             const SymbolStats* stats2, SymbolStats* result) {
   size_t i;
   for (i = 0; i < ZOPFLI_NUM_LL; i++) {
-    result->litlens[i] =
-        (size_t) (stats1->litlens[i] * w1 + stats2->litlens[i] * w2);
+    result->litlens[i] = stats1->litlens[i] + stats2->litlens[i] / 2;
   }
   for (i = 0; i < ZOPFLI_NUM_D; i++) {
-    result->dists[i] =
-        (size_t) (stats1->dists[i] * w1 + stats2->dists[i] * w2);
+    result->dists[i] = stats1->dists[i] + stats2->dists[i] / 2;
   }
   result->litlens[256] = 1;  /* End symbol. */
 }
@@ -150,11 +148,6 @@ int ZopfliGetCostShift(size_t blocksize) {
   return shift;
 }
 
-/* Rounds a non-negative bit cost to fixed point with the given shift. */
-static ZopfliCost ScaleCost(double cost, int shift) {
-  return (ZopfliCost)(cost * (double)((size_t)1 << shift) + 0.5);
-}
-
 /* Fills in mincost: the cheapest cost any valid match can have. Only the 30
 real distance symbols are considered, matching the deflate spec. */
 static void SetMinMatchCost(CostCache* c) {
@@ -170,20 +163,21 @@ static void SetMinMatchCost(CostCache* c) {
   c->mincost = minll + mind;
 }
 
-/* Builds the cache from symbol statistics (the per-iteration cost model). */
+/* Builds the cache from symbol statistics (the per-iteration cost model). The
+entropy in stats is already Q(shift) fixed point, so it is the scaled cost
+directly; only the literal extra bits (length/dist) need the << shift. */
 static void BuildStatCostCache(const SymbolStats* stats, int shift,
                                CostCache* c) {
   int i;
   for (i = 0; i < 256; i++) {
-    c->lit_cost[i] = ScaleCost(stats->ll_symbols[i], shift);
+    c->lit_cost[i] = (ZopfliCost)stats->ll_symbols[i];
   }
   for (i = ZOPFLI_MIN_MATCH; i <= ZOPFLI_MAX_MATCH; i++) {
-    c->ll_cost[i] = ScaleCost(stats->ll_symbols[ZopfliGetLengthSymbol(i)],
-                              shift)
+    c->ll_cost[i] = (ZopfliCost)stats->ll_symbols[ZopfliGetLengthSymbol(i)]
         + ((ZopfliCost)ZopfliGetLengthExtraBits(i) << shift);
   }
   for (i = 0; i < 30; i++) {
-    c->d_cost[i] = ScaleCost(stats->d_symbols[i], shift)
+    c->d_cost[i] = (ZopfliCost)stats->d_symbols[i]
         + ((ZopfliCost)ZopfliGetDistSymbolExtraBits(i) << shift);
   }
   SetMinMatchCost(c);
@@ -463,14 +457,16 @@ static void FollowPath(const unsigned char* in, size_t instart, size_t inend,
   }
 }
 
-/* Calculates the entropy of the statistics */
-static void CalculateStatistics(SymbolStats* stats) {
-  ZopfliCalculateEntropy(stats->litlens, ZOPFLI_NUM_LL, stats->ll_symbols);
-  ZopfliCalculateEntropy(stats->dists, ZOPFLI_NUM_D, stats->d_symbols);
+/* Calculates the entropy of the statistics at the block's cost shift (Q(shift)
+fixed point), so the result feeds the cost model directly. */
+static void CalculateStatistics(SymbolStats* stats, int shift) {
+  ZopfliCalculateEntropy(stats->litlens, ZOPFLI_NUM_LL, stats->ll_symbols, shift);
+  ZopfliCalculateEntropy(stats->dists, ZOPFLI_NUM_D, stats->d_symbols, shift);
 }
 
 /* Appends the symbol statistics from the store. */
-static void GetStatistics(const ZopfliLZ77Store* store, SymbolStats* stats) {
+static void GetStatistics(const ZopfliLZ77Store* store, SymbolStats* stats,
+                          int shift) {
   size_t i;
   for (i = 0; i < store->size; i++) {
     if (store->dists[i] == 0) {
@@ -482,7 +478,7 @@ static void GetStatistics(const ZopfliLZ77Store* store, SymbolStats* stats) {
   }
   stats->litlens[256] = 1;  /* End symbol. */
 
-  CalculateStatistics(stats);
+  CalculateStatistics(stats, shift);
 }
 
 /*
@@ -538,9 +534,9 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
       (ZopfliCost*)malloc(sizeof(*costs) * (blocksize + 1));
   int shift = ZopfliGetCostShift(blocksize);
   CostCache cache;
-  double cost;
-  double bestcost = ZOPFLI_LARGE_FLOAT;
-  double lastcost = 0;
+  uint32_t cost;
+  uint32_t bestcost = ZOPFLI_LARGE_COST;
+  uint32_t lastcost = 0;
   /* Try randomizing the costs a bit once the size stabilizes. */
   RanState ran_state;
   int lastrandomstep = -1;
@@ -560,7 +556,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
 
   /* Initial run. */
   ZopfliLZ77Greedy(s, in, instart, inend, &currentstore, h);
-  GetStatistics(&currentstore, &stats);
+  GetStatistics(&currentstore, &stats, shift);
 
   /* Repeat statistics with each time the cost model from the previous stat
   run. Iteration 0 fills the cache gaps the greedy pass left, so it needs the
@@ -585,18 +581,18 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     }
     CopyStats(&stats, &laststats);
     ClearStatFreqs(&stats);
-    GetStatistics(&currentstore, &stats);
+    GetStatistics(&currentstore, &stats, shift);
     if (lastrandomstep != -1) {
       /* This makes it converge slower but better. Do it only once the
       randomness kicks in so that if the user does few iterations, it gives a
       better result sooner. */
-      AddWeighedStatFreqs(&stats, 1.0, &laststats, 0.5, &stats);
-      CalculateStatistics(&stats);
+      AddStatFreqsHalf(&stats, &laststats, &stats);
+      CalculateStatistics(&stats, shift);
     }
     if (i > 5 && cost == lastcost) {
       CopyStats(&beststats, &stats);
       RandomizeStatFreqs(&ran_state, &stats);
-      CalculateStatistics(&stats);
+      CalculateStatistics(&stats, shift);
       lastrandomstep = i;
     }
     lastcost = cost;

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -222,7 +222,7 @@ static void UpdateCostForRange(ZopfliCost* costs, unsigned short* length_array,
     if (newCost < costs[j + k]) {
       assert(k <= ZOPFLI_MAX_MATCH);
       costs[j + k] = newCost;
-      length_array[j + k] = k;
+      length_array[j + k] = (unsigned short)k;
       dist_array[j + k] = dist;
     }
   }

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -231,6 +231,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
                                     size_t instart, size_t inend,
                                     const CostCache* cache,
                                     unsigned short* length_array,
+                                    unsigned short* dist_array,
                                     ZopfliHash* h, ZopfliCost* costs) {
   /* Best cost to get here so far. */
   size_t blocksize = inend - instart;
@@ -255,6 +256,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
   for (i = 1; i < blocksize + 1; i++) costs[i] = ZOPFLI_COST_SENTINEL;
   costs[0] = 0;  /* Because it's the start. */
   length_array[0] = 0;
+  dist_array[0] = 0;
 
   for (i = instart; i < inend; i++) {
     size_t j = i - instart;  /* Index in the costs array and length_array. */
@@ -277,6 +279,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       for (k = 0; k < ZOPFLI_MAX_MATCH; k++) {
         costs[j + ZOPFLI_MAX_MATCH] = costs[j] + symbolcost;
         length_array[j + ZOPFLI_MAX_MATCH] = ZOPFLI_MAX_MATCH;
+        dist_array[j + ZOPFLI_MAX_MATCH] = 1;  /* Dist-1 repetition. */
         i++;
         j++;
         ZopfliUpdateHash(in, i, inend, h);
@@ -294,6 +297,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       if (newCost < costs[j + 1]) {
         costs[j + 1] = newCost;
         length_array[j + 1] = 1;
+        dist_array[j + 1] = 0;  /* Literal. */
       }
     }
     /* Lengths. */
@@ -312,6 +316,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
         assert(k <= ZOPFLI_MAX_MATCH);
         costs[j + k] = newCost;
         length_array[j + k] = k;
+        dist_array[j + k] = sublen[k];
       }
     }
   }
@@ -349,55 +354,33 @@ static void TraceBackwards(size_t size, const unsigned short* length_array,
   }
 }
 
-static void FollowPath(ZopfliBlockState* s,
-                       const unsigned char* in, size_t instart, size_t inend,
-                       unsigned short* path, size_t pathsize,
-                       ZopfliLZ77Store* store, ZopfliHash *h) {
-  size_t i, j, pos = 0;
-  size_t windowstart = instart > ZOPFLI_WINDOW_SIZE
-      ? instart - ZOPFLI_WINDOW_SIZE : 0;
-
-  size_t total_length_test = 0;
+/*
+Outputs the lz77 symbols for the chosen path. Distances were already computed
+during GetBestLengths (dist_array, parallel to length_array), so unlike the
+forward pass this needs no hash and no match recalculation.
+*/
+static void FollowPath(const unsigned char* in, size_t instart, size_t inend,
+                       const unsigned short* path, size_t pathsize,
+                       const unsigned short* dist_array,
+                       ZopfliLZ77Store* store) {
+  size_t i, pos = instart;
+  size_t cur = 0;  /* Position within the block, i.e. pos - instart. */
 
   if (instart == inend) return;
 
-  ZopfliResetHash(ZOPFLI_WINDOW_SIZE, h);
-  ZopfliWarmupHash(in, windowstart, inend, h);
-  for (i = windowstart; i < instart; i++) {
-    ZopfliUpdateHash(in, i, inend, h);
-  }
-
-  pos = instart;
   for (i = 0; i < pathsize; i++) {
     unsigned short length = path[i];
-    unsigned short dummy_length;
-    unsigned short dist;
     assert(pos < inend);
-
-    ZopfliUpdateHash(in, pos, inend, h);
-
-    /* Add to output. */
     if (length >= ZOPFLI_MIN_MATCH) {
-      /* Get the distance by recalculating longest match. The found length
-      should match the length from the path. */
-      ZopfliFindLongestMatch(s, h, in, pos, inend, length, 0,
-                             &dist, &dummy_length);
-      assert(!(dummy_length != length && length > 2 && dummy_length > 2));
+      unsigned short dist = dist_array[cur + length];
       ZopfliVerifyLenDist(in, inend, pos, dist, length);
       ZopfliStoreLitLenDist(length, dist, pos, store);
-      total_length_test += length;
     } else {
       length = 1;
       ZopfliStoreLitLenDist(in[pos], 0, pos, store);
-      total_length_test++;
     }
-
-
     assert(pos + length <= inend);
-    for (j = 1; j < length; j++) {
-      ZopfliUpdateHash(in, pos + j, inend, h);
-    }
-
+    cur += length;
     pos += length;
   }
 }
@@ -442,16 +425,16 @@ returns the cost that was, according to the cost model, needed to get to the end
 static ZopfliCost LZ77OptimalRun(ZopfliBlockState* s,
     const unsigned char* in, size_t instart, size_t inend,
     unsigned short** path, size_t* pathsize,
-    unsigned short* length_array, const CostCache* cache,
-    ZopfliLZ77Store* store,
+    unsigned short* length_array, unsigned short* dist_array,
+    const CostCache* cache, ZopfliLZ77Store* store,
     ZopfliHash* h, ZopfliCost* costs) {
   ZopfliCost cost = GetBestLengths(s, in, instart, inend, cache,
-                length_array, h, costs);
+                length_array, dist_array, h, costs);
   free(*path);
   *path = 0;
   *pathsize = 0;
   TraceBackwards(inend - instart, length_array, path, pathsize);
-  FollowPath(s, in, instart, inend, *path, *pathsize, store, h);
+  FollowPath(in, instart, inend, *path, *pathsize, dist_array, store);
   assert(cost < ZOPFLI_COST_SENTINEL);
   return cost;
 }
@@ -463,6 +446,8 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   /* Dist to get to here with smallest cost. */
   size_t blocksize = inend - instart;
   unsigned short* length_array =
+      (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
+  unsigned short* dist_array =
       (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
   unsigned short* path = 0;
   size_t pathsize = 0;
@@ -484,6 +469,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
 
   if (!costs) exit(-1); /* Allocation failed. */
   if (!length_array) exit(-1); /* Allocation failed. */
+  if (!dist_array) exit(-1); /* Allocation failed. */
 
   InitRanState(&ran_state);
   InitStats(&stats);
@@ -504,7 +490,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     ZopfliInitLZ77Store(in, &currentstore);
     BuildStatCostCache(&stats, shift, &cache);
     LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
-                   length_array, &cache, &currentstore, h, costs);
+                   length_array, dist_array, &cache, &currentstore, h, costs);
     cost = ZopfliCalculateBlockSize(&currentstore, 0, currentstore.size, 2);
     if (s->options->verbose_more || (s->options->verbose && cost < bestcost)) {
       fprintf(stderr, "Iteration %d: %d bit\n", i, (int) cost);
@@ -535,6 +521,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   }
 
   free(length_array);
+  free(dist_array);
   free(path);
   free(costs);
   ZopfliCleanLZ77Store(&currentstore);
@@ -550,6 +537,8 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   size_t blocksize = inend - instart;
   unsigned short* length_array =
       (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
+  unsigned short* dist_array =
+      (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
   unsigned short* path = 0;
   size_t pathsize = 0;
   ZopfliHash hash;
@@ -560,6 +549,7 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
 
   if (!costs) exit(-1); /* Allocation failed. */
   if (!length_array) exit(-1); /* Allocation failed. */
+  if (!dist_array) exit(-1); /* Allocation failed. */
 
   ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, h);
 
@@ -570,9 +560,10 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   result for fixed tree, no repeated runs are needed since the tree is known. */
   BuildFixedCostCache(ZopfliGetCostShift(blocksize), &cache);
   LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
-                 length_array, &cache, store, h, costs);
+                 length_array, dist_array, &cache, store, h, costs);
 
   free(length_array);
+  free(dist_array);
   free(path);
   free(costs);
   ZopfliCleanHash(h);

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -155,10 +155,10 @@ static void SetMinMatchCost(CostCache* c) {
   ZopfliCost minll = c->ll_cost[ZOPFLI_MIN_MATCH];
   ZopfliCost mind = c->d_cost[0];
   for (i = ZOPFLI_MIN_MATCH + 1; i <= ZOPFLI_MAX_MATCH; i++) {
-    if (c->ll_cost[i] < minll) minll = c->ll_cost[i];
+    minll = ZOPFLI_MIN(minll, c->ll_cost[i]);
   }
   for (i = 1; i < 30; i++) {
-    if (c->d_cost[i] < mind) mind = c->d_cost[i];
+    mind = ZOPFLI_MIN(mind, c->d_cost[i]);
   }
   c->mincost = minll + mind;
 }
@@ -202,10 +202,6 @@ static void BuildFixedCostCache(int shift, CostCache* c) {
     c->d_cost[i] = (ZopfliCost)base << shift;
   }
   SetMinMatchCost(c);
-}
-
-static size_t zopfli_min(size_t a, size_t b) {
-  return a < b ? a : b;
 }
 
 /*
@@ -352,11 +348,11 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
           const unsigned char* run =
               &s->lmc->pool[(size_t)s->lmc->run_off[lmcpos] * 3];
           size_t klo;
-          kend = zopfli_min((size_t)cachedlen, inend - i);
+          kend = ZOPFLI_MIN((size_t)cachedlen, inend - i);
           for (klo = 3; klo <= kend; run += 3) {
             size_t runlen = (size_t)run[0] + 3;
             unsigned short rundist = (unsigned short)(run[1] + 256 * run[2]);
-            size_t khi = runlen > kend ? kend : runlen;
+            size_t khi = ZOPFLI_MIN(runlen, kend);
             if (klo <= khi) {
               ZopfliCost dcost = cache->d_cost[ZopfliGetDistSymbol(rundist)];
               UpdateCostForRange(costs, length_array, dist_array, j, klo, khi,
@@ -379,7 +375,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
 
     /* Lengths. sublen[k] is piecewise-constant, so group equal-distance runs
     and apply each run's cost once. */
-    kend = zopfli_min(leng, inend - i);
+    kend = ZOPFLI_MIN(leng, inend - i);
     k = 3;
     while (k <= kend) {
       unsigned short rundist = sublen[k];

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -332,11 +332,16 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
     if (s->lmc) {
       size_t lmcpos = i - s->blockstart;
       unsigned cachedlen = s->lmc->length[lmcpos];
-      if ((cachedlen == 0 || s->lmc->dist[lmcpos] != 0)
-          && cachedlen <= ZopfliMaxCachedSublen(s->lmc, lmcpos, cachedlen)) {
+      /* cache_available: length 0, or a stored dist. Only then is the cache slot
+      written (sublen is otherwise uninitialized). maxsub is computed once and
+      reused for the trigger and the run extraction. */
+      int avail = (cachedlen == 0 || s->lmc->dist[lmcpos] != 0);
+      unsigned maxsub = avail ?
+          ZopfliMaxCachedSublen(s->lmc, lmcpos, cachedlen) : 0;
+      if (avail && cachedlen <= maxsub) {
         unsigned short run_maxlen[ZOPFLI_CACHE_LENGTH];
         unsigned short run_dist[ZOPFLI_CACHE_LENGTH];
-        int nruns = ZopfliCacheSublenRuns(s->lmc, lmcpos, cachedlen,
+        int nruns = ZopfliCacheSublenRuns(s->lmc, lmcpos, maxsub,
                                           run_maxlen, run_dist);
         size_t klo = 3;
         int r;
@@ -541,8 +546,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   /* Repeat statistics with each time the cost model from the previous stat
   run. */
   for (i = 0; i < numiterations; i++) {
-    ZopfliCleanLZ77Store(&currentstore);
-    ZopfliInitLZ77Store(in, &currentstore);
+    ZopfliResetLZ77Store(&currentstore);
     BuildStatCostCache(&stats, shift, &cache);
     LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
                    length_array, dist_array, &cache, &currentstore, h, costs);

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "squeeze.h"

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -303,20 +303,29 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
     /* Lengths. */
     kend = zopfli_min(leng, inend-i);
     mincostaddcostj = mincost + costs[j];
-    for (k = 3; k <= kend; k++) {
-      ZopfliCost newCost;
+    {
+      /* sublen[k] is piecewise-constant, so cache the dist cost and recompute
+         the dist symbol only when the distance changes. */
+      unsigned short curdist = 0;
+      ZopfliCost dcost = 0;
+      for (k = 3; k <= kend; k++) {
+        ZopfliCost newCost;
 
-      /* The cheapest a match can be is mincost; skip if we already beat it. */
-     if (costs[j + k] <= mincostaddcostj) continue;
+        /* The cheapest a match can be is mincost; skip if we already beat it. */
+        if (costs[j + k] <= mincostaddcostj) continue;
 
-      newCost = cache->ll_cost[k]
-          + cache->d_cost[ZopfliGetDistSymbol(sublen[k])] + costs[j];
-      assert(newCost >= 0);
-      if (newCost < costs[j + k]) {
-        assert(k <= ZOPFLI_MAX_MATCH);
-        costs[j + k] = newCost;
-        length_array[j + k] = k;
-        dist_array[j + k] = sublen[k];
+        if (sublen[k] != curdist) {
+          curdist = sublen[k];
+          dcost = cache->d_cost[ZopfliGetDistSymbol(curdist)];
+        }
+        newCost = cache->ll_cost[k] + dcost + costs[j];
+        assert(newCost >= 0);
+        if (newCost < costs[j + k]) {
+          assert(k <= ZOPFLI_MAX_MATCH);
+          costs[j + k] = newCost;
+          length_array[j + k] = k;
+          dist_array[j + k] = curdist;
+        }
       }
     }
   }

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -215,6 +215,30 @@ static size_t zopfli_min(size_t a, size_t b) {
 }
 
 /*
+Applies the optimal-parse cost update for a run of match lengths [klo, khi] that
+all share one distance, at block index j. Shared by the cached-run fast path and
+the freshly-found-match path so there is a single cost-update implementation.
+*/
+static void UpdateCostForRange(ZopfliCost* costs, unsigned short* length_array,
+    unsigned short* dist_array, size_t j, size_t klo, size_t khi,
+    unsigned short dist, ZopfliCost dcost, const CostCache* cache,
+    ZopfliCost costsj, ZopfliCost mincostaddcostj) {
+  size_t k;
+  for (k = klo; k <= khi; k++) {
+    ZopfliCost newCost;
+    if (costs[j + k] <= mincostaddcostj) continue;
+    newCost = cache->ll_cost[k] + dcost + costsj;
+    assert(newCost >= 0);
+    if (newCost < costs[j + k]) {
+      assert(k <= ZOPFLI_MAX_MATCH);
+      costs[j + k] = newCost;
+      length_array[j + k] = k;
+      dist_array[j + k] = dist;
+    }
+  }
+}
+
+/*
 Performs the forward pass for "squeeze". Gets the most optimal length to reach
 every byte from a previous byte, using cost calculations.
 s: the ZopfliBlockState
@@ -287,9 +311,6 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
     }
 #endif
 
-    ZopfliFindLongestMatch(s, h, in, i, inend, ZOPFLI_MAX_MATCH, sublen,
-                           &dist, &leng);
-
     /* Literal. */
     if (i + 1 <= inend) {
       ZopfliCost newCost = cache->lit_cost[in[i]] + costs[j];
@@ -300,33 +321,58 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
         dist_array[j + 1] = 0;  /* Literal. */
       }
     }
-    /* Lengths. */
-    kend = zopfli_min(leng, inend-i);
     mincostaddcostj = mincost + costs[j];
-    {
-      /* sublen[k] is piecewise-constant, so cache the dist cost and recompute
-         the dist symbol only when the distance changes. */
-      unsigned short curdist = 0;
-      ZopfliCost dcost = 0;
-      for (k = 3; k <= kend; k++) {
-        ZopfliCost newCost;
 
-        /* The cheapest a match can be is mincost; skip if we already beat it. */
-        if (costs[j + k] <= mincostaddcostj) continue;
-
-        if (sublen[k] != curdist) {
-          curdist = sublen[k];
-          dcost = cache->d_cost[ZopfliGetDistSymbol(curdist)];
+#ifdef ZOPFLI_LONGEST_MATCH_CACHE
+    /* Fast path: when this position's match is fully cached, run the cost DP
+    straight from the cache's runs instead of materializing all sublen entries.
+    The trigger is exactly TryGetFromLongestMatchCache's full-sublen hit (limit
+    ZOPFLI_MAX_MATCH, sublen present), so the runs equal what ZopfliFindLongest-
+    Match would have produced; anything else falls through to the call below. */
+    if (s->lmc) {
+      size_t lmcpos = i - s->blockstart;
+      unsigned cachedlen = s->lmc->length[lmcpos];
+      if ((cachedlen == 0 || s->lmc->dist[lmcpos] != 0)
+          && cachedlen <= ZopfliMaxCachedSublen(s->lmc, lmcpos, cachedlen)) {
+        unsigned short run_maxlen[ZOPFLI_CACHE_LENGTH];
+        unsigned short run_dist[ZOPFLI_CACHE_LENGTH];
+        int nruns = ZopfliCacheSublenRuns(s->lmc, lmcpos, cachedlen,
+                                          run_maxlen, run_dist);
+        size_t klo = 3;
+        int r;
+        kend = zopfli_min((size_t)cachedlen, inend - i);
+        for (r = 0; r < nruns && klo <= kend; r++) {
+          size_t khi = run_maxlen[r];
+          if (khi > kend) khi = kend;
+          if (klo <= khi) {
+            ZopfliCost dcost = cache->d_cost[ZopfliGetDistSymbol(run_dist[r])];
+            UpdateCostForRange(costs, length_array, dist_array, j, klo, khi,
+                               run_dist[r], dcost, cache, costs[j],
+                               mincostaddcostj);
+          }
+          klo = (size_t)run_maxlen[r] + 1;
         }
-        newCost = cache->ll_cost[k] + dcost + costs[j];
-        assert(newCost >= 0);
-        if (newCost < costs[j + k]) {
-          assert(k <= ZOPFLI_MAX_MATCH);
-          costs[j + k] = newCost;
-          length_array[j + k] = k;
-          dist_array[j + k] = curdist;
-        }
+        continue;
       }
+    }
+#endif
+
+    ZopfliFindLongestMatch(s, h, in, i, inend, ZOPFLI_MAX_MATCH, sublen,
+                           &dist, &leng);
+
+    /* Lengths. sublen[k] is piecewise-constant, so group equal-distance runs
+    and apply each run's cost once. */
+    kend = zopfli_min(leng, inend - i);
+    k = 3;
+    while (k <= kend) {
+      unsigned short rundist = sublen[k];
+      size_t khi = k;
+      ZopfliCost dcost;
+      while (khi + 1 <= kend && sublen[khi + 1] == rundist) khi++;
+      dcost = cache->d_cost[ZopfliGetDistSymbol(rundist)];
+      UpdateCostForRange(costs, length_array, dist_array, j, k, khi,
+                         rundist, dcost, cache, costs[j], mincostaddcostj);
+      k = khi + 1;
     }
   }
 

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -138,13 +138,21 @@ typedef struct CostCache {
 
 int ZopfliGetCostShift(size_t blocksize) {
   /* A single position costs at most ~32 bits, so a whole block costs less than
-  32 * blocksize bits. Pick the largest shift keeping the scaled total below
-  2^29, which leaves headroom below the 2^30 sentinel and the type maximum.
-  Smaller blocks get more fractional bits. */
+  32 * blocksize bits. Pick the largest shift keeping the scaled total <= 2^29,
+  which leaves headroom below the 2^30 sentinel and the type maximum. Smaller
+  blocks get more fractional bits. The floor is 0 (not 3): big blocks simply get
+  fewer fractional bits rather than overflowing. This covers blocksize up to
+  2^24; in normal use blocks are far smaller (bounded by the master block size,
+  ZOPFLI_MASTER_BLOCK_SIZE), so the floor is never reached. */
   int shift = 16;
-  while (shift > 3 && (size_t)32 * blocksize > ((size_t)1 << (29 - shift))) {
+  /* 64-bit so the bound is computed identically on 32- and 64-bit platforms
+  (size_t is 32-bit on ILP32, where 32 * blocksize could otherwise wrap). */
+  while (shift > 0 && (uint64_t)32 * blocksize > ((uint64_t)1 << (29 - shift))) {
     shift--;
   }
+  /* Beyond 2^24 even shift 0 cannot hold the bound; the int cost DP would
+  overflow. Only reachable with master blocks disabled and one huge block. */
+  assert(((uint64_t)32 * blocksize << shift) <= ((uint64_t)1 << 29));
   return shift;
 }
 

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -500,7 +500,8 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     BuildStatCostCache(&stats, shift, &cache);
     LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
                    length_array, dist_array, &cache, &currentstore, h, costs);
-    cost = ZopfliCalculateBlockSize(&currentstore, 0, currentstore.size, 2);
+    cost = ZopfliCalculateBlockSizeScratch(&s->katascratch, &currentstore, 0,
+                                           currentstore.size, 2);
     if (s->options->verbose_more || (s->options->verbose && cost < bestcost)) {
       fprintf(stderr, "Iteration %d: %d bit\n", i, (int) cost);
     }

--- a/src/zopfli/squeeze.h
+++ b/src/zopfli/squeeze.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*

--- a/src/zopfli/squeeze.h
+++ b/src/zopfli/squeeze.h
@@ -34,6 +34,12 @@ solution.
 #include "lz77.h"
 
 /*
+Returns the fixed-point shift the optimal-parse cost model uses for a block of
+the given size. Exposed so the overflow bound can be unit-tested; see squeeze.c.
+*/
+int ZopfliGetCostShift(size_t blocksize);
+
+/*
 Calculates lit/len and dist pairs for given data.
 If instart is larger than 0, it uses values before instart as starting
 dictionary.

--- a/src/zopfli/symbols.h
+++ b/src/zopfli/symbols.h
@@ -25,61 +25,26 @@ Utilities for using the lz77 symbols of the deflate spec.
 #ifndef ZOPFLI_SYMBOLS_H_
 #define ZOPFLI_SYMBOLS_H_
 
-#include "util.h"  /* ZOPFLI_INLINE, ZopfliCLZ32, ZOPFLI_HAS_FAST_CLZ */
+#include "util.h"  /* ZOPFLI_INLINE, ZopfliCLZ32 */
 
 /* Gets the amount of extra bits for the given dist, cfr. the DEFLATE spec. */
 ZOPFLI_INLINE int ZopfliGetDistExtraBits(int dist) {
-#ifdef ZOPFLI_HAS_FAST_CLZ
   if (dist < 5) return 0;
   return (31 ^ ZopfliCLZ32((uint32_t)(dist - 1))) - 1; /* log2(dist - 1) - 1 */
-#else
-  if (dist < 5) return 0;
-  else if (dist < 9) return 1;
-  else if (dist < 17) return 2;
-  else if (dist < 33) return 3;
-  else if (dist < 65) return 4;
-  else if (dist < 129) return 5;
-  else if (dist < 257) return 6;
-  else if (dist < 513) return 7;
-  else if (dist < 1025) return 8;
-  else if (dist < 2049) return 9;
-  else if (dist < 4097) return 10;
-  else if (dist < 8193) return 11;
-  else if (dist < 16385) return 12;
-  else return 13;
-#endif
 }
 
 /* Gets value of the extra bits for the given dist, cfr. the DEFLATE spec. */
 ZOPFLI_INLINE int ZopfliGetDistExtraBitsValue(int dist) {
-#ifdef ZOPFLI_HAS_FAST_CLZ
   if (dist < 5) {
     return 0;
   } else {
     int l = 31 ^ ZopfliCLZ32((uint32_t)(dist - 1)); /* log2(dist - 1) */
     return (dist - (1 + (1 << l))) & ((1 << (l - 1)) - 1);
   }
-#else
-  if (dist < 5) return 0;
-  else if (dist < 9) return (dist - 5) & 1;
-  else if (dist < 17) return (dist - 9) & 3;
-  else if (dist < 33) return (dist - 17) & 7;
-  else if (dist < 65) return (dist - 33) & 15;
-  else if (dist < 129) return (dist - 65) & 31;
-  else if (dist < 257) return (dist - 129) & 63;
-  else if (dist < 513) return (dist - 257) & 127;
-  else if (dist < 1025) return (dist - 513) & 255;
-  else if (dist < 2049) return (dist - 1025) & 511;
-  else if (dist < 4097) return (dist - 2049) & 1023;
-  else if (dist < 8193) return (dist - 4097) & 2047;
-  else if (dist < 16385) return (dist - 8193) & 4095;
-  else return (dist - 16385) & 8191;
-#endif
 }
 
 /* Gets the symbol for the given dist, cfr. the DEFLATE spec. */
 ZOPFLI_INLINE int ZopfliGetDistSymbol(int dist) {
-#ifdef ZOPFLI_HAS_FAST_CLZ
   if (dist < 5) {
     return dist - 1;
   } else {
@@ -87,44 +52,6 @@ ZOPFLI_INLINE int ZopfliGetDistSymbol(int dist) {
     int r = ((dist - 1) >> (l - 1)) & 1;
     return l * 2 + r;
   }
-#else
-  if (dist < 193) {
-    if (dist < 13) {  /* dist 0..13. */
-      if (dist < 5) return dist - 1;
-      else if (dist < 7) return 4;
-      else if (dist < 9) return 5;
-      else return 6;
-    } else {  /* dist 13..193. */
-      if (dist < 17) return 7;
-      else if (dist < 25) return 8;
-      else if (dist < 33) return 9;
-      else if (dist < 49) return 10;
-      else if (dist < 65) return 11;
-      else if (dist < 97) return 12;
-      else if (dist < 129) return 13;
-      else return 14;
-    }
-  } else {
-    if (dist < 2049) {  /* dist 193..2049. */
-      if (dist < 257) return 15;
-      else if (dist < 385) return 16;
-      else if (dist < 513) return 17;
-      else if (dist < 769) return 18;
-      else if (dist < 1025) return 19;
-      else if (dist < 1537) return 20;
-      else return 21;
-    } else {  /* dist 2049..32768. */
-      if (dist < 3073) return 22;
-      else if (dist < 4097) return 23;
-      else if (dist < 6145) return 24;
-      else if (dist < 8193) return 25;
-      else if (dist < 12289) return 26;
-      else if (dist < 16385) return 27;
-      else if (dist < 24577) return 28;
-      else return 29;
-    }
-  }
-#endif
 }
 
 /* Gets the amount of extra bits for the given length, cfr. the DEFLATE spec. */

--- a/src/zopfli/symbols.h
+++ b/src/zopfli/symbols.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*
@@ -24,21 +25,13 @@ Utilities for using the lz77 symbols of the deflate spec.
 #ifndef ZOPFLI_SYMBOLS_H_
 #define ZOPFLI_SYMBOLS_H_
 
-/* __has_builtin available in clang */
-#ifdef __has_builtin
-# if __has_builtin(__builtin_clz)
-#   define ZOPFLI_HAS_BUILTIN_CLZ
-# endif
-/* __builtin_clz available beginning with GCC 3.4 */
-#elif __GNUC__ * 100 + __GNUC_MINOR__ >= 304
-# define ZOPFLI_HAS_BUILTIN_CLZ
-#endif
+#include "util.h"  /* ZOPFLI_INLINE, ZopfliCLZ32, ZOPFLI_HAS_FAST_CLZ */
 
 /* Gets the amount of extra bits for the given dist, cfr. the DEFLATE spec. */
-static int ZopfliGetDistExtraBits(int dist) {
-#ifdef ZOPFLI_HAS_BUILTIN_CLZ
+ZOPFLI_INLINE int ZopfliGetDistExtraBits(int dist) {
+#ifdef ZOPFLI_HAS_FAST_CLZ
   if (dist < 5) return 0;
-  return (31 ^ __builtin_clz(dist - 1)) - 1; /* log2(dist - 1) - 1 */
+  return (31 ^ ZopfliCLZ32((uint32_t)(dist - 1))) - 1; /* log2(dist - 1) - 1 */
 #else
   if (dist < 5) return 0;
   else if (dist < 9) return 1;
@@ -58,12 +51,12 @@ static int ZopfliGetDistExtraBits(int dist) {
 }
 
 /* Gets value of the extra bits for the given dist, cfr. the DEFLATE spec. */
-static int ZopfliGetDistExtraBitsValue(int dist) {
-#ifdef ZOPFLI_HAS_BUILTIN_CLZ
+ZOPFLI_INLINE int ZopfliGetDistExtraBitsValue(int dist) {
+#ifdef ZOPFLI_HAS_FAST_CLZ
   if (dist < 5) {
     return 0;
   } else {
-    int l = 31 ^ __builtin_clz(dist - 1); /* log2(dist - 1) */
+    int l = 31 ^ ZopfliCLZ32((uint32_t)(dist - 1)); /* log2(dist - 1) */
     return (dist - (1 + (1 << l))) & ((1 << (l - 1)) - 1);
   }
 #else
@@ -85,12 +78,12 @@ static int ZopfliGetDistExtraBitsValue(int dist) {
 }
 
 /* Gets the symbol for the given dist, cfr. the DEFLATE spec. */
-static int ZopfliGetDistSymbol(int dist) {
-#ifdef ZOPFLI_HAS_BUILTIN_CLZ
+ZOPFLI_INLINE int ZopfliGetDistSymbol(int dist) {
+#ifdef ZOPFLI_HAS_FAST_CLZ
   if (dist < 5) {
     return dist - 1;
   } else {
-    int l = (31 ^ __builtin_clz(dist - 1)); /* log2(dist - 1) */
+    int l = (31 ^ ZopfliCLZ32((uint32_t)(dist - 1))); /* log2(dist - 1) */
     int r = ((dist - 1) >> (l - 1)) & 1;
     return l * 2 + r;
   }
@@ -135,7 +128,7 @@ static int ZopfliGetDistSymbol(int dist) {
 }
 
 /* Gets the amount of extra bits for the given length, cfr. the DEFLATE spec. */
-static int ZopfliGetLengthExtraBits(int l) {
+ZOPFLI_INLINE int ZopfliGetLengthExtraBits(int l) {
   static const int table[259] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -158,7 +151,7 @@ static int ZopfliGetLengthExtraBits(int l) {
 }
 
 /* Gets value of the extra bits for the given length, cfr. the DEFLATE spec. */
-static int ZopfliGetLengthExtraBitsValue(int l) {
+ZOPFLI_INLINE int ZopfliGetLengthExtraBitsValue(int l) {
   static const int table[259] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 2, 3, 0,
     1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
@@ -180,7 +173,7 @@ static int ZopfliGetLengthExtraBitsValue(int l) {
 Gets the symbol for the given length, cfr. the DEFLATE spec.
 Returns the symbol in the range [257-285] (inclusive)
 */
-static int ZopfliGetLengthSymbol(int l) {
+ZOPFLI_INLINE int ZopfliGetLengthSymbol(int l) {
   static const int table[259] = {
     0, 0, 0, 257, 258, 259, 260, 261, 262, 263, 264,
     265, 265, 266, 266, 267, 267, 268, 268,
@@ -219,7 +212,7 @@ static int ZopfliGetLengthSymbol(int l) {
 }
 
 /* Gets the amount of extra bits for the given length symbol. */
-static int ZopfliGetLengthSymbolExtraBits(int s) {
+ZOPFLI_INLINE int ZopfliGetLengthSymbolExtraBits(int s) {
   static const int table[29] = {
     0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
     3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0
@@ -228,7 +221,7 @@ static int ZopfliGetLengthSymbolExtraBits(int s) {
 }
 
 /* Gets the amount of extra bits for the given distance symbol. */
-static int ZopfliGetDistSymbolExtraBits(int s) {
+ZOPFLI_INLINE int ZopfliGetDistSymbolExtraBits(int s) {
   static const int table[30] = {
     0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8,
     9, 9, 10, 10, 11, 11, 12, 12, 13, 13

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -21,7 +21,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include "tree.h"
 
 #include <assert.h>
-#include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -69,28 +69,43 @@ void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
   free(next_code);
 }
 
-void ZopfliCalculateEntropy(const size_t* count, size_t n, double* bitlengths) {
-  static const double kInvLog2 = 1.4426950408889;  /* 1.0 / log(2.0) */
-  unsigned sum = 0;
+/*
+log2(x) as a Q`frac` fixed-point value (frac <= 16, x >= 1). Integer-only and
+deterministic. clz gives both the integer part (31 - clz) and the shift that
+normalizes the mantissa to Q31 [2^31, 2^32). The fractional part is the classic
+square-and-compare on that mantissa (its square needs 64 bits). One guard bit is
+computed then rounded.
+*/
+static uint32_t IntLog2Fixed(uint32_t x, int frac) {
+  int lz = __builtin_clz(x);              /* x >= 1, so 0 <= lz <= 31. */
+  uint64_t m = (uint64_t)x << lz;         /* Q31 mantissa, [2^31, 2^32). */
+  uint32_t fracpart = 0;
+  int b;
+  for (b = 0; b <= frac; b++) {  /* frac + 1 bits (one guard bit). */
+    m = (m * m) >> 31;          /* square, keep Q31; now in [2^31, 2^33). */
+    fracpart <<= 1;
+    if (m >> 32) { fracpart |= 1; m >>= 1; }  /* mantissa^2 >= 2 -> emit a bit. */
+  }
+  fracpart = (fracpart + 1) >> 1;  /* round the guard bit away. */
+  return ((unsigned)(31 - lz) << frac) + fracpart;
+}
+
+void ZopfliCalculateEntropy(const size_t* count, size_t n,
+                            uint32_t* bitlengths, int frac) {
+  uint32_t sum = 0;
   unsigned i;
-  double log2sum;
+  uint32_t log2sum;
   for (i = 0; i < n; ++i) {
     sum += count[i];
   }
-  log2sum = (sum == 0 ? log(n) : log(sum)) * kInvLog2;
+  log2sum = IntLog2Fixed(sum == 0 ? (uint32_t)n : sum, frac);
   for (i = 0; i < n; ++i) {
-    /* When the count of the symbol is 0, but its cost is requested anyway, it
-    means the symbol will appear at least once anyway, so give it the cost as if
-    its count is 1.*/
-    if (count[i] == 0) bitlengths[i] = log2sum;
-    else bitlengths[i] = log2sum - log(count[i]) * kInvLog2;
-    /* Depending on compiler and architecture, the above subtraction of two
-    floating point numbers may give a negative result very close to zero
-    instead of zero (e.g. -5.973954e-17 with gcc 4.1.2 on Ubuntu 11.4). Clamp
-    it to zero. These floating point imprecisions do not affect the cost model
-    significantly so this is ok. */
-    if (bitlengths[i] < 0 && bitlengths[i] > -1e-5) bitlengths[i] = 0;
-    assert(bitlengths[i] >= 0);
+    /* When the count is 0 but its cost is requested, the symbol will appear at
+    least once, so cost it as count 1: log2sum - log2(1) = log2sum. log2 is
+    monotonic so log2(count) <= log2sum, hence the result is exactly >= 0. */
+    bitlengths[i] = count[i] == 0
+        ? log2sum
+        : log2sum - IntLog2Fixed((uint32_t)count[i], frac);
   }
 }
 

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -93,9 +93,19 @@ void ZopfliCalculateEntropy(const size_t* count, size_t n, double* bitlengths) {
   }
 }
 
-void ZopfliCalculateBitLengths(const size_t* count, size_t n, int maxbits,
-                               unsigned* bitlengths) {
-  int error = ZopfliLengthLimitedCodeLengths(count, n, maxbits, bitlengths);
+void ZopfliCalculateBitLengthsScratch(ZopfliKatajainenScratch* scratch,
+                                      const size_t* count, size_t n, int maxbits,
+                                      unsigned* bitlengths) {
+  int error = ZopfliLengthLimitedCodeLengthsScratch(
+      scratch, count, n, maxbits, bitlengths);
   (void) error;
   assert(!error);
+}
+
+void ZopfliCalculateBitLengths(const size_t* count, size_t n, int maxbits,
+                               unsigned* bitlengths) {
+  ZopfliKatajainenScratch scratch;
+  ZopfliInitKatajainenScratch(&scratch);
+  ZopfliCalculateBitLengthsScratch(&scratch, count, n, maxbits, bitlengths);
+  ZopfliCleanKatajainenScratch(&scratch);
 }

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -52,7 +52,7 @@ void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
   code = 0;
   bl_count[0] = 0;
   for (bits = 1; bits <= maxbits; bits++) {
-    code = (code + bl_count[bits-1]) << 1;
+    code = (unsigned)((code + bl_count[bits-1]) << 1);
     next_code[bits] = code;
   }
   /* 3) Assign numerical values to all codes, using consecutive values for all
@@ -60,7 +60,7 @@ void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
   for (i = 0;  i < n; i++) {
     unsigned len = lengths[i];
     if (len != 0) {
-      symbols[i] = next_code[len];
+      symbols[i] = (unsigned)next_code[len];
       next_code[len]++;
     }
   }
@@ -96,7 +96,7 @@ void ZopfliCalculateEntropy(const size_t* count, size_t n,
   unsigned i;
   uint32_t log2sum;
   for (i = 0; i < n; ++i) {
-    sum += count[i];
+    sum += (uint32_t)count[i];
   }
   log2sum = IntLog2Fixed(sum == 0 ? (uint32_t)n : sum, frac);
   for (i = 0; i < n; ++i) {
@@ -113,7 +113,7 @@ void ZopfliCalculateBitLengthsScratch(ZopfliKatajainenScratch* scratch,
                                       const size_t* count, size_t n, int maxbits,
                                       unsigned* bitlengths) {
   int error = ZopfliLengthLimitedCodeLengthsScratch(
-      scratch, count, n, maxbits, bitlengths);
+      scratch, count, (int)n, maxbits, bitlengths);
   (void) error;
   assert(!error);
 }

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -77,7 +77,7 @@ square-and-compare on that mantissa (its square needs 64 bits). One guard bit is
 computed then rounded.
 */
 static uint32_t IntLog2Fixed(uint32_t x, int frac) {
-  int lz = __builtin_clz(x);              /* x >= 1, so 0 <= lz <= 31. */
+  int lz = ZopfliCLZ32(x);                /* x >= 1, so 0 <= lz <= 31. */
   uint64_t m = (uint64_t)x << lz;         /* Q31 mantissa, [2^31, 2^32). */
   uint32_t fracpart = 0;
   int b;

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -81,6 +81,9 @@ static uint32_t IntLog2Fixed(uint32_t x, int frac) {
   uint64_t m = (uint64_t)x << lz;         /* Q31 mantissa, [2^31, 2^32). */
   uint32_t fracpart = 0;
   int b;
+  /* frac <= 16 keeps fracpart's bits and the final << frac within range;
+  guaranteed by the caller (the cost shift is 0..16). */
+  assert(frac >= 0 && frac <= 16);
   for (b = 0; b <= frac; b++) {  /* frac + 1 bits (one guard bit). */
     m = (m * m) >> 31;          /* square, keep Q31; now in [2^31, 2^33). */
     fracpart <<= 1;

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "tree.h"

--- a/src/zopfli/tree.h
+++ b/src/zopfli/tree.h
@@ -26,12 +26,22 @@ Utilities for creating and using Huffman trees.
 
 #include <string.h>
 
+#include "katajainen.h"
+
 /*
 Calculates the bitlengths for the Huffman tree, based on the counts of each
 symbol.
 */
 void ZopfliCalculateBitLengths(const size_t* count, size_t n, int maxbits,
                                unsigned *bitlengths);
+
+/*
+As ZopfliCalculateBitLengths, but reuses caller-owned scratch (thread-safe when
+each thread passes its own).
+*/
+void ZopfliCalculateBitLengthsScratch(ZopfliKatajainenScratch* scratch,
+                                      const size_t* count, size_t n, int maxbits,
+                                      unsigned *bitlengths);
 
 /*
 Converts a series of Huffman tree bitlengths, to the bit values of the symbols.

--- a/src/zopfli/tree.h
+++ b/src/zopfli/tree.h
@@ -25,6 +25,7 @@ Utilities for creating and using Huffman trees.
 #ifndef ZOPFLI_TREE_H_
 #define ZOPFLI_TREE_H_
 
+#include <stdint.h>
 #include <string.h>
 
 #include "katajainen.h"
@@ -51,12 +52,13 @@ void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
                             unsigned* symbols);
 
 /*
-Calculates the entropy of each symbol, based on the counts of each symbol. The
-result is similar to the result of ZopfliCalculateBitLengths, but with the
-actual theoritical bit lengths according to the entropy. Since the resulting
-values are fractional, they cannot be used to encode the tree specified by
-DEFLATE.
+Calculates the entropy (ideal bit length) of each symbol from its count, as
+fixed point with `frac` fractional bits (Q`frac`, frac <= 16): bitlengths[i] =
+-log2(count[i] / sum) scaled by 2^frac. Integer-only and deterministic across
+CPUs. These fractional costs drive the optimal parse; they cannot encode the
+DEFLATE tree (that uses ZopfliCalculateBitLengths).
 */
-void ZopfliCalculateEntropy(const size_t* count, size_t n, double* bitlengths);
+void ZopfliCalculateEntropy(const size_t* count, size_t n,
+                            uint32_t* bitlengths, int frac);
 
 #endif  /* ZOPFLI_TREE_H_ */

--- a/src/zopfli/tree.h
+++ b/src/zopfli/tree.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*

--- a/src/zopfli/util.c
+++ b/src/zopfli/util.c
@@ -28,7 +28,7 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 void ZopfliInitOptions(ZopfliOptions* options) {
   options->verbose = 0;
   options->verbose_more = 0;
-  options->numiterations = 15;
+  options->numiterations = 0;  /* 0 = auto (size-dependent). */
   options->blocksplitting = 1;
   options->blocksplittinglast = 0;
   options->blocksplittingmax = 15;

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -65,6 +65,16 @@ Used to initialize costs for example
 #define ZOPFLI_LARGE_FLOAT 1e30
 
 /*
+Integer type for the squeeze optimal-parse cost accumulator. Kept 32-bit so the
+hot per-byte costs[] array and its add/compare stay single-word, which matters
+on 32-bit processors. `int` is 32-bit on every ILP32 and LP64 target of
+interest, so no width detection is needed. Costs are stored in fixed point with
+a per-block shift (see squeeze.c); the shift is chosen so the worst-case
+accumulated cost cannot overflow this type.
+*/
+typedef int ZopfliCost;
+
+/*
 For longest match cache. max 256. Uses huge amounts of memory but makes it
 faster. Uses this many times three bytes per single byte of the input data.
 This is so because longest match finding has to find the exact distance

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -82,6 +82,15 @@ Set it to 0 to disable master blocks.
 #define ZOPFLI_MASTER_BLOCK_SIZE 1000000
 
 /*
+Largest part (in bytes) the optimal-parse cost model can represent. ZopfliCost
+is 32-bit and a block costs < 32 * blocksize bits, so 32 * blocksize must stay
+<= 2^29 (see ZopfliGetCostShift), capping a safe block at 2^24 bytes. The
+master-block loop clamps part sizes to this even when ZOPFLI_MASTER_BLOCK_SIZE
+is 0 (disabled) or larger, so the cost DP can never overflow.
+*/
+#define ZOPFLI_COST_MAX_BLOCK_SIZE ((uint32_t)1 << 24)
+
+/*
 Sentinel larger than any real block-size/cost (in bits), for initializing a
 running minimum. Cost values are uint32_t (a block is < 2^31 bits), so UINT32_MAX
 exceeds any real value; same value on every platform. Only ever compared, never

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -26,6 +26,7 @@ basic deflate specification values and generic program options.
 #ifndef ZOPFLI_UTIL_H_
 #define ZOPFLI_UTIL_H_
 
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -61,9 +62,12 @@ Set it to 0 to disable master blocks.
 #define ZOPFLI_MASTER_BLOCK_SIZE 1000000
 
 /*
-Used to initialize costs for example
+Sentinel larger than any real block-size/cost (in bits), for initializing a
+running minimum. Cost values are uint32_t (a block is < 2^31 bits), so UINT32_MAX
+exceeds any real value; same value on every platform. Only ever compared, never
+added, so it cannot overflow.
 */
-#define ZOPFLI_LARGE_FLOAT 1e30
+#define ZOPFLI_LARGE_COST UINT32_MAX
 
 /*
 Integer type for the squeeze optimal-parse cost accumulator. Kept 32-bit so the

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -30,6 +30,30 @@ basic deflate specification values and generic program options.
 #include <string.h>
 #include <stdlib.h>
 
+/* Inline qualifier for header helpers; MSVC's C spells it `__inline`. */
+#ifdef _MSC_VER
+#define ZOPFLI_INLINE static __inline
+#else
+#define ZOPFLI_INLINE static inline
+#endif
+
+/* Count-leading-zeros support: clang/GCC have __builtin_clz; MSVC's C compiler
+uses the _BitScanReverse intrinsic. ZOPFLI_HAS_FAST_CLZ marks either as present
+(callers can use it to pick a bit-twiddling path over a scalar fallback). */
+#if defined(__has_builtin)
+# if __has_builtin(__builtin_clz)
+#  define ZOPFLI_HAS_BUILTIN_CLZ
+# endif
+#elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 304)
+# define ZOPFLI_HAS_BUILTIN_CLZ
+#endif
+#if defined(ZOPFLI_HAS_BUILTIN_CLZ)
+# define ZOPFLI_HAS_FAST_CLZ
+#elif defined(_MSC_VER)
+# include <intrin.h>
+# define ZOPFLI_HAS_FAST_CLZ
+#endif
+
 /* Minimum and maximum length that can be encoded in deflate. */
 #define ZOPFLI_MAX_MATCH 258
 #define ZOPFLI_MIN_MATCH 3
@@ -135,6 +159,12 @@ varies from file to file.
 */
 #define ZOPFLI_LAZY_MATCHING
 
+/* Integer min and absolute difference. Function-like macros so they work for
+any integer type used in the hot path (int/size_t/unsigned/unsigned short)
+without truncation. Args are evaluated twice: pass side-effect-free operands. */
+#define ZOPFLI_MIN(a, b) ((a) < (b) ? (a) : (b))
+#define ZOPFLI_ABS_DIFF(x, y) ((x) > (y) ? (x) - (y) : (y) - (x))
+
 /*
 Appends value to dynamically allocated memory, doubling its allocation size
 whenever needed.
@@ -169,5 +199,19 @@ equal than *size.
 }
 #endif
 
+/* Number of leading zero bits in a 32-bit value; x must be nonzero. */
+ZOPFLI_INLINE int ZopfliCLZ32(uint32_t x) {
+#if defined(ZOPFLI_HAS_BUILTIN_CLZ)
+  return __builtin_clz(x);
+#elif defined(_MSC_VER)
+  unsigned long idx;
+  _BitScanReverse(&idx, x);
+  return 31 - (int)idx;
+#else
+  int n;
+  for (n = 0; !(x & 0x80000000u); ++n) x <<= 1;
+  return n;
+#endif
+}
 
 #endif  /* ZOPFLI_UTIL_H_ */

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 /*

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -38,8 +38,7 @@ basic deflate specification values and generic program options.
 #endif
 
 /* Count-leading-zeros support: clang/GCC have __builtin_clz; MSVC's C compiler
-uses the _BitScanReverse intrinsic. ZOPFLI_HAS_FAST_CLZ marks either as present
-(callers can use it to pick a bit-twiddling path over a scalar fallback). */
+uses the _BitScanReverse intrinsic (anything else falls back to a loop). */
 #if defined(__has_builtin)
 # if __has_builtin(__builtin_clz)
 #  define ZOPFLI_HAS_BUILTIN_CLZ
@@ -47,11 +46,8 @@ uses the _BitScanReverse intrinsic. ZOPFLI_HAS_FAST_CLZ marks either as present
 #elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 304)
 # define ZOPFLI_HAS_BUILTIN_CLZ
 #endif
-#if defined(ZOPFLI_HAS_BUILTIN_CLZ)
-# define ZOPFLI_HAS_FAST_CLZ
-#elif defined(_MSC_VER)
+#if !defined(ZOPFLI_HAS_BUILTIN_CLZ) && defined(_MSC_VER)
 # include <intrin.h>
-# define ZOPFLI_HAS_FAST_CLZ
 #endif
 
 /* Minimum and maximum length that can be encoded in deflate. */

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "zlib_container.h"
@@ -71,9 +72,11 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
   ZOPFLI_APPEND_DATA(checksum % 256, out, outsize);
 
   if (options->verbose) {
+    /* Percent removed with 2 decimals, integer-only (basis points). */
+    long bp = insize ? (long)(((long long)insize - (long long)*outsize) * 10000
+                              / (long long)insize) : 0;
     fprintf(stderr,
-            "Original Size: %d, Zlib: %d, Compression: %f%% Removed\n",
-            (int)insize, (int)*outsize,
-            100.0 * (double)(insize - *outsize) / (double)insize);
+            "Original Size: %d, Zlib: %d, Compression: %ld.%02ld%% Removed\n",
+            (int)insize, (int)*outsize, bp / 100, (bp < 0 ? -bp : bp) % 100);
   }
 }

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -34,7 +34,7 @@ static unsigned adler32(const unsigned char* data, size_t size)
   unsigned s2 = 1 >> 16;
 
   while (size > 0) {
-    size_t amount = size > sums_overflow ? sums_overflow : size;
+    size_t amount = ZOPFLI_MIN(size, sums_overflow);
     size -= amount;
     while (amount > 0) {
       s1 += (*data++);

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -77,7 +77,7 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
                               / (long long)insize) : 0;
     long abp = bp < 0 ? -bp : bp;  /* keep the sign for small negatives */
     fprintf(stderr,
-            "Original Size: %d, Zlib: %d, Compression: %s%ld.%02ld%% Removed\n",
-            (int)insize, (int)*outsize, bp < 0 ? "-" : "", abp / 100, abp % 100);
+            "Original Size: %zu, Zlib: %zu, Compression: %s%ld.%02ld%% Removed\n",
+            insize, *outsize, bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
 }

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -75,8 +75,9 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
     /* Percent removed with 2 decimals, integer-only (basis points). */
     long bp = insize ? (long)(((long long)insize - (long long)*outsize) * 10000
                               / (long long)insize) : 0;
+    long abp = bp < 0 ? -bp : bp;  /* keep the sign for small negatives */
     fprintf(stderr,
-            "Original Size: %d, Zlib: %d, Compression: %ld.%02ld%% Removed\n",
-            (int)insize, (int)*outsize, bp / 100, (bp < 0 ? -bp : bp) % 100);
+            "Original Size: %d, Zlib: %d, Compression: %s%ld.%02ld%% Removed\n",
+            (int)insize, (int)*outsize, bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
 }

--- a/src/zopfli/zopfli.h
+++ b/src/zopfli/zopfli.h
@@ -38,9 +38,8 @@ typedef struct ZopfliOptions {
   int verbose_more;
 
   /*
-  Maximum amount of times to rerun forward and backward pass to optimize LZ77
-  compression cost. Good values: 10, 15 for small files, 5 for files over
-  several MB in size or it will be too slow.
+  Times to rerun the LZ77 optimization pass. 0 (default) = auto: a size-
+  dependent count, larger for larger inputs. A value > 0 forces that fixed count.
   */
   int numiterations;
 

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -35,7 +35,8 @@ decompressor.
 
 /* Windows workaround for stdout output. */
 #if _WIN32
-#include <fcntl.h>
+#include <fcntl.h>  /* _O_BINARY */
+#include <io.h>     /* _setmode, _fileno */
 #endif
 
 /*

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -171,8 +171,8 @@ int main(int argc, char* argv[]) {
           "  -c    write the result on standard output, instead of disk"
           " filename + '.gz'\n"
           "  -v    verbose mode\n"
-          "  --i#  perform # iterations (default 15). More gives"
-          " more compression but is slower."
+          "  --i#  perform # iterations (fixed). Default (or --i0) is auto:"
+          " a size-dependent count, more for larger files."
           " Examples: --i10, --i50, --i1000\n");
       fprintf(stderr,
           "  --gzip        output to gzip format (default)\n"
@@ -183,8 +183,8 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  if (options.numiterations < 1) {
-    fprintf(stderr, "Error: must have 1 or more iterations\n");
+  if (options.numiterations < 0) {
+    fprintf(stderr, "Error: number of iterations must be 0 (auto) or more\n");
     return 0;
   }
 

--- a/src/zopflipng/zopflipng_bin.cc
+++ b/src/zopflipng/zopflipng_bin.cc
@@ -476,5 +476,5 @@ int main(int argc, char *argv[]) {
 
   if (dryrun) printf("No files were written because dry run was specified\n");
 
-  return total_errors;
+  return (int)total_errors;
 }

--- a/test/deflate_test.cc
+++ b/test/deflate_test.cc
@@ -44,4 +44,23 @@ TEST(Deflate, BlockSizeAutoTypePicksSmallest) {
   ZopfliCleanLZ77Store(&store);
 }
 
+TEST(Deflate, UseExpensiveFixedHeuristic) {
+  // Small blocks always qualify regardless of cost.
+  EXPECT_TRUE(ZopfliUseExpensiveFixed(500, 1000000u, 1u));
+
+  // Large block, fixed within 1.1x of dynamic -> worthwhile.
+  EXPECT_TRUE(ZopfliUseExpensiveFixed(2000, 100u, 100u));
+  // Large block, fixed far above 1.1x of dynamic -> not worthwhile.
+  EXPECT_FALSE(ZopfliUseExpensiveFixed(2000, 1000u, 100u));
+
+  // Overflow regression: both costs are within the < 2^31 bit invariant, but
+  // fixedcost*10 and dyncost*11 exceed UINT32_MAX. Fixed (~4.29e9) is far above
+  // 1.1x dynamic (1.1e9), so the correct answer is false. With 32-bit
+  // arithmetic fixedcost*10 wraps to 4 (<= dyncost*11), which would flip the
+  // result to true.
+  const uint32_t fixedcost = 429496730u;  // *10 = UINT32_MAX + 4, wraps to 4
+  const uint32_t dyncost = 100000000u;    // *11 = 1.1e9, no wrap
+  EXPECT_FALSE(ZopfliUseExpensiveFixed(2000, fixedcost, dyncost));
+}
+
 }  // namespace

--- a/test/deflate_test.cc
+++ b/test/deflate_test.cc
@@ -53,14 +53,16 @@ TEST(Deflate, UseExpensiveFixedHeuristic) {
   // Large block, fixed far above 1.1x of dynamic -> not worthwhile.
   EXPECT_FALSE(ZopfliUseExpensiveFixed(2000, 1000u, 100u));
 
-  // Overflow regression: both costs are within the < 2^31 bit invariant, but
-  // fixedcost*10 and dyncost*11 exceed UINT32_MAX. Fixed (~4.29e9) is far above
-  // 1.1x dynamic (1.1e9), so the correct answer is false. With 32-bit
-  // arithmetic fixedcost*10 wraps to 4 (<= dyncost*11), which would flip the
-  // result to true.
+#if !(ZOPFLI_MASTER_BLOCK_SIZE != 0 && (ZOPFLI_MASTER_BLOCK_SIZE * 32 * 11 <= 0xFFFFFFFF))
+  // Only reachable where the 64-bit path is compiled (master blocks disabled or
+  // large): both costs are within the < 2^31 bit invariant, but fixedcost*10
+  // and dyncost*11 exceed UINT32_MAX. Fixed (~4.29e9) is far above 1.1x dynamic
+  // (1.1e9), so the answer is false; a 32-bit compare would wrap fixedcost*10
+  // to 4 (<= dyncost*11) and flip it to true.
   const uint32_t fixedcost = 429496730u;  // *10 = UINT32_MAX + 4, wraps to 4
   const uint32_t dyncost = 100000000u;    // *11 = 1.1e9, no wrap
   EXPECT_FALSE(ZopfliUseExpensiveFixed(2000, fixedcost, dyncost));
+#endif
 }
 
 }  // namespace

--- a/test/deflate_test.cc
+++ b/test/deflate_test.cc
@@ -30,16 +30,16 @@ TEST(Deflate, BlockSizeAutoTypePicksSmallest) {
   ZopfliLZ77Store store;
   zopfli_test::GreedyStore(in, &store);
 
-  double s0 = ZopfliCalculateBlockSize(&store, 0, store.size, 0);
-  double s1 = ZopfliCalculateBlockSize(&store, 0, store.size, 1);
-  double s2 = ZopfliCalculateBlockSize(&store, 0, store.size, 2);
-  double best = ZopfliCalculateBlockSizeAutoType(&store, 0, store.size);
+  uint32_t s0 = ZopfliCalculateBlockSize(&store, 0, store.size, 0);
+  uint32_t s1 = ZopfliCalculateBlockSize(&store, 0, store.size, 1);
+  uint32_t s2 = ZopfliCalculateBlockSize(&store, 0, store.size, 2);
+  uint32_t best = ZopfliCalculateBlockSizeAutoType(&store, 0, store.size);
 
-  EXPECT_GT(s0, 0.0);
-  EXPECT_GT(s1, 0.0);
-  EXPECT_GT(s2, 0.0);
-  double min3 = std::min(s0, std::min(s1, s2));
-  EXPECT_NEAR(best, min3, 1e-6);
+  EXPECT_GT(s0, 0u);
+  EXPECT_GT(s1, 0u);
+  EXPECT_GT(s2, 0u);
+  uint32_t min3 = std::min(s0, std::min(s1, s2));
+  EXPECT_EQ(best, min3);
 
   ZopfliCleanLZ77Store(&store);
 }

--- a/test/fixedpoint_range_test.cc
+++ b/test/fixedpoint_range_test.cc
@@ -6,9 +6,9 @@
 
 // Range coverage for the fixed-point optimal-parse cost model. The squeeze
 // accumulator is a 32-bit integer with a per-block fractional shift; these
-// tests span block sizes from a single byte (largest shift) through the master
-// block boundary (smallest shift) to prove the shift never lets the accumulator
-// overflow and that the parse stays correct across the whole range.
+// tests span block sizes from a single byte (largest shift) up to the largest
+// supported block, ZOPFLI_COST_MAX_BLOCK_SIZE (shift 0), to prove the shift
+// never lets the accumulator overflow and that the parse stays correct.
 
 namespace {
 
@@ -27,15 +27,18 @@ std::vector<unsigned char> Repetitive(size_t n) {
 //    every block size, is in range, and shrinks as blocks grow. This proves the
 //    overflow bound directly, without depending on input data.
 TEST(FixedPointRange, CostShiftInvariant) {
+  // Includes 2^22, 2^23 and the maximum supported block (2^24) so the small
+  // shifts (2, 1, 0) the contract allows are actually exercised.
   const size_t sizes[] = {1, 2, 256, 257, 300, 8192, 65536, 262144,
-                          999999, 1000000, 1000001, 1500000, 2000000};
+                          999999, 1000000, 1000001, 1500000, 2000000,
+                          4194304, 8388608, ZOPFLI_COST_MAX_BLOCK_SIZE};
   int prev = 100;
   size_t i;
   for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
     int shift = ZopfliGetCostShift(sizes[i]);
     // Worst case is ~32 bits per position; scaled it must stay below 2^30.
     unsigned long long scaled = ((unsigned long long)32 * sizes[i]) << shift;
-    EXPECT_GE(shift, 3);
+    EXPECT_GE(shift, 0);
     EXPECT_LE(shift, 16);
     EXPECT_LT(scaled, (1ULL << 30)) << "overflow risk at blocksize "
                                     << sizes[i];

--- a/test/fixedpoint_range_test.cc
+++ b/test/fixedpoint_range_test.cc
@@ -1,0 +1,157 @@
+#include "zopfli_c_api.h"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+// Range coverage for the fixed-point optimal-parse cost model. The squeeze
+// accumulator is a 32-bit integer with a per-block fractional shift; these
+// tests span block sizes from a single byte (largest shift) through the master
+// block boundary (smallest shift) to prove the shift never lets the accumulator
+// overflow and that the parse stays correct across the whole range.
+
+namespace {
+
+using zopfli_test::PseudoRandom;
+
+// Compressible shape: a non-trivial pattern (period > ZOPFLI_MIN_MATCH) tiled
+// to length n, giving many LZ77 matches and therefore large blocks.
+std::vector<unsigned char> Repetitive(size_t n) {
+  std::vector<unsigned char> pattern = PseudoRandom(251, 99);
+  std::vector<unsigned char> v(n);
+  for (size_t i = 0; i < n; i++) v[i] = pattern[i % pattern.size()];
+  return v;
+}
+
+// 1. The shift keeps the worst-case accumulated cost below the sentinel for
+//    every block size, is in range, and shrinks as blocks grow. This proves the
+//    overflow bound directly, without depending on input data.
+TEST(FixedPointRange, CostShiftInvariant) {
+  const size_t sizes[] = {1, 2, 256, 257, 300, 8192, 65536, 262144,
+                          999999, 1000000, 1000001, 1500000, 2000000};
+  int prev = 100;
+  size_t i;
+  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+    int shift = ZopfliGetCostShift(sizes[i]);
+    // Worst case is ~32 bits per position; scaled it must stay below 2^30.
+    unsigned long long scaled = ((unsigned long long)32 * sizes[i]) << shift;
+    EXPECT_GE(shift, 3);
+    EXPECT_LE(shift, 16);
+    EXPECT_LT(scaled, (1ULL << 30)) << "overflow risk at blocksize "
+                                    << sizes[i];
+    EXPECT_LE(shift, prev) << "shift not monotone at blocksize " << sizes[i];
+    prev = shift;
+  }
+}
+
+// Runs both optimal-parse entry points on a single block and checks the parse
+// covers exactly the input. An overflow-corrupted cost would derail the dynamic
+// program and break this; with assertions enabled ZopfliVerifyLenDist also
+// validates every emitted match.
+void CheckSqueezeCovers(const std::vector<unsigned char>& in, int iters) {
+  ZopfliOptions options;
+  ZopfliInitOptions(&options);
+  ZopfliBlockState s;
+  ZopfliInitBlockState(&options, 0, in.size(), 1, &s);
+
+  ZopfliLZ77Store store;
+  ZopfliInitLZ77Store(in.data(), &store);
+  ZopfliLZ77Optimal(&s, in.data(), 0, in.size(), iters, &store);
+  EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
+  EXPECT_GT(store.size, 0u);
+  ZopfliCleanLZ77Store(&store);
+
+  ZopfliLZ77Store fixed_store;
+  ZopfliInitLZ77Store(in.data(), &fixed_store);
+  ZopfliLZ77OptimalFixed(&s, in.data(), 0, in.size(), &fixed_store);
+  EXPECT_EQ(ZopfliLZ77GetByteRange(&fixed_store, 0, fixed_store.size),
+            in.size());
+  ZopfliCleanLZ77Store(&fixed_store);
+
+  ZopfliCleanBlockState(&s);
+}
+
+// 2. Drive the squeeze directly over a single block at every size, including
+//    sizes past the master block so the smallest shift is exercised (direct
+//    calls are not subject to master-block splitting).
+TEST(FixedPointRange, SqueezeCoversInputAcrossSizes) {
+  const size_t sizes[] = {1, 2, 3, 13, 300, 8 * 1024, 64 * 1024,
+                          256 * 1024, 1000000, 1500000};
+  size_t i;
+  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+    int iters = sizes[i] >= 256 * 1024 ? 1 : 3;
+    CheckSqueezeCovers(PseudoRandom(sizes[i]), iters);
+    CheckSqueezeCovers(Repetitive(sizes[i]), iters);
+  }
+}
+
+#ifdef ZOPFLI_TEST_HAVE_ZLIB
+
+std::vector<unsigned char> Compress(ZopfliFormat format,
+                                    const std::vector<unsigned char>& in,
+                                    int iters, int blocksplitting) {
+  ZopfliOptions options;
+  ZopfliInitOptions(&options);
+  options.numiterations = iters;
+  options.blocksplitting = blocksplitting;
+  zopfli_test::Output out;
+  ZopfliCompress(&options, format, in.data(), in.size(), out.out(),
+                 out.size_ptr());
+  return out.bytes();
+}
+
+// 3. Compress across the size range and through the master block boundary, with
+//    block splitting off (whole input as one block per master block, the
+//    smallest shift compression can reach) and on, then decompress and compare.
+//    This is the decisive correctness check that fixed point never corrupts the
+//    stream.
+TEST(FixedPointRange, CompressRoundTrip) {
+  const size_t sizes[] = {1, 300, 8 * 1024, 64 * 1024, 262144, 1000001};
+  size_t i;
+  int split;
+  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+    int iters = sizes[i] >= 256 * 1024 ? 1 : 5;
+    std::vector<unsigned char> shapes[2];
+    shapes[0] = PseudoRandom(sizes[i]);
+    shapes[1] = Repetitive(sizes[i]);
+    int shape;
+    for (shape = 0; shape < 2; shape++) {
+      const std::vector<unsigned char>& in = shapes[shape];
+      for (split = 0; split < 2; split++) {
+        std::vector<unsigned char> gz =
+            Compress(ZOPFLI_FORMAT_GZIP, in, iters, split);
+        EXPECT_EQ(zopfli_test::Inflate(gz, 31), in)
+            << "gzip size " << sizes[i] << " shape " << shape << " split "
+            << split;
+        std::vector<unsigned char> zl =
+            Compress(ZOPFLI_FORMAT_ZLIB, in, iters, split);
+        EXPECT_EQ(zopfli_test::Inflate(zl, 15), in)
+            << "zlib size " << sizes[i] << " shape " << shape << " split "
+            << split;
+      }
+    }
+  }
+}
+
+// 4. The fixed-point model must still drive real compression: a cost model
+//    broken by overflow would collapse to near-all-literals and fail to shrink.
+TEST(FixedPointRange, CompressShrinksRepetitive) {
+  const size_t sizes[] = {64 * 1024, 262144, 1000001};
+  size_t i;
+  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+    std::vector<unsigned char> in = Repetitive(sizes[i]);
+    std::vector<unsigned char> out =
+        Compress(ZOPFLI_FORMAT_GZIP, in, 1, 1);
+    EXPECT_LT(out.size(), in.size() / 2) << "size " << sizes[i];
+  }
+}
+
+#else  // ZOPFLI_TEST_HAVE_ZLIB
+
+TEST(FixedPointRange, CompressRoundTrip) {
+  GTEST_SKIP() << "zlib not available; round-trip check skipped";
+}
+
+#endif  // ZOPFLI_TEST_HAVE_ZLIB
+
+}  // namespace

--- a/test/tree_test.cc
+++ b/test/tree_test.cc
@@ -38,17 +38,22 @@ TEST(Tree, LengthsToSymbolsZeroLengthGetsNoCode) {
 
 TEST(Tree, Entropy) {
   size_t counts[4] = {2, 2, 2, 2};
-  double bitlengths[4] = {0};
-  ZopfliCalculateEntropy(counts, 4, bitlengths);
-  // Uniform distribution over 4 symbols => 2 bits each.
-  for (int i = 0; i < 4; i++) EXPECT_NEAR(bitlengths[i], 2.0, 1e-9);
+  uint32_t bitlengths[4] = {0};
+  ZopfliCalculateEntropy(counts, 4, bitlengths, 16);
+  // Uniform over 4 symbols => 2 bits each; Q16 fixed point = 2 << 16 (exact:
+  // log2(8) - log2(2) = 3 - 1, both powers of two).
+  for (int i = 0; i < 4; i++) EXPECT_EQ(bitlengths[i], 2u << 16);
 }
 
-TEST(Tree, EntropyZeroCountClamped) {
+TEST(Tree, EntropyZeroCount) {
   size_t counts[3] = {0, 0, 5};
-  double bitlengths[3] = {0};
-  ZopfliCalculateEntropy(counts, 3, bitlengths);
-  for (int i = 0; i < 3; i++) EXPECT_GE(bitlengths[i], 0.0);
+  uint32_t bitlengths[3] = {0};
+  ZopfliCalculateEntropy(counts, 3, bitlengths, 16);
+  // The only present symbol costs 0 bits; absent symbols are costed as count 1,
+  // i.e. log2(sum) > 0. Integer result is exactly >= 0 (no float clamp needed).
+  EXPECT_EQ(bitlengths[2], 0u);
+  EXPECT_GT(bitlengths[0], 0u);
+  EXPECT_GT(bitlengths[1], 0u);
 }
 
 }  // namespace

--- a/test/zopfli_c_api.h
+++ b/test/zopfli_c_api.h
@@ -19,8 +19,13 @@ extern "C" {
 }
 
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <vector>
+
+#ifdef ZOPFLI_TEST_HAVE_ZLIB
+#include <zlib.h>
+#endif
 
 namespace zopfli_test {
 
@@ -76,6 +81,35 @@ inline std::vector<unsigned char> PseudoRandom(size_t n, unsigned seed = 1) {
   }
   return v;
 }
+
+#ifdef ZOPFLI_TEST_HAVE_ZLIB
+// Inflates a zopfli output for round-trip checks. window_bits selects the
+// container: 31 for gzip, 15 for zlib, -15 for raw deflate. Returns the
+// decompressed bytes, or an empty vector on error.
+inline std::vector<unsigned char> Inflate(const std::vector<unsigned char>& in,
+                                          int window_bits) {
+  z_stream zs;
+  std::vector<unsigned char> out;
+  unsigned char buf[65536];
+  int ret;
+  memset(&zs, 0, sizeof(zs));
+  if (inflateInit2(&zs, window_bits) != Z_OK) return out;
+  zs.next_in = const_cast<unsigned char*>(in.data());
+  zs.avail_in = static_cast<unsigned>(in.size());
+  do {
+    zs.next_out = buf;
+    zs.avail_out = sizeof(buf);
+    ret = inflate(&zs, Z_NO_FLUSH);
+    if (ret != Z_OK && ret != Z_STREAM_END) {
+      inflateEnd(&zs);
+      return std::vector<unsigned char>();
+    }
+    out.insert(out.end(), buf, buf + (sizeof(buf) - zs.avail_out));
+  } while (ret != Z_STREAM_END);
+  inflateEnd(&zs);
+  return out;
+}
+#endif  // ZOPFLI_TEST_HAVE_ZLIB
 
 }  // namespace zopfli_test
 

--- a/test/zopfli_public_test.cc
+++ b/test/zopfli_public_test.cc
@@ -70,8 +70,8 @@ TEST(ZopfliPublic, Matrix) {
                                   ZOPFLI_FORMAT_DEFLATE};
   for (const auto& in : inputs) {
     for (ZopfliFormat fmt : formats) {
-      // numiterations 0 exercises the greedy-only path; blocksplitting
-      // 0 vs 1 exercises both block-layout branches.
+      // numiterations 0 exercises the auto (size-dependent) path;
+      // blocksplitting 0 vs 1 exercises both block-layout branches.
       EXPECT_FALSE(Compress(fmt, in, 0, 0).empty());
       EXPECT_FALSE(Compress(fmt, in, 5, 1).empty());
     }


### PR DESCRIPTION
This pull request makes several important changes to improve determinism, portability, and code quality in the Zopfli codebase. The core library is now fully float-free and deterministic across platforms, with all cost calculations performed in integer fixed point. The build system is updated to enforce C99, remove unnecessary math library dependencies, and treat warnings as errors for first-party code. The block splitter logic is refactored to use integer costs throughout, and author attributions are updated. Documentation is significantly expanded to describe the new determinism, build/test discipline, and code style.

**Determinism and integer-only cost model:**
- Refactored the block splitter (`src/zopfli/blocksplitter.c`) to use integer (`uint32_t`) fixed-point costs instead of floating point, ensuring platform-independent, bit-identical output and removing all floating-point math from the core library. Added a reusable `ZopfliKatajainenScratch` workspace for cost calculations. (Fe2899aa)
- Updated documentation (`README.md`) to explain that the core library is now deterministic and float-free, detailing the rationale and implications for reproducibility and embedded targets.

**Build system and code quality improvements:**
- Updated the build system (`CMakeLists.txt` and `Makefile`) to enforce C99 (`-std=gnu99`), remove the `-lm` math library dependency for the integer-only core, and treat warnings as errors for all first-party code (with exceptions for vendored LodePNG). Also, added stricter warning flags and clarified how asserts are controlled via `NDEBUG`. (F48b359e, F7ceb12c)
- Added optional zlib linkage for tests in CMake, enabling round-trip checks when available.

**Documentation and code style:**
- Introduced a new repo-specific guidance file (`CLAUDE.md`) outlining language, style, build/test discipline, and performance/benchmarking practices specific to this codebase.
- Updated author attribution in source files to include Ardavon Falls for recent contributions. [[1]](diffhunk://#diff-8add4b38de10e0a69eb085f58b6c496708688cd914ef8c7abbbed1f9f2d24182R18-R24) [[2]](diffhunk://#diff-e38553b6bcad1d266b1b79db78b25724d90d94bbbb0be8ae7ff8cc49fb9ef58cR18)

These changes collectively improve the maintainability, portability, and reliability of the codebase while documenting the new development standards and rationale.