### PR TITLE
Improved memory usage and made it more cache friendly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,62 +32,11 @@ CLAUDE.md; this file adds what's specific to this codebase.
   conan's GTest provider; run with `ctest`. Don't use `gtest_*` CMake helper
   functions. Keep asserts enabled in the test build.
 
-## Performance-work discipline
-This repo is an optimization effort. For any perf change:
+## Performance
+This is an optimization effort. The perf playbook — benchmarking method on this
+machine, hot-path architecture notes, and the tried-and-rejected ideas — lives
+in `optimization.md`; read it before any performance change. Two standing rules
+for every change:
 - **Keep output byte-identical** to the pre-change baseline unless explicitly
-  agreed otherwise. Verify with `md5` of compressed output in **both regimes** —
-  default (`-i15`) and high-iteration (`--i200`) — on text and binary inputs.
-- Validate with **asserts ON** (build without `-DNDEBUG`): `ZopfliVerifyLenDist`
-  then checks every emitted match — a free per-match correctness net.
-- Run the `ctest` suite.
-- **Single-threaded only.** Never propose or add threads/OpenMP/parallelism,
-  even though blocks and iterations are independent. (Explicit project decision.)
-
-## Benchmarking on this machine
-- Wall-clock/user-CPU is dominated by background CPU contention (a `b2`/conan
-  build at 100%, CLion/Rider). The same binary has varied 26–53 s for one run.
-- Before timing: `ps -Ao pcpu,comm | sort -rn | head` and ensure no
-  `b2`/`cc`/`clang`/`ninja`/`cmake` is busy. Interleave runs (A/B/A/B…) and take
-  the **minimum**.
-- For small deltas, the `sample` profiler's **relative function shares** are more
-  reliable than wall-clock (load-independent). gprof is unavailable (clang
-  rejects `-pg` on macOS); use `sample`.
-
-## Architecture notes (hot path)
-- The cost model in `squeeze.c` is **fixed-point `int`** (`ZopfliCost`, per-block
-  shift from `ZopfliGetCostShift`). The whole core library is now **float-free
-  and deterministic across CPUs**: `ZopfliCalculateEntropy` uses an integer
-  fixed-point log2 (`IntLog2Fixed`, Q`shift`), and the block-size/splitter/cost
-  values are `uint32_t` (`IntLog2Fixed`'s mantissa square is `uint64_t`). Build
-  is gnu99 (`<stdint.h>`), no `-lm`. Keep it float-free (it targets FPU-less
-  devices and bit-reproducible output) — verify with the `-ffast-math` md5 test.
-- Nearly all time is in `ZopfliLZ77Optimal` → `LZ77OptimalRun` →
-  `GetBestLengths` (forward DP: hash bookkeeping + `ZopfliFindLongestMatch` +
-  cost DP). `FollowPath` no longer touches the hash — distances are carried
-  forward in `dist_array` alongside `length_array`.
-- Regimes differ: default iterations are match-finding + katajainen bound; high
-  iterations are squeeze-inner-loop + hash bound.
-- `ZopfliUpdateHash` now runs only in the greedy pass and DP iteration 0. The
-  LMC stores the *complete* sublen as variable-length runs (`cache.c`:
-  `run_off` + `pool`, `all_complete`), so once a block is fully cached the
-  squeeze DP serves every position from cache and `GetBestLengths` skips the
-  whole hash rebuild for iterations ≥2 (`build_hash` flag). Blocks using the
-  long-repetition shortcut or overflowing the pool budget keep `all_complete=0`
-  and rebuild the hash every iteration, as before.
-
-## Tried and rejected (don't redo without new evidence)
-- `static inline` of `ZopfliUpdateHash`: measured ~3% but reverted — not worth
-  the complexity.
-- One-step-ahead `__builtin_prefetch` in `ZopfliUpdateHash`: regressed ~8%
-  (prefetch distance too short).
-- Ratio lever `ZOPFLI_MAX_CHAIN_HITS` 8192→32768: 0% size change on a mixed
-  corpus and on constructed pathological input — the cap effectively never binds
-  within the 32 KB window. Only costs speed.
-- Ratio lever: making `FindMinimum`'s block-split search finer (more samples +
-  exhaustive converged-window scan): +0.03% (worse). `SplitCost` minimizes a
-  *greedy*-LZ77 proxy while output uses optimal LZ77; precise proxy-minimization
-  overfits and diverges. The coarse 9-point search is intentional tuning.
-- Splitter histogram memoization: already done. `store->ll_counts`/`d_counts`
-  are maintained as incremental prefix sums, and `ZopfliLZ77GetHistogram`
-  computes any range by subtracting two cumulative snapshots (O(~320), not
-  O(range)). It's ~0.1% in the profile — not a bottleneck. Don't re-propose.
+  agreed otherwise (verify `md5` in both `-i15` and `--i200`, text + binary).
+- **Single-threaded only** — never add threads/OpenMP/parallelism.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,66 @@ The source code of Zopfli is under `src/zopfli`. `zopfli_bin.c` is separate from
 the library and contains an example program to create very well compressed gzip
 files.
 
+## Modifications from Stock Zopfli
+
+This fork is a drop-in replacement — it emits standard DEFLATE/zlib/gzip that any
+existing decoder reads — but differs from upstream zopfli in four ways. Each is
+detailed in its own section below; the highlights:
+
+**Faster.** At a matched iteration count the optimal parse is **~2.5× faster
+than stock zopfli** (and a bit more on incompressible data):
+
+| Input    | Stock zopfli | QVXLabs/Zopfli | Speedup |
+|----------|-------------:|---------------:|:-------:|
+| 256 KB text   |   1.45 s |   0.70 s | 2.1× |
+| 1 MB text     |   4.77 s |   1.92 s | 2.5× |
+| 3 MB text     |  13.12 s |   5.35 s | 2.5× |
+| 10 MB text    |  43.62 s |  17.69 s | 2.5× |
+| 256 KB binary |   0.44 s |   0.18 s | 2.5× |
+| 1 MB binary   |   1.66 s |   0.65 s | 2.6× |
+| 3 MB binary   |   5.59 s |   1.90 s | 2.9× |
+| 10 MB binary  |  18.63 s |   6.63 s | 2.8× |
+
+<sub>Measured on an Intel Core i9-8950HK (Coffee Lake), release `-O3 -DNDEBUG`,
+25 iterations (stock's hardcoded count; the fork was run with `--i25` to match),
+min of 2 runs. Text = concatenated source; binary = incompressible random data.</sub>
+
+It also scales much better at high iteration counts: the longest-match cache
+makes passes after the first nearly free, whereas stock's cost is roughly linear
+in the iteration count. The main changes (all preserving the encoder's output):
+an integer fixed-point cost model replacing the `double` function-pointer cost
+callbacks; carrying match distances forward so the final path walk never
+re-searches the hash; fusing the longest-match cache directly into the cost
+dynamic-program; a variable-length match cache that lets iterations ≥2 skip the
+per-byte hash rebuild entirely; and reusing scratch buffers instead of per-call
+allocations.
+
+**Deterministic & floating-point-free.** The cost model (including the entropy /
+`-log2`) is computed entirely in integer fixed point, so output is **bit-identical
+on every CPU, compiler, and FP mode**, and the core needs no `libm` — it runs on
+FPU-less microcontrollers. Output is *not* byte-identical to stock zopfli; it
+defines a new canonical, platform-independent encoding. See the
+**Deterministic, floating-point-free** section below.
+
+**Lower memory.** Hot data structures were trimmed to what the data actually
+needs — 16-bit hash tables (right-sized to the used bucket count), 32-bit LZ77
+cumulative histograms, and dropping two precomputed per-symbol arrays that are
+cheaply recomputed on the fly — reducing peak resident memory with
+**byte-identical output**. Measured peak RSS (`/usr/bin/time -l`, 3 MB input,
+`--i200`):
+
+| Input                         | Before   | After   | Saved          |
+|-------------------------------|---------:|--------:|:--------------:|
+| Text (~3 MB)                  | 35.2 MB  | 30.4 MB | 4.8 MB (−14%)  |
+| Incompressible binary (~3 MB) | 100.4 MB | 69.9 MB | 30.5 MB (−30%) |
+
+Incompressible input has ~1 LZ77 symbol per byte, so the per-symbol arrays — and
+thus the savings — are largest there; text compresses to fewer symbols.
+
+**Auto iteration count.** The default `numiterations` is `0` = auto: the number
+of optimization passes scales with input size (larger inputs have a longer tail
+of gains) instead of a fixed 15. See the **Iterations** section below.
+
 ## Deterministic, floating-point-free
 
 This fork's core library (`src/zopfli`) contains **no floating point**. The cost

--- a/src/zopfli/hash.c
+++ b/src/zopfli/hash.c
@@ -26,19 +26,25 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #define HASH_SHIFT 5
 #define HASH_MASK 32767
 
+/* Empty/uninitialized 16-bit hash slot. Real positions and hash values are
+<= HASH_MASK (32767), so 0xFFFF can never collide with a valid entry. */
+#define ZOPFLI_HASH_EMPTY ((unsigned short)-1)
+
 void ZopfliAllocHash(size_t window_size, ZopfliHash* h) {
-  h->head = (int*)malloc(sizeof(*h->head) * 65536);
+  /* head/head2 are indexed by the masked hash value, so only HASH_MASK + 1
+  buckets are ever used (not 65536). */
+  h->head = (unsigned short*)malloc(sizeof(*h->head) * (HASH_MASK + 1));
   h->prev = (unsigned short*)malloc(sizeof(*h->prev) * window_size);
-  h->hashval = (int*)malloc(sizeof(*h->hashval) * window_size);
+  h->hashval = (unsigned short*)malloc(sizeof(*h->hashval) * window_size);
 
 #ifdef ZOPFLI_HASH_SAME
   h->same = (unsigned short*)malloc(sizeof(*h->same) * window_size);
 #endif
 
 #ifdef ZOPFLI_HASH_SAME_HASH
-  h->head2 = (int*)malloc(sizeof(*h->head2) * 65536);
+  h->head2 = (unsigned short*)malloc(sizeof(*h->head2) * (HASH_MASK + 1));
   h->prev2 = (unsigned short*)malloc(sizeof(*h->prev2) * window_size);
-  h->hashval2 = (int*)malloc(sizeof(*h->hashval2) * window_size);
+  h->hashval2 = (unsigned short*)malloc(sizeof(*h->hashval2) * window_size);
 #endif
 }
 
@@ -46,13 +52,13 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
   size_t i;
 
   h->val = 0;
-  for (i = 0; i < 65536; i++) {
-    h->head[i] = -1;  /* -1 indicates no head so far. */
+  for (i = 0; i < HASH_MASK + 1; i++) {
+    h->head[i] = ZOPFLI_HASH_EMPTY;  /* no head so far. */
   }
   for (i = 0; i < window_size; i++) {
     /* If prev[j] == j, then prev[j] is uninitialized. */
     h->prev[i] = (unsigned short)i;
-    h->hashval[i] = -1;
+    h->hashval[i] = ZOPFLI_HASH_EMPTY;
   }
 
 #ifdef ZOPFLI_HASH_SAME
@@ -63,12 +69,12 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
 
 #ifdef ZOPFLI_HASH_SAME_HASH
   h->val2 = 0;
-  for (i = 0; i < 65536; i++) {
-    h->head2[i] = -1;
+  for (i = 0; i < HASH_MASK + 1; i++) {
+    h->head2[i] = ZOPFLI_HASH_EMPTY;
   }
   for (i = 0; i < window_size; i++) {
     h->prev2[i] = (unsigned short)i;
-    h->hashval2[i] = -1;
+    h->hashval2[i] = ZOPFLI_HASH_EMPTY;
   }
 #endif
 }
@@ -108,7 +114,8 @@ void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
   UpdateHashValue(h, pos + ZOPFLI_MIN_MATCH <= end ?
       array[pos + ZOPFLI_MIN_MATCH - 1] : 0);
   h->hashval[hpos] = h->val;
-  if (h->head[h->val] != -1 && h->hashval[h->head[h->val]] == h->val) {
+  if (h->head[h->val] != ZOPFLI_HASH_EMPTY &&
+      h->hashval[h->head[h->val]] == h->val) {
     h->prev[hpos] = h->head[h->val];
   }
   else h->prev[hpos] = hpos;
@@ -129,7 +136,8 @@ void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
 #ifdef ZOPFLI_HASH_SAME_HASH
   h->val2 = ((h->same[hpos] - ZOPFLI_MIN_MATCH) & 255) ^ h->val;
   h->hashval2[hpos] = h->val2;
-  if (h->head2[h->val2] != -1 && h->hashval2[h->head2[h->val2]] == h->val2) {
+  if (h->head2[h->val2] != ZOPFLI_HASH_EMPTY &&
+      h->hashval2[h->head2[h->val2]] == h->val2) {
     h->prev2[hpos] = h->head2[h->val2];
   }
   else h->prev2[hpos] = hpos;

--- a/src/zopfli/hash.h
+++ b/src/zopfli/hash.h
@@ -26,18 +26,25 @@ The hash for ZopfliFindLongestMatch of lz77.c.
 
 #include "util.h"
 
+/*
+head/hashval are unsigned short: hash values are masked to [0, HASH_MASK] (15
+bits) and stored values are window positions (<= 32767) or the (unsigned
+short)-1 empty sentinel, so 16 bits suffice. This roughly halves the hash
+allocation (and head/head2 are also right-sized to HASH_MASK + 1 buckets), which
+cuts memory and improves locality on small-cache targets. See ZopfliAllocHash.
+*/
 typedef struct ZopfliHash {
-  int* head;  /* Hash value to index of its most recent occurrence. */
+  unsigned short* head;  /* Hash value to index of its most recent occurrence. */
   unsigned short* prev;  /* Index to index of prev. occurrence of same hash. */
-  int* hashval;  /* Index to hash value at this index. */
+  unsigned short* hashval;  /* Index to hash value at this index. */
   int val;  /* Current hash value. */
 
 #ifdef ZOPFLI_HASH_SAME_HASH
   /* Fields with similar purpose as the above hash, but for the second hash with
   a value that is calculated differently.  */
-  int* head2;  /* Hash value to index of its most recent occurrence. */
+  unsigned short* head2;  /* Hash value to index of its most recent occurrence.*/
   unsigned short* prev2;  /* Index to index of prev. occurrence of same hash. */
-  int* hashval2;  /* Index to hash value at this index. */
+  unsigned short* hashval2;  /* Index to hash value at this index. */
   int val2;  /* Current hash value. */
 #endif
 

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -33,8 +33,6 @@ void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store) {
   store->dists = 0;
   store->pos = 0;
   store->data = data;
-  store->ll_symbol = 0;
-  store->d_symbol = 0;
   store->ll_counts = 0;
   store->d_counts = 0;
 }
@@ -43,8 +41,6 @@ void ZopfliCleanLZ77Store(ZopfliLZ77Store* store) {
   free(store->litlens);
   free(store->dists);
   free(store->pos);
-  free(store->ll_symbol);
-  free(store->d_symbol);
   free(store->ll_counts);
   free(store->d_counts);
 }
@@ -57,7 +53,7 @@ static size_t CeilDiv(size_t a, size_t b) {
 Grows the store's arrays to hold at least 'need' lz77 symbols, reusing the
 existing allocation (geometric growth). The ll_counts/d_counts lengths are
 deterministic functions of the symbol capacity, so one capacity covers all
-seven arrays.
+five arrays.
 */
 static void ZopfliReserveLZ77Store(ZopfliLZ77Store* store, size_t need) {
   size_t newcap, llc, dc;
@@ -71,16 +67,11 @@ static void ZopfliReserveLZ77Store(ZopfliLZ77Store* store, size_t need) {
   store->dists = (unsigned short*)realloc(
       store->dists, sizeof(*store->dists) * newcap);
   store->pos = (size_t*)realloc(store->pos, sizeof(*store->pos) * newcap);
-  store->ll_symbol = (unsigned short*)realloc(
-      store->ll_symbol, sizeof(*store->ll_symbol) * newcap);
-  store->d_symbol = (unsigned short*)realloc(
-      store->d_symbol, sizeof(*store->d_symbol) * newcap);
-  store->ll_counts = (size_t*)realloc(
+  store->ll_counts = (uint32_t*)realloc(
       store->ll_counts, sizeof(*store->ll_counts) * llc);
-  store->d_counts = (size_t*)realloc(
+  store->d_counts = (uint32_t*)realloc(
       store->d_counts, sizeof(*store->d_counts) * dc);
   if (!store->litlens || !store->dists || !store->pos) exit(-1);
-  if (!store->ll_symbol || !store->d_symbol) exit(-1);
   if (!store->ll_counts || !store->d_counts) exit(-1);
   store->cap = newcap;
 }
@@ -100,17 +91,12 @@ void ZopfliCopyLZ77Store(
       (unsigned short*)malloc(sizeof(*dest->litlens) * source->size);
   dest->dists = (unsigned short*)malloc(sizeof(*dest->dists) * source->size);
   dest->pos = (size_t*)malloc(sizeof(*dest->pos) * source->size);
-  dest->ll_symbol =
-      (unsigned short*)malloc(sizeof(*dest->ll_symbol) * source->size);
-  dest->d_symbol =
-      (unsigned short*)malloc(sizeof(*dest->d_symbol) * source->size);
-  dest->ll_counts = (size_t*)malloc(sizeof(*dest->ll_counts) * llsize);
-  dest->d_counts = (size_t*)malloc(sizeof(*dest->d_counts) * dsize);
+  dest->ll_counts = (uint32_t*)malloc(sizeof(*dest->ll_counts) * llsize);
+  dest->d_counts = (uint32_t*)malloc(sizeof(*dest->d_counts) * dsize);
 
   /* Allocation failed. */
   if (!dest->litlens || !dest->dists) exit(-1);
   if (!dest->pos) exit(-1);
-  if (!dest->ll_symbol || !dest->d_symbol) exit(-1);
   if (!dest->ll_counts || !dest->d_counts) exit(-1);
 
   dest->size = source->size;
@@ -119,8 +105,6 @@ void ZopfliCopyLZ77Store(
     dest->litlens[i] = source->litlens[i];
     dest->dists[i] = source->dists[i];
     dest->pos[i] = source->pos[i];
-    dest->ll_symbol[i] = source->ll_symbol[i];
-    dest->d_symbol[i] = source->d_symbol[i];
   }
   for (i = 0; i < llsize; i++) {
     dest->ll_counts[i] = source->ll_counts[i];
@@ -166,12 +150,8 @@ void ZopfliStoreLitLenDist(unsigned short length, unsigned short dist,
   assert(length < 259);
 
   if (dist == 0) {
-    store->ll_symbol[origsize] = length;
-    store->d_symbol[origsize] = 0;
     store->ll_counts[llstart + length]++;
   } else {
-    store->ll_symbol[origsize] = ZopfliGetLengthSymbol(length);
-    store->d_symbol[origsize] = ZopfliGetDistSymbol(dist);
     store->ll_counts[llstart + ZopfliGetLengthSymbol(length)]++;
     store->d_counts[dstart + ZopfliGetDistSymbol(dist)]++;
   }
@@ -196,6 +176,17 @@ size_t ZopfliLZ77GetByteRange(const ZopfliLZ77Store* lz77,
       1 : lz77->litlens[l]) - lz77->pos[lstart];
 }
 
+/* Lit/len Huffman symbol at store position i, recomputed from litlens/dists
+(the cached ll_symbol/d_symbol arrays were dropped to save memory). For a
+literal (dist 0) the symbol is the byte value in litlens; otherwise it is the
+length symbol. d_symbol is just ZopfliGetDistSymbol(dist), inlined at its (two,
+dist != 0 guarded) use sites. */
+static unsigned LitLenSymbol(const ZopfliLZ77Store* lz77, size_t i) {
+  return lz77->dists[i] == 0
+      ? lz77->litlens[i]
+      : (unsigned)ZopfliGetLengthSymbol(lz77->litlens[i]);
+}
+
 static void ZopfliLZ77GetHistogramAt(const ZopfliLZ77Store* lz77, size_t lpos,
                                      size_t* ll_counts, size_t* d_counts) {
   /* The real histogram is created by using the histogram for this chunk, but
@@ -207,13 +198,13 @@ static void ZopfliLZ77GetHistogramAt(const ZopfliLZ77Store* lz77, size_t lpos,
     ll_counts[i] = lz77->ll_counts[llpos + i];
   }
   for (i = lpos + 1; i < llpos + ZOPFLI_NUM_LL && i < lz77->size; i++) {
-    ll_counts[lz77->ll_symbol[i]]--;
+    ll_counts[LitLenSymbol(lz77, i)]--;
   }
   for (i = 0; i < ZOPFLI_NUM_D; i++) {
     d_counts[i] = lz77->d_counts[dpos + i];
   }
   for (i = lpos + 1; i < dpos + ZOPFLI_NUM_D && i < lz77->size; i++) {
-    if (lz77->dists[i] != 0) d_counts[lz77->d_symbol[i]]--;
+    if (lz77->dists[i] != 0) d_counts[ZopfliGetDistSymbol(lz77->dists[i])]--;
   }
 }
 
@@ -225,8 +216,8 @@ void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
     memset(ll_counts, 0, sizeof(*ll_counts) * ZOPFLI_NUM_LL);
     memset(d_counts, 0, sizeof(*d_counts) * ZOPFLI_NUM_D);
     for (i = lstart; i < lend; i++) {
-      ll_counts[lz77->ll_symbol[i]]++;
-      if (lz77->dists[i] != 0) d_counts[lz77->d_symbol[i]]++;
+      ll_counts[LitLenSymbol(lz77, i)]++;
+      if (lz77->dists[i] != 0) d_counts[ZopfliGetDistSymbol(lz77->dists[i])]++;
     }
   } else {
     /* Subtract the cumulative histograms at the end and the start to get the
@@ -462,9 +453,9 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
 
   unsigned dist = 0;  /* Not unsigned short on purpose. */
 
-  int* hhead = h->head;
+  unsigned short* hhead = h->head;
   unsigned short* hprev = h->prev;
-  int* hhashval = h->hashval;
+  unsigned short* hhashval = h->hashval;
   int hval = h->val;
   /* hhashval is read only by asserts (line ~511), which NDEBUG strips. */
   (void)hhashval;

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -26,6 +26,7 @@ compression.
 #ifndef ZOPFLI_LZ77_H_
 #define ZOPFLI_LZ77_H_
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "cache.h"
@@ -53,15 +54,12 @@ typedef struct ZopfliLZ77Store {
   const unsigned char* data;  /* original data */
   size_t* pos;  /* position in data where this LZ77 command begins */
 
-  unsigned short* ll_symbol;
-  unsigned short* d_symbol;
-
   /* Cumulative histograms wrapping around per chunk. Each chunk has the amount
   of distinct symbols as length, so using 1 value per LZ77 symbol, we have a
   precise histogram at every N symbols, and the rest can be calculated by
   looping through the actual symbols of this chunk. */
-  size_t* ll_counts;
-  size_t* d_counts;
+  uint32_t* ll_counts;
+  uint32_t* d_counts;
 } ZopfliLZ77Store;
 
 void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store);

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -24,7 +24,14 @@ decompress. Decompression can be done by any standard gzip, zlib or deflate
 decompressor.
 */
 
+/* Request 64-bit file offsets (off_t / ftello / fseeko) so files larger than
+2 GB load even on 32-bit builds. Must precede any system header. */
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,6 +46,15 @@ decompressor.
 #include <io.h>     /* _setmode, _fileno */
 #endif
 
+/* 64-bit file seek/tell: __int64 on MSVC, off_t (64-bit, see above) elsewhere. */
+#ifdef _MSC_VER
+#define ZOPFLI_FSEEK64 _fseeki64
+#define ZOPFLI_FTELL64 _ftelli64
+#else
+#define ZOPFLI_FSEEK64 fseeko
+#define ZOPFLI_FTELL64 ftello
+#endif
+
 /*
 Loads a file into a memory array. Returns 1 on success, 0 if file doesn't exist
 or couldn't be opened.
@@ -46,23 +62,34 @@ or couldn't be opened.
 static int LoadFile(const char* filename,
                     unsigned char** out, size_t* outsize) {
   FILE* file;
+  long long filesize;
 
   *out = 0;
   *outsize = 0;
   file = fopen(filename, "rb");
   if (!file) return 0;
 
-  fseek(file , 0 , SEEK_END);
-  *outsize = ftell(file);
-  if(*outsize > 2147483647) {
-    fprintf(stderr,"Files larger than 2GB are not supported.\n");
+  ZOPFLI_FSEEK64(file, 0, SEEK_END);
+  filesize = ZOPFLI_FTELL64(file);
+  rewind(file);
+  if (filesize < 0) { fclose(file); return 0; }
+
+  /* The whole file is loaded into memory, so it must fit in size_t (and be
+  mallocable). On 64-bit builds that is effectively unbounded; on 32-bit builds
+  it caps near 4 GB. */
+  if ((unsigned long long)filesize > (unsigned long long)SIZE_MAX) {
+    fprintf(stderr, "File too large to load into memory on this build.\n");
     exit(EXIT_FAILURE);
   }
-  rewind(file);
+  *outsize = (size_t)filesize;
 
-  *out = (unsigned char*)malloc(*outsize);
+  *out = (unsigned char*)malloc(*outsize ? *outsize : 1);
+  if (!*out) {
+    fprintf(stderr, "Error: out of memory loading file.\n");
+    exit(EXIT_FAILURE);
+  }
 
-  if (*outsize && (*out)) {
+  if (*outsize) {
     size_t testsize = fread(*out, 1, *outsize, file);
     if (testsize != *outsize) {
       /* It could be a directory */
@@ -74,7 +101,6 @@ static int LoadFile(const char* filename,
     }
   }
 
-  assert(!(*outsize) || out);  /* If size is not zero, out must be allocated. */
   fclose(file);
   return 1;
 }

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -69,7 +69,9 @@ static int LoadFile(const char* filename,
   file = fopen(filename, "rb");
   if (!file) return 0;
 
-  ZOPFLI_FSEEK64(file, 0, SEEK_END);
+  /* Seek must succeed for the size from ftell to be meaningful; a non-seekable
+  input (pipe, fifo) or I/O error here means we can't size the file. */
+  if (ZOPFLI_FSEEK64(file, 0, SEEK_END) != 0) { fclose(file); return 0; }
   filesize = ZOPFLI_FTELL64(file);
   rewind(file);
   if (filesize < 0) { fclose(file); return 0; }


### PR DESCRIPTION
This pull request introduces several optimizations and memory usage improvements to the Zopfli codebase, with a particular focus on the hash table and LZ77 store data structures. The most important changes include reducing the memory footprint of hash tables by switching to 16-bit storage, removing redundant arrays from the LZ77 store to save memory, and updating related logic to recompute values on the fly. Documentation has also been updated to reflect these improvements and provide more detail on the fork's differences from upstream.

**Hash Table Memory Optimization**
* Changed hash table fields (`head`, `hashval`, and their secondary variants) from `int*` to `unsigned short*`, reducing memory by right-sizing allocations to the actual number of buckets and using a 16-bit empty sentinel value. All related logic and initializations now use the new sentinel and types. [[1]](diffhunk://#diff-e06fa77e4ccffd3dc235492e17b90b3f859027c0b059421ec4dc90874688b3e0R29-R61) [[2]](diffhunk://#diff-e06fa77e4ccffd3dc235492e17b90b3f859027c0b059421ec4dc90874688b3e0L66-R77) [[3]](diffhunk://#diff-e06fa77e4ccffd3dc235492e17b90b3f859027c0b059421ec4dc90874688b3e0L111-R118) [[4]](diffhunk://#diff-e06fa77e4ccffd3dc235492e17b90b3f859027c0b059421ec4dc90874688b3e0L132-R140) [[5]](diffhunk://#diff-899a2c614dcef5fd952d8288c52e03526fc05cf542480e07878b5254c029f39dR29-R47) [[6]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL465-R458)

**LZ77 Store Simplification & Memory Reduction**
* Removed the `ll_symbol` and `d_symbol` arrays from `ZopfliLZ77Store`, as their values can be recomputed as needed, saving memory and simplifying allocation and copying logic. All related code paths now use a helper function to compute these values on demand. [[1]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL36-L37) [[2]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL46-L47) [[3]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL60-R56) [[4]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL74-L83) [[5]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL103-L113) [[6]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL122-L123) [[7]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL169-L174) [[8]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efR179-R189) [[9]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL210-R207) [[10]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL228-R220) [[11]](diffhunk://#diff-6e960a9d9383cec33a441365362ef6146843b252c79dbe94deb4069c1afdb940L56-R62)

* Updated the types of `ll_counts` and `d_counts` from `size_t*` to `uint32_t*` for more efficient storage, and updated all allocation, copying, and usage sites accordingly. [[1]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL74-L83) [[2]](diffhunk://#diff-e5e5565b6adce23c50c480cf7077d8931dc562c3eb25c464da94bf4b631803efL103-L113) [[3]](diffhunk://#diff-6e960a9d9383cec33a441365362ef6146843b252c79dbe94deb4069c1afdb940L56-R62)

**Documentation Updates**
* Added a new section to the `README.md` detailing the fork's key changes compared to upstream Zopfli, including speed, determinism, memory use, and the auto iteration count feature.
* Updated `CLAUDE.md` to clarify the performance discipline and move benchmarking and hot-path architecture notes to a dedicated `optimization.md`, with a focus on output determinism and single-threaded operation.

**Header and Type Consistency**
* Added `<stdint.h>` include to `lz77.h` to support the new `uint32_t` types.

These changes collectively reduce memory usage, improve cache locality, and simplify the codebase while preserving output correctness and determinism.