### PR TITLE
Added custom allocator, small other improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,21 @@ for every change:
 - **Keep output byte-identical** to the pre-change baseline unless explicitly
   agreed otherwise (verify `md5` in both `-i15` and `--i200`, text + binary).
 - **Single-threaded only** — never add threads/OpenMP/parallelism.
+
+### Benchmark corpus (README tables)
+The README perf/memory tables are reproducible with this corpus and method (no
+private corpus is checked in; regenerate it locally):
+- **Text** = the repo's own C/C++ source concatenated
+  (`cat src/zopfli/*.c src/zopfli/*.h src/zopflipng/*.cc
+  src/zopflipng/lodepng/*.cpp src/zopflipng/lodepng/*.h README.md`, ~690 KB
+  base), then **extended by repetition** (`head -c` of the base repeated) to hit
+  the 256 KB / 1 MB / 3 MB / 10 MB sizes. The iterations table uses the first
+  ~415 KB of that base (real, un-repeated source).
+- **Binary** = incompressible random data (`head -c <size> /dev/urandom`).
+- **Stock baseline** = upstream `google/zopfli` built from a shallow clone, for
+  the fork-vs-stock columns.
+- **Method**: i9-8950HK, release `-O3 -DNDEBUG`; speed = `--i15` for both
+  binaries (stock's default), min of 2 runs; memory = peak RSS via
+  `/usr/bin/time -l` at `--i200` on the 3 MB inputs. Re-measure on an idle
+  machine (`ps -Ao pcpu,comm | sort -rn | head`) — wall times are contention-
+  sensitive. Compressed sizes are deterministic; only timings are noisy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,11 @@
 Repo-specific guidance. General coding preferences live in the user-global
 CLAUDE.md; this file adds what's specific to this codebase.
 
+## Upstream
+Upstream zopfli is read-only — this fork does not merge from it. Don't preserve
+upstream's file layout or structure for merge-ability; the code is free to
+diverge (reorganize, rename, restructure) when it improves the codebase.
+
 ## Language & style
 - **gnu99** — built with `-std=gnu99 -pedantic -W -Wall -Wextra` (C99 for
   `<stdint.h>` fixed-width cost types, plus the GNU `__builtin_clz` the code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ if(BUILD_TESTING)
     test/deflate_test.cc
     test/squeeze_test.cc
     test/fixedpoint_range_test.cc
+    test/custom_allocator_test.cc
   )
   target_link_libraries(zopfli_tests PRIVATE libzopfli GTest::gtest_main)
   set_target_properties(zopfli_tests PROPERTIES

--- a/README.md
+++ b/README.md
@@ -180,6 +180,24 @@ bytes and the checksum (gzip uses CRC-32, zlib Adler-32, raw DEFLATE none).
 Choose by what the consumer expects, not for ratio. `verbose` / `-v` only prints
 progress to stderr and has no effect on the output.
 
+### Custom allocator — `zrealloc` / `alloc_context`
+
+By default zopfli allocates with the standard `realloc`/`free`. To route every
+allocation through your own allocator (e.g. an arena, or a fixed pool on an
+embedded target), set `options.zrealloc` to a `realloc`-style callback and,
+optionally, `options.alloc_context` to a pointer handed back to it unchanged:
+
+```c
+void* my_realloc(void* alloc_context, void* ptr, size_t size);
+```
+
+It follows `realloc` semantics with one addition: `size == 0` must free `ptr` and
+return `NULL`; `ptr == NULL` allocates; it returns `NULL` only on genuine failure
+(which zopfli treats as fatal). `ZopfliInitOptions` points `zrealloc` at an
+internal default backed by the standard library; leaving it at that default (or
+setting it back to `NULL`) keeps standard-library allocation. This changes only
+*how* memory is obtained, never the compressed output.
+
 ## Getting started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -37,23 +37,24 @@ This fork is a drop-in replacement — it emits standard DEFLATE/zlib/gzip that 
 existing decoder reads — but differs from upstream zopfli in four ways. Each is
 detailed in its own section below; the highlights:
 
-**Faster.** At a matched iteration count the optimal parse is **~2.5× faster
-than stock zopfli** (and a bit more on incompressible data):
+**Faster.** At a matched iteration count the optimal parse is **~2× faster than
+stock zopfli on text and ~3× on incompressible data**:
 
 | Input    | Stock zopfli | QVXLabs/Zopfli | Speedup |
 |----------|-------------:|---------------:|:-------:|
-| 256 KB text   |   1.45 s |   0.70 s | 2.1× |
-| 1 MB text     |   4.77 s |   1.92 s | 2.5× |
-| 3 MB text     |  13.12 s |   5.35 s | 2.5× |
-| 10 MB text    |  43.62 s |  17.69 s | 2.5× |
-| 256 KB binary |   0.44 s |   0.18 s | 2.5× |
-| 1 MB binary   |   1.66 s |   0.65 s | 2.6× |
-| 3 MB binary   |   5.59 s |   1.90 s | 2.9× |
-| 10 MB binary  |  18.63 s |   6.63 s | 2.8× |
+| 256 KB text   |   1.04 s |   0.70 s | 1.5× |
+| 1 MB text     |   3.35 s |   1.87 s | 1.8× |
+| 3 MB text     |   9.91 s |   5.22 s | 1.9× |
+| 10 MB text    |  34.29 s |  17.03 s | 2.0× |
+| 256 KB binary |   0.49 s |   0.17 s | 2.9× |
+| 1 MB binary   |   2.33 s |   0.71 s | 3.3× |
+| 3 MB binary   |   6.16 s |   1.89 s | 3.3× |
+| 10 MB binary  |  19.99 s |   5.82 s | 3.4× |
 
 <sub>Measured on an Intel Core i9-8950HK (Coffee Lake), release `-O3 -DNDEBUG`,
-25 iterations (stock's hardcoded count; the fork was run with `--i25` to match),
-min of 2 runs. Text = concatenated source; binary = incompressible random data.</sub>
+15 iterations (`--i15` for both; stock's default), min of 2 runs. Text =
+concatenated source (zopfli + zopflipng + lodepng), extended by repetition for
+the larger sizes; binary = incompressible random data.</sub>
 
 It also scales much better at high iteration counts: the longest-match cache
 makes passes after the first nearly free, whereas stock's cost is roughly linear
@@ -75,14 +76,13 @@ defines a new canonical, platform-independent encoding. See the
 **Lower memory.** Hot data structures were trimmed to what the data actually
 needs — 16-bit hash tables (right-sized to the used bucket count), 32-bit LZ77
 cumulative histograms, and dropping two precomputed per-symbol arrays that are
-cheaply recomputed on the fly — reducing peak resident memory with
-**byte-identical output**. Measured peak RSS (`/usr/bin/time -l`, 3 MB input,
-`--i200`):
+cheaply recomputed on the fly — so peak resident memory is well below stock
+zopfli's. Measured peak RSS (`/usr/bin/time -l`, 3 MB input, `--i200`):
 
-| Input                         | Before   | After   | Saved          |
-|-------------------------------|---------:|--------:|:--------------:|
-| Text (~3 MB)                  | 35.2 MB  | 30.4 MB | 4.8 MB (−14%)  |
-| Incompressible binary (~3 MB) | 100.4 MB | 69.9 MB | 30.5 MB (−30%) |
+| Input                         | Stock zopfli | QVXLabs/Zopfli | Saved          |
+|-------------------------------|-------------:|---------------:|:--------------:|
+| Text (~3 MB)                  |   23.7 MB    |    15.2 MB     | 8.5 MB (−36%)  |
+| Incompressible binary (~3 MB) |  122.0 MB    |    75.1 MB     | 46.9 MB (−38%) |
 
 Incompressible input has ~1 LZ77 symbol per byte, so the per-symbol arrays — and
 thus the savings — are largest there; text compresses to fewer symbols.
@@ -142,21 +142,23 @@ The table below compresses ~415 KB of text at various **fixed** `--i#` counts
 
 | Iterations (`--i`) | Compressed size | Reduction vs `--i15` | Relative runtime |
 |:------------------:|----------------:|:--------------------:|:----------------:|
-| 5                  |   101,950 bytes | −0.06% (**worse**)   |       ~0.3×       |
-| 15                 |   101,886 bytes | —                    |        1×        |
-| 30                 |   101,857 bytes | 0.03%                |        ~2×        |
-| 50                 |   101,854 bytes | 0.03%                |        ~3×        |
-| 100                |   101,796 bytes | 0.09%                |        ~7×        |
-| 200                |   101,704 bytes | 0.18%                |       ~13×        |
-| 500                |   101,674 bytes | 0.21%                |       ~33×        |
-| 1000               |   101,661 bytes | 0.22%                |       ~67×        |
+| 5                  |   101,124 bytes | −0.09% (**worse**)   |      ~0.7×        |
+| 15                 |   101,036 bytes | —                    |        1×        |
+| 30                 |   101,021 bytes | 0.01%                |       ~1.3×       |
+| 50                 |   101,016 bytes | 0.02%                |       ~1.8×       |
+| 100                |   100,996 bytes | 0.04%                |        ~3×        |
+| 200                |   100,994 bytes | 0.04%                |       ~5.4×       |
+| 500                |   100,992 bytes | 0.04%                |       ~13×        |
+| 1000               |   100,986 bytes | 0.05%                |       ~25×        |
 
-Takeaways: `--i15` already captures ~99.8% of what `--i1000` achieves; the
-*entire* remaining headroom from iterations is ~0.22%, and most of it is in the
-first ~8 passes. `--i5` hasn't converged (output is larger). The auto default
-spends more passes on larger inputs, where that thin tail is worth chasing;
-force a fixed `--i#` to cap runtime. Highly compressible (text-like) data
-benefits most — incompressible or binary data converges flatter.
+Takeaways: `--i15` already captures all but ~0.05% of what `--i1000` achieves;
+that thin tail is the *entire* remaining headroom from iterations, and most of it
+lands in the first ~8 passes. `--i5` hasn't converged (output is larger). The
+longest-match cache makes passes after the first cheap, so the runtime cost of
+high counts is far below stock's roughly linear scaling. The auto default spends
+more passes on larger inputs, where that tail is worth chasing; force a fixed
+`--i#` to cap runtime. Highly compressible (text-like) data benefits most —
+incompressible or binary data converges flatter.
 
 ### Block splitting — `blocksplitting`, `blocksplittingmax`, `blocksplittinglast`
 

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -236,7 +236,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   /* Reused across all block-size evaluations of this split. */
   ZopfliKatajainenScratch scratch;
 
-  ctxv.options = options;
+  ctxv.options = *options;
 
   if (lz77->size < 10) return;  /* This code fails on tiny files. */
 
@@ -306,7 +306,7 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
   ZopfliHash hash;
   ZopfliHash* h = &hash;
 
-  ctxv.options = options;
+  ctxv.options = *options;
 
   ZopfliInitLZ77Store(in, &store);
   ZopfliInitBlockState(ctx, instart, inend, 0, &s);
@@ -349,8 +349,8 @@ void ZopfliBlockSplitSimple(const uint8_t* in,
                             size_t** splitpoints, size_t* npoints) {
   size_t i = instart;
   while (i < inend) {
-    /* No options/context here; allocate via the default allocator. */
-    ZOPFLI_APPEND_DATA(NULL, i, splitpoints, npoints);
+    /* No caller options here; use the default-allocator context. */
+    ZOPFLI_APPEND_DATA(ZopfliDefaultContext(), i, splitpoints, npoints);
     i += blocksize;
   }
   (void)in;

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -25,6 +25,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "context.h"
 #include "deflate.h"
 #include "squeeze.h"
 #include "tree.h"
@@ -38,6 +39,7 @@ context: for your implementation
 typedef uint32_t FindMinimumFun(size_t i, void* context);
 
 typedef struct SplitCostContext {
+  const ZopfliContext* ctx;
   const ZopfliLZ77Store* lz77;
   ZopfliKatajainenScratch* scratch;
   size_t start;
@@ -114,10 +116,12 @@ dists: ll77 distances
 lstart: start of block
 lend: end of block (not inclusive)
 */
-static uint32_t EstimateCost(ZopfliKatajainenScratch* scratch,
+static uint32_t EstimateCost(const ZopfliContext* ctx,
+                           ZopfliKatajainenScratch* scratch,
                            const ZopfliLZ77Store* lz77,
                            size_t lstart, size_t lend) {
-  return ZopfliCalculateBlockSizeAutoTypeScratch(scratch, lz77, lstart, lend);
+  return ZopfliCalculateBlockSizeAutoTypeScratch(ctx, scratch, lz77, lstart,
+                                                 lend);
 }
 
 /*
@@ -127,13 +131,14 @@ type: FindMinimumFun
 */
 static uint32_t SplitCost(size_t i, void* context) {
   SplitCostContext* c = (SplitCostContext*)context;
-  return EstimateCost(c->scratch, c->lz77, c->start, i)
-      + EstimateCost(c->scratch, c->lz77, i, c->end);
+  return EstimateCost(c->ctx, c->scratch, c->lz77, c->start, i)
+      + EstimateCost(c->ctx, c->scratch, c->lz77, i, c->end);
 }
 
-static void AddSorted(size_t value, size_t** out, size_t* outsize) {
+static void AddSorted(const ZopfliContext* ctx, size_t value,
+                      size_t** out, size_t* outsize) {
   size_t i;
-  ZOPFLI_APPEND_DATA(value, out, outsize);
+  ZOPFLI_APPEND_DATA(ctx, value, out, outsize);
   for (i = 0; i + 1 < *outsize; i++) {
     if ((*out)[i] > value) {
       size_t j;
@@ -149,10 +154,11 @@ static void AddSorted(size_t value, size_t** out, size_t* outsize) {
 /*
 Prints the block split points as decimal and hex values in the terminal.
 */
-static void PrintBlockSplitPoints(const ZopfliLZ77Store* lz77,
+static void PrintBlockSplitPoints(const ZopfliContext* ctx,
+                                  const ZopfliLZ77Store* lz77,
                                   const size_t* lz77splitpoints,
                                   size_t nlz77points) {
-  size_t* splitpoints = 0;
+  size_t* splitpoints = NULL;
   size_t npoints = 0;
   size_t i;
   /* The input is given as lz77 indices, but we want to see the uncompressed
@@ -162,7 +168,7 @@ static void PrintBlockSplitPoints(const ZopfliLZ77Store* lz77,
     for (i = 0; i < lz77->size; i++) {
       size_t length = lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
       if (lz77splitpoints[npoints] == i) {
-        ZOPFLI_APPEND_DATA(pos, &splitpoints, &npoints);
+        ZOPFLI_APPEND_DATA(ctx, pos, &splitpoints, &npoints);
         if (npoints == nlz77points) break;
       }
       pos += length;
@@ -180,7 +186,7 @@ static void PrintBlockSplitPoints(const ZopfliLZ77Store* lz77,
   }
   fprintf(stderr, ")\n");
 
-  ZopfliRealloc(splitpoints, 0);
+  ZopfliRealloc(ctx, splitpoints, 0);
 }
 
 /*
@@ -219,6 +225,8 @@ static int FindLargestSplittableBlock(
 void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
                           const ZopfliLZ77Store* lz77, size_t maxblocks,
                           size_t** splitpoints, size_t* npoints) {
+  ZopfliContext ctxv;
+  const ZopfliContext* ctx = &ctxv;
   size_t lstart, lend;
   size_t i;
   size_t llpos = 0;
@@ -228,11 +236,13 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   /* Reused across all block-size evaluations of this split. */
   ZopfliKatajainenScratch scratch;
 
+  ctxv.options = options;
+
   if (lz77->size < 10) return;  /* This code fails on tiny files. */
 
   ZopfliInitKatajainenScratch(&scratch);
 
-  done = (uint8_t*)ZopfliRealloc(NULL, lz77->size);
+  done = (uint8_t*)ZopfliRealloc(ctx, NULL, lz77->size);
   for (i = 0; i < lz77->size; i++) done[i] = 0;
 
   lstart = 0;
@@ -244,6 +254,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
       break;
     }
 
+    c.ctx = ctx;
     c.lz77 = lz77;
     c.scratch = &scratch;
     c.start = lstart;
@@ -254,12 +265,12 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
     assert(llpos > lstart);
     assert(llpos < lend);
 
-    origcost = EstimateCost(&scratch, lz77, lstart, lend);
+    origcost = EstimateCost(ctx, &scratch, lz77, lstart, lend);
 
     if (splitcost > origcost || llpos == lstart + 1 || llpos == lend) {
       done[lstart] = 1;
     } else {
-      AddSorted(llpos, splitpoints, npoints);
+      AddSorted(ctx, llpos, splitpoints, npoints);
       numblocks++;
     }
 
@@ -274,31 +285,35 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   }
 
   if (options->verbose) {
-    PrintBlockSplitPoints(lz77, *splitpoints, *npoints);
+    PrintBlockSplitPoints(ctx, lz77, *splitpoints, *npoints);
   }
 
-  ZopfliCleanKatajainenScratch(&scratch);
-  ZopfliRealloc(done, 0);
+  ZopfliCleanKatajainenScratch(ctx, &scratch);
+  ZopfliRealloc(ctx, done, 0);
 }
 
 void ZopfliBlockSplit(const ZopfliOptions* options,
                       const uint8_t* in, size_t instart, size_t inend,
                       size_t maxblocks, size_t** splitpoints, size_t* npoints) {
+  ZopfliContext ctxv;
+  const ZopfliContext* ctx = &ctxv;
   size_t pos = 0;
   size_t i;
   ZopfliBlockState s;
-  size_t* lz77splitpoints = 0;
+  size_t* lz77splitpoints = NULL;
   size_t nlz77points = 0;
   ZopfliLZ77Store store;
   ZopfliHash hash;
   ZopfliHash* h = &hash;
 
+  ctxv.options = options;
+
   ZopfliInitLZ77Store(in, &store);
-  ZopfliInitBlockState(options, instart, inend, 0, &s);
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, h);
+  ZopfliInitBlockState(ctx, instart, inend, 0, &s);
+  ZopfliAllocHash(ctx, ZOPFLI_WINDOW_SIZE, h);
 
   *npoints = 0;
-  *splitpoints = 0;
+  *splitpoints = NULL;
 
   /* Unintuitively, Using a simple LZ77 method here instead of ZopfliLZ77Optimal
   results in better blocks. */
@@ -314,7 +329,7 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
     for (i = 0; i < store.size; i++) {
       size_t length = store.dists[i] == 0 ? 1 : store.litlens[i];
       if (lz77splitpoints[*npoints] == i) {
-        ZOPFLI_APPEND_DATA(pos, splitpoints, npoints);
+        ZOPFLI_APPEND_DATA(ctx, pos, splitpoints, npoints);
         if (*npoints == nlz77points) break;
       }
       pos += length;
@@ -322,10 +337,10 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
   }
   assert(*npoints == nlz77points);
 
-  ZopfliRealloc(lz77splitpoints, 0);
+  ZopfliRealloc(ctx, lz77splitpoints, 0);
   ZopfliCleanBlockState(&s);
-  ZopfliCleanLZ77Store(&store);
-  ZopfliCleanHash(h);
+  ZopfliCleanLZ77Store(ctx, &store);
+  ZopfliCleanHash(ctx, h);
 }
 
 void ZopfliBlockSplitSimple(const uint8_t* in,
@@ -334,7 +349,8 @@ void ZopfliBlockSplitSimple(const uint8_t* in,
                             size_t** splitpoints, size_t* npoints) {
   size_t i = instart;
   while (i < inend) {
-    ZOPFLI_APPEND_DATA(i, splitpoints, npoints);
+    /* No options/context here; allocate via the default allocator. */
+    ZOPFLI_APPEND_DATA(NULL, i, splitpoints, npoints);
     i += blocksize;
   }
   (void)in;

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -37,6 +37,13 @@ context: for your implementation
 */
 typedef uint32_t FindMinimumFun(size_t i, void* context);
 
+typedef struct SplitCostContext {
+  const ZopfliLZ77Store* lz77;
+  ZopfliKatajainenScratch* scratch;
+  size_t start;
+  size_t end;
+} SplitCostContext;
+
 /*
 Finds minimum of function f(i) where i is of type size_t, f(i) is of type
 uint32_t, i is in range start-end (excluding end).
@@ -113,14 +120,6 @@ static uint32_t EstimateCost(ZopfliKatajainenScratch* scratch,
   return ZopfliCalculateBlockSizeAutoTypeScratch(scratch, lz77, lstart, lend);
 }
 
-typedef struct SplitCostContext {
-  const ZopfliLZ77Store* lz77;
-  ZopfliKatajainenScratch* scratch;
-  size_t start;
-  size_t end;
-} SplitCostContext;
-
-
 /*
 Gets the cost which is the sum of the cost of the left and the right section
 of the data.
@@ -181,7 +180,7 @@ static void PrintBlockSplitPoints(const ZopfliLZ77Store* lz77,
   }
   fprintf(stderr, ")\n");
 
-  free(splitpoints);
+  ZopfliRealloc(splitpoints, 0);
 }
 
 /*
@@ -198,7 +197,7 @@ lend: output variable, giving end of block.
 returns 1 if a block was found, 0 if no block found (all are done).
 */
 static int FindLargestSplittableBlock(
-    size_t lz77size, const unsigned char* done,
+    size_t lz77size, const uint8_t* done,
     const size_t* splitpoints, size_t npoints,
     size_t* lstart, size_t* lend) {
   size_t longest = 0;
@@ -224,7 +223,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   size_t i;
   size_t llpos = 0;
   size_t numblocks = 1;
-  unsigned char* done;
+  uint8_t* done;
   uint32_t splitcost, origcost;
   /* Reused across all block-size evaluations of this split. */
   ZopfliKatajainenScratch scratch;
@@ -233,8 +232,7 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
 
   ZopfliInitKatajainenScratch(&scratch);
 
-  done = (unsigned char*)malloc(lz77->size);
-  if (!done) exit(-1); /* Allocation failed. */
+  done = (uint8_t*)ZopfliRealloc(NULL, lz77->size);
   for (i = 0; i < lz77->size; i++) done[i] = 0;
 
   lstart = 0;
@@ -280,11 +278,11 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
   }
 
   ZopfliCleanKatajainenScratch(&scratch);
-  free(done);
+  ZopfliRealloc(done, 0);
 }
 
 void ZopfliBlockSplit(const ZopfliOptions* options,
-                      const unsigned char* in, size_t instart, size_t inend,
+                      const uint8_t* in, size_t instart, size_t inend,
                       size_t maxblocks, size_t** splitpoints, size_t* npoints) {
   size_t pos = 0;
   size_t i;
@@ -324,13 +322,13 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
   }
   assert(*npoints == nlz77points);
 
-  free(lz77splitpoints);
+  ZopfliRealloc(lz77splitpoints, 0);
   ZopfliCleanBlockState(&s);
   ZopfliCleanLZ77Store(&store);
   ZopfliCleanHash(h);
 }
 
-void ZopfliBlockSplitSimple(const unsigned char* in,
+void ZopfliBlockSplitSimple(const uint8_t* in,
                             size_t instart, size_t inend,
                             size_t blocksize,
                             size_t** splitpoints, size_t* npoints) {

--- a/src/zopfli/blocksplitter.h
+++ b/src/zopfli/blocksplitter.h
@@ -58,14 +58,14 @@ npoints: pointer to amount of splitpoints, for the dynamic array. The amount of
   blocks is the amount of splitpoitns + 1.
 */
 void ZopfliBlockSplit(const ZopfliOptions* options,
-                      const unsigned char* in, size_t instart, size_t inend,
+                      const uint8_t* in, size_t instart, size_t inend,
                       size_t maxblocks, size_t** splitpoints, size_t* npoints);
 
 /*
 Divides the input into equal blocks, does not even take LZ77 lengths into
 account.
 */
-void ZopfliBlockSplitSimple(const unsigned char* in,
+void ZopfliBlockSplitSimple(const uint8_t* in,
                             size_t instart, size_t inend,
                             size_t blocksize,
                             size_t** splitpoints, size_t* npoints);

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -29,16 +29,19 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 /* run_off sentinel: this position has no full sublen stored (pool overflow). */
 #define LMC_NO_SUBLEN ((unsigned)-1)
 
-void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
+void ZopfliInitCache(const ZopfliContext* ctx, size_t blocksize,
+                     ZopfliLongestMatchCache* lmc) {
   size_t i;
-  lmc->length = (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * blocksize);
-  lmc->dist = (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * blocksize);
-  lmc->run_off = (unsigned*)ZopfliRealloc(NULL, sizeof(unsigned) * blocksize);
+  lmc->length =
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(uint16_t) * blocksize);
+  lmc->dist = (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(uint16_t) * blocksize);
+  lmc->run_off =
+      (unsigned*)ZopfliRealloc(ctx, NULL, sizeof(unsigned) * blocksize);
   /* Same byte budget as the old fixed cache, used now as a shared run pool. */
   lmc->pool_cap = (size_t)ZOPFLI_CACHE_LENGTH * blocksize;
   lmc->pool_used = 0;
   lmc->all_complete = 1;
-  lmc->pool = (uint8_t*)ZopfliRealloc(NULL, 3 * lmc->pool_cap);
+  lmc->pool = (uint8_t*)ZopfliRealloc(ctx, NULL, 3 * lmc->pool_cap);
   /* For an empty block (blocksize 0) the arrays above are zero-size and stay
   NULL; nothing below reads them. Real allocation failures abort inside
   ZopfliRealloc, so no out-of-memory check is needed here. */
@@ -52,11 +55,11 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   for (i = 0; i < blocksize; i++) lmc->dist[i] = 0;
 }
 
-void ZopfliCleanCache(ZopfliLongestMatchCache* lmc) {
-  ZopfliRealloc(lmc->length, 0);
-  ZopfliRealloc(lmc->dist, 0);
-  ZopfliRealloc(lmc->pool, 0);
-  ZopfliRealloc(lmc->run_off, 0);
+void ZopfliCleanCache(const ZopfliContext* ctx, ZopfliLongestMatchCache* lmc) {
+  ZopfliRealloc(ctx, lmc->length, 0);
+  ZopfliRealloc(ctx, lmc->dist, 0);
+  ZopfliRealloc(ctx, lmc->pool, 0);
+  ZopfliRealloc(ctx, lmc->run_off, 0);
 }
 
 void ZopfliSublenToCache(const uint16_t* sublen,

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -31,24 +31,17 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   size_t i;
-  lmc->length = (unsigned short*)malloc(sizeof(unsigned short) * blocksize);
-  lmc->dist = (unsigned short*)malloc(sizeof(unsigned short) * blocksize);
-  lmc->run_off = (unsigned*)malloc(sizeof(unsigned) * blocksize);
+  lmc->length = (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * blocksize);
+  lmc->dist = (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * blocksize);
+  lmc->run_off = (unsigned*)ZopfliRealloc(NULL, sizeof(unsigned) * blocksize);
   /* Same byte budget as the old fixed cache, used now as a shared run pool. */
   lmc->pool_cap = (size_t)ZOPFLI_CACHE_LENGTH * blocksize;
   lmc->pool_used = 0;
   lmc->all_complete = 1;
-  lmc->pool = (unsigned char*)malloc(3 * lmc->pool_cap);
-  /* blocksize == 0 makes every malloc above a malloc(0), which may return NULL
-  without being an error; nothing below is read for an empty block. Otherwise
-  any NULL is a real allocation failure (length/dist are written just below). */
-  if (blocksize != 0 && (lmc->length == NULL || lmc->dist == NULL ||
-                         lmc->run_off == NULL || lmc->pool == NULL)) {
-    fprintf(stderr,
-        "Error: Out of memory. Tried allocating %zu bytes of memory.\n",
-        3 * lmc->pool_cap);
-    exit (EXIT_FAILURE);
-  }
+  lmc->pool = (uint8_t*)ZopfliRealloc(NULL, 3 * lmc->pool_cap);
+  /* For an empty block (blocksize 0) the arrays above are zero-size and stay
+  NULL; nothing below reads them. Real allocation failures abort inside
+  ZopfliRealloc, so no out-of-memory check is needed here. */
 
   /* length > 0 and dist 0 is invalid combination, which indicates on purpose
   that this cache value is not filled in yet. pool and run_off are intentionally
@@ -60,18 +53,18 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
 }
 
 void ZopfliCleanCache(ZopfliLongestMatchCache* lmc) {
-  free(lmc->length);
-  free(lmc->dist);
-  free(lmc->pool);
-  free(lmc->run_off);
+  ZopfliRealloc(lmc->length, 0);
+  ZopfliRealloc(lmc->dist, 0);
+  ZopfliRealloc(lmc->pool, 0);
+  ZopfliRealloc(lmc->run_off, 0);
 }
 
-void ZopfliSublenToCache(const unsigned short* sublen,
+void ZopfliSublenToCache(const uint16_t* sublen,
                          size_t pos, size_t length,
                          ZopfliLongestMatchCache* lmc) {
   size_t i;
   size_t nruns = 0;
-  unsigned char* run;
+  uint8_t* run;
 
 #if ZOPFLI_CACHE_LENGTH == 0
   return;
@@ -96,9 +89,9 @@ void ZopfliSublenToCache(const unsigned short* sublen,
   run = &lmc->pool[lmc->pool_used * 3];
   for (i = 3; i <= length; i++) {
     if (i == length || sublen[i] != sublen[i + 1]) {
-      run[0] = (unsigned char)(i - 3);
-      run[1] = sublen[i] % 256;
-      run[2] = (sublen[i] >> 8) % 256;
+      run[0] = (uint8_t)(i - 3);
+      run[1] = sublen[i] & 0xff;
+      run[2] = (sublen[i] >> 8) & 0xff;
       run += 3;
     }
   }
@@ -107,10 +100,10 @@ void ZopfliSublenToCache(const unsigned short* sublen,
 
 void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
                          size_t pos, size_t length,
-                         unsigned short* sublen) {
+                         uint16_t* sublen) {
   size_t i;
   unsigned prevlength = 0;
-  unsigned char* run;
+  uint8_t* run;
 #if ZOPFLI_CACHE_LENGTH == 0
   return;
 #endif

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -40,9 +40,9 @@ all_complete clears if a position overflows the pool budget (pathological
 input); those positions fall back to recomputation as over-cap ones did before.
 */
 typedef struct ZopfliLongestMatchCache {
-  unsigned short* length;
-  unsigned short* dist;
-  unsigned char* pool;  /* Shared run pool, 3 bytes per run. */
+  uint16_t* length;
+  uint16_t* dist;
+  uint8_t* pool;  /* Shared run pool, 3 bytes per run. */
   unsigned* run_off;  /* Per pos: first run index in pool, or LMC_NO_SUBLEN. */
   size_t pool_used;  /* Next free run slot. */
   size_t pool_cap;  /* Pool capacity in runs. */
@@ -56,14 +56,14 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc);
 void ZopfliCleanCache(ZopfliLongestMatchCache* lmc);
 
 /* Stores sublen array in the cache. */
-void ZopfliSublenToCache(const unsigned short* sublen,
+void ZopfliSublenToCache(const uint16_t* sublen,
                          size_t pos, size_t length,
                          ZopfliLongestMatchCache* lmc);
 
 /* Extracts sublen array from the cache. */
 void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
                          size_t pos, size_t length,
-                         unsigned short* sublen);
+                         uint16_t* sublen);
 
 /* Returns the length up to which could be stored in the cache. */
 unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -50,10 +50,11 @@ typedef struct ZopfliLongestMatchCache {
 } ZopfliLongestMatchCache;
 
 /* Initializes the ZopfliLongestMatchCache. */
-void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc);
+void ZopfliInitCache(const ZopfliContext* ctx, size_t blocksize,
+                     ZopfliLongestMatchCache* lmc);
 
 /* Frees up the memory of the ZopfliLongestMatchCache. */
-void ZopfliCleanCache(ZopfliLongestMatchCache* lmc);
+void ZopfliCleanCache(const ZopfliContext* ctx, ZopfliLongestMatchCache* lmc);
 
 /* Stores sublen array in the cache. */
 void ZopfliSublenToCache(const uint16_t* sublen,

--- a/src/zopfli/context.h
+++ b/src/zopfli/context.h
@@ -1,0 +1,36 @@
+/*
+Copyright 2011 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: afalls@qvxlabs.com (Ardavon Falls)
+*/
+
+#ifndef ZOPFLI_CONTEXT_H_
+#define ZOPFLI_CONTEXT_H_
+
+#include "util.h"    /* forward typedef of ZopfliContext */
+#include "zopfli.h"  /* ZopfliOptions */
+
+/*
+Internal per-compression context. Carries the options (which hold the custom
+allocator hook) so a single pointer threads configuration and allocation through
+the code instead of many parameters. Built at each public entry point from the
+caller's ZopfliOptions; util.h forward-typedefs it so ZopfliRealloc can take it
+without an include cycle.
+*/
+struct ZopfliContext {
+  const ZopfliOptions* options;
+};
+
+#endif  /* ZOPFLI_CONTEXT_H_ */

--- a/src/zopfli/context.h
+++ b/src/zopfli/context.h
@@ -23,14 +23,14 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include "zopfli.h"  /* ZopfliOptions */
 
 /*
-Internal per-compression context. Carries the options (which hold the custom
-allocator hook) so a single pointer threads configuration and allocation through
-the code instead of many parameters. Built at each public entry point from the
-caller's ZopfliOptions; util.h forward-typedefs it so ZopfliRealloc can take it
-without an include cycle.
+Internal per-compression context. Holds a copy of the options (which carry the
+custom allocator hook) so a single pointer threads configuration and allocation
+through the code instead of many parameters. Built at each public entry point
+from the caller's ZopfliOptions; util.h forward-typedefs it so ZopfliRealloc can
+take it without an include cycle.
 */
 struct ZopfliContext {
-  const ZopfliOptions* options;
+  ZopfliOptions options;
 };
 
 #endif  /* ZOPFLI_CONTEXT_H_ */

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -26,6 +26,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include <stdlib.h>
 
 #include "blocksplitter.h"
+#include "context.h"
 #include "squeeze.h"
 #include "symbols.h"
 #include "tree.h"
@@ -37,19 +38,20 @@ Given the value of bp and the amount of bytes, the amount of bits represented
 is not simply bytesize * 8 + bp because even representing one bit requires a
 whole byte. It is: (bp == 0) ? (bytesize * 8) : ((bytesize - 1) * 8 + bp)
 */
-static void AddBit(int bit, uint8_t* bp, ZopfliBuf* buf) {
-  if (*bp == 0) ZopfliBufPush(buf, 0);
+static void AddBit(const ZopfliContext* ctx, int bit,
+                   uint8_t* bp, ZopfliBuf* buf) {
+  if (*bp == 0) ZopfliBufPush(ctx, buf, 0);
   buf->data[buf->size - 1] |= bit << *bp;
   *bp = (*bp + 1) & 7;
 }
 
-static void AddBits(unsigned symbol, unsigned length,
+static void AddBits(const ZopfliContext* ctx, unsigned symbol, unsigned length,
                     uint8_t* bp, ZopfliBuf* buf) {
   /* TODO(lode): make more efficient (add more bits at once). */
   unsigned i;
   for (i = 0; i < length; i++) {
     unsigned bit = (symbol >> i) & 1;
-    if (*bp == 0) ZopfliBufPush(buf, 0);
+    if (*bp == 0) ZopfliBufPush(ctx, buf, 0);
     buf->data[buf->size - 1] |= bit << *bp;
     *bp = (*bp + 1) & 7;
   }
@@ -59,13 +61,14 @@ static void AddBits(unsigned symbol, unsigned length,
 Adds bits, like AddBits, but the order is inverted. The deflate specification
 uses both orders in one standard.
 */
-static void AddHuffmanBits(unsigned symbol, unsigned length,
+static void AddHuffmanBits(const ZopfliContext* ctx,
+                           unsigned symbol, unsigned length,
                            uint8_t* bp, ZopfliBuf* buf) {
   /* TODO(lode): make more efficient (add more bits at once). */
   unsigned i;
   for (i = 0; i < length; i++) {
     unsigned bit = (symbol >> (length - i - 1)) & 1;
-    if (*bp == 0) ZopfliBufPush(buf, 0);
+    if (*bp == 0) ZopfliBufPush(ctx, buf, 0);
     buf->data[buf->size - 1] |= bit << *bp;
     *bp = (*bp + 1) & 7;
   }
@@ -102,15 +105,16 @@ static void PatchDistanceCodesForBuggyDecoders(unsigned* d_lengths) {
 Encodes the Huffman tree and returns how many bits its encoding takes. If out
 is a null pointer, only returns the size and runs faster.
 */
-static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
+static size_t EncodeTree(const ZopfliContext* ctx,
+                         ZopfliKatajainenScratch* scratch,
                          const unsigned* ll_lengths,
                          const unsigned* d_lengths,
                          int use_16, int use_17, int use_18,
                          uint8_t* bp, ZopfliBuf* buf) {
   unsigned lld_total;  /* Total amount of literal, length, distance codes. */
   /* Runlength encoded version of lengths of litlen and dist trees. */
-  unsigned* rle = 0;
-  unsigned* rle_bits = 0;  /* Extra bits for rle values 16, 17 and 18. */
+  unsigned* rle = NULL;
+  unsigned* rle_bits = NULL;  /* Extra bits for rle values 16, 17 and 18. */
   size_t rle_size = 0;  /* Size of rle array. */
   size_t rle_bits_size = 0;  /* Should have same value as rle_size. */
   unsigned hlit = 29;  /* 286 - 257 */
@@ -155,8 +159,8 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
         while (count >= 11) {
           unsigned count2 = ZOPFLI_MIN(count, 138u);
           if (!size_only) {
-            ZOPFLI_APPEND_DATA(18, &rle, &rle_size);
-            ZOPFLI_APPEND_DATA(count2 - 11, &rle_bits, &rle_bits_size);
+            ZOPFLI_APPEND_DATA(ctx, 18, &rle, &rle_size);
+            ZOPFLI_APPEND_DATA(ctx, count2 - 11, &rle_bits, &rle_bits_size);
           }
           clcounts[18]++;
           count -= count2;
@@ -166,8 +170,8 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
         while (count >= 3) {
           unsigned count2 = ZOPFLI_MIN(count, 10u);
           if (!size_only) {
-            ZOPFLI_APPEND_DATA(17, &rle, &rle_size);
-            ZOPFLI_APPEND_DATA(count2 - 3, &rle_bits, &rle_bits_size);
+            ZOPFLI_APPEND_DATA(ctx, 17, &rle, &rle_size);
+            ZOPFLI_APPEND_DATA(ctx, count2 - 3, &rle_bits, &rle_bits_size);
           }
           clcounts[17]++;
           count -= count2;
@@ -180,14 +184,14 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
       count--;  /* Since the first one is hardcoded. */
       clcounts[symbol]++;
       if (!size_only) {
-        ZOPFLI_APPEND_DATA(symbol, &rle, &rle_size);
-        ZOPFLI_APPEND_DATA(0, &rle_bits, &rle_bits_size);
+        ZOPFLI_APPEND_DATA(ctx, symbol, &rle, &rle_size);
+        ZOPFLI_APPEND_DATA(ctx, 0, &rle_bits, &rle_bits_size);
       }
       while (count >= 3) {
         unsigned count2 = ZOPFLI_MIN(count, 6u);
         if (!size_only) {
-          ZOPFLI_APPEND_DATA(16, &rle, &rle_size);
-          ZOPFLI_APPEND_DATA(count2 - 3, &rle_bits, &rle_bits_size);
+          ZOPFLI_APPEND_DATA(ctx, 16, &rle, &rle_size);
+          ZOPFLI_APPEND_DATA(ctx, count2 - 3, &rle_bits, &rle_bits_size);
         }
         clcounts[16]++;
         count -= count2;
@@ -198,36 +202,36 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
     clcounts[symbol] += count;
     while (count > 0) {
       if (!size_only) {
-        ZOPFLI_APPEND_DATA(symbol, &rle, &rle_size);
-        ZOPFLI_APPEND_DATA(0, &rle_bits, &rle_bits_size);
+        ZOPFLI_APPEND_DATA(ctx, symbol, &rle, &rle_size);
+        ZOPFLI_APPEND_DATA(ctx, 0, &rle_bits, &rle_bits_size);
       }
       count--;
     }
   }
 
-  ZopfliCalculateBitLengthsScratch(scratch, clcounts, 19, 7, clcl);
-  if (!size_only) ZopfliLengthsToSymbols(clcl, 19, 7, clsymbols);
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, clcounts, 19, 7, clcl);
+  if (!size_only) ZopfliLengthsToSymbols(ctx, clcl, 19, 7, clsymbols);
 
   hclen = 15;
   /* Trim zeros. */
   while (hclen > 0 && clcounts[order[hclen + 4 - 1]] == 0) hclen--;
 
   if (!size_only) {
-    AddBits(hlit, 5, bp, buf);
-    AddBits(hdist, 5, bp, buf);
-    AddBits(hclen, 4, bp, buf);
+    AddBits(ctx, hlit, 5, bp, buf);
+    AddBits(ctx, hdist, 5, bp, buf);
+    AddBits(ctx, hclen, 4, bp, buf);
 
     for (i = 0; i < hclen + 4; i++) {
-      AddBits(clcl[order[i]], 3, bp, buf);
+      AddBits(ctx, clcl[order[i]], 3, bp, buf);
     }
 
     for (i = 0; i < rle_size; i++) {
       unsigned symbol = clsymbols[rle[i]];
-      AddHuffmanBits(symbol, clcl[rle[i]], bp, buf);
+      AddHuffmanBits(ctx, symbol, clcl[rle[i]], bp, buf);
       /* Extra bits. */
-      if (rle[i] == 16) AddBits(rle_bits[i], 2, bp, buf);
-      else if (rle[i] == 17) AddBits(rle_bits[i], 3, bp, buf);
-      else if (rle[i] == 18) AddBits(rle_bits[i], 7, bp, buf);
+      if (rle[i] == 16) AddBits(ctx, rle_bits[i], 2, bp, buf);
+      else if (rle[i] == 17) AddBits(ctx, rle_bits[i], 3, bp, buf);
+      else if (rle[i] == 18) AddBits(ctx, rle_bits[i], 7, bp, buf);
     }
   }
 
@@ -242,13 +246,14 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
   result_size += clcounts[18] * 7;
 
   /* Note: in case of "size_only" these are null pointers so no effect. */
-  ZopfliRealloc(rle, 0);
-  ZopfliRealloc(rle_bits, 0);
+  ZopfliRealloc(ctx, rle, 0);
+  ZopfliRealloc(ctx, rle_bits, 0);
 
   return result_size;
 }
 
-static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
+static void AddDynamicTree(const ZopfliContext* ctx,
+                           ZopfliKatajainenScratch* scratch,
                            const unsigned* ll_lengths,
                            const unsigned* d_lengths,
                            uint8_t* bp, ZopfliBuf* buf) {
@@ -257,16 +262,16 @@ static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
   size_t bestsize = 0;
 
   for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(scratch, ll_lengths, d_lengths,
+    size_t size = EncodeTree(ctx, scratch, ll_lengths, d_lengths,
                              i & 1, i & 2, i & 4,
-                             0, 0);
+                             0, NULL);
     if (bestsize == 0 || size < bestsize) {
       bestsize = size;
       best = i;
     }
   }
 
-  EncodeTree(scratch, ll_lengths, d_lengths,
+  EncodeTree(ctx, scratch, ll_lengths, d_lengths,
              best & 1, best & 2, best & 4,
              bp, buf);
 }
@@ -274,16 +279,17 @@ static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
 /*
 Gives the exact size of the tree, in bits, as it will be encoded in DEFLATE.
 */
-static size_t CalculateTreeSize(ZopfliKatajainenScratch* scratch,
+static size_t CalculateTreeSize(const ZopfliContext* ctx,
+                                ZopfliKatajainenScratch* scratch,
                                 const unsigned* ll_lengths,
                                 const unsigned* d_lengths) {
   size_t result = 0;
   int i;
 
   for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(scratch, ll_lengths, d_lengths,
+    size_t size = EncodeTree(ctx, scratch, ll_lengths, d_lengths,
                              i & 1, i & 2, i & 4,
-                             0, 0);
+                             0, NULL);
     if (result == 0 || size < result) result = size;
   }
 
@@ -295,7 +301,8 @@ Adds all lit/len and dist codes from the lists as huffman symbols. Does not add
 end code 256. expected_data_size is the uncompressed block size, used for
 assert, but you can set it to 0 to not do the assertion.
 */
-static void AddLZ77Data(const ZopfliLZ77Store* lz77,
+static void AddLZ77Data(const ZopfliContext* ctx,
+                        const ZopfliLZ77Store* lz77,
                         size_t lstart, size_t lend,
                         size_t expected_data_size,
                         const unsigned* ll_symbols, const unsigned* ll_lengths,
@@ -310,7 +317,7 @@ static void AddLZ77Data(const ZopfliLZ77Store* lz77,
     if (dist == 0) {
       assert(litlen < 256);
       assert(ll_lengths[litlen] > 0);
-      AddHuffmanBits(ll_symbols[litlen], ll_lengths[litlen], bp, buf);
+      AddHuffmanBits(ctx, ll_symbols[litlen], ll_lengths[litlen], bp, buf);
       testlength++;
     } else {
       unsigned lls = ZopfliGetLengthSymbol(litlen);
@@ -318,12 +325,12 @@ static void AddLZ77Data(const ZopfliLZ77Store* lz77,
       assert(litlen >= 3 && litlen <= 288);
       assert(ll_lengths[lls] > 0);
       assert(d_lengths[ds] > 0);
-      AddHuffmanBits(ll_symbols[lls], ll_lengths[lls], bp, buf);
-      AddBits(ZopfliGetLengthExtraBitsValue(litlen),
+      AddHuffmanBits(ctx, ll_symbols[lls], ll_lengths[lls], bp, buf);
+      AddBits(ctx, ZopfliGetLengthExtraBitsValue(litlen),
               ZopfliGetLengthExtraBits(litlen),
               bp, buf);
-      AddHuffmanBits(d_symbols[ds], d_lengths[ds], bp, buf);
-      AddBits(ZopfliGetDistExtraBitsValue(dist),
+      AddHuffmanBits(ctx, d_symbols[ds], d_lengths[ds], bp, buf);
+      AddBits(ctx, ZopfliGetDistExtraBitsValue(dist),
               ZopfliGetDistExtraBits(dist),
               bp, buf);
       testlength += litlen;
@@ -427,7 +434,8 @@ Changes the population counts in a way that the consequent Huffman tree
 compression, especially its rle-part, will be more likely to compress this data
 more efficiently. length contains the size of the histogram.
 */
-void OptimizeHuffmanForRle(int length, size_t* counts) {
+void OptimizeHuffmanForRle(const ZopfliContext* ctx, int length,
+                           size_t* counts) {
   int i, k, stride;
   size_t symbol, sum, limit;
   int* good_for_rle;
@@ -445,7 +453,7 @@ void OptimizeHuffmanForRle(int length, size_t* counts) {
   }
   /* 2) Let's mark all population counts that already can be encoded
   with an rle code.*/
-  good_for_rle = (int*)ZopfliRealloc(NULL, (unsigned)length * sizeof(int));
+  good_for_rle = (int*)ZopfliRealloc(ctx, NULL, (unsigned)length * sizeof(int));
   for (i = 0; i < length; ++i) good_for_rle[i] = 0;
 
   /* Let's not spoil any of the existing good rle codes.
@@ -510,7 +518,7 @@ void OptimizeHuffmanForRle(int length, size_t* counts) {
     }
   }
 
-  ZopfliRealloc(good_for_rle, 0);
+  ZopfliRealloc(ctx, good_for_rle, 0);
 }
 
 /*
@@ -519,7 +527,7 @@ uses it, otherwise keeps the original. Returns size of encoded tree and data in
 bits, not including the 3-bit block header.
 */
 static uint32_t TryOptimizeHuffmanForRle(
-    ZopfliKatajainenScratch* scratch,
+    const ZopfliContext* ctx, ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend,
     const size_t* ll_counts, const size_t* d_counts,
     unsigned* ll_lengths, unsigned* d_lengths) {
@@ -532,21 +540,22 @@ static uint32_t TryOptimizeHuffmanForRle(
   uint32_t treesize2;
   uint32_t datasize2;
 
-  treesize = (uint32_t)CalculateTreeSize(scratch, ll_lengths, d_lengths);
+  treesize = (uint32_t)CalculateTreeSize(ctx, scratch, ll_lengths, d_lengths);
   datasize = (uint32_t)CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
       ll_lengths, d_lengths, lz77, lstart, lend);
 
   memcpy(ll_counts2, ll_counts, sizeof(ll_counts2));
   memcpy(d_counts2, d_counts, sizeof(d_counts2));
-  OptimizeHuffmanForRle(ZOPFLI_NUM_LL, ll_counts2);
-  OptimizeHuffmanForRle(ZOPFLI_NUM_D, d_counts2);
-  ZopfliCalculateBitLengthsScratch(scratch, ll_counts2, ZOPFLI_NUM_LL, 15,
+  OptimizeHuffmanForRle(ctx, ZOPFLI_NUM_LL, ll_counts2);
+  OptimizeHuffmanForRle(ctx, ZOPFLI_NUM_D, d_counts2);
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, ll_counts2, ZOPFLI_NUM_LL, 15,
                                    ll_lengths2);
-  ZopfliCalculateBitLengthsScratch(scratch, d_counts2, ZOPFLI_NUM_D, 15,
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, d_counts2, ZOPFLI_NUM_D, 15,
                                    d_lengths2);
   PatchDistanceCodesForBuggyDecoders(d_lengths2);
 
-  treesize2 = (uint32_t)CalculateTreeSize(scratch, ll_lengths2, d_lengths2);
+  treesize2 = (uint32_t)CalculateTreeSize(ctx, scratch, ll_lengths2,
+                                          d_lengths2);
   datasize2 = (uint32_t)CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
       ll_lengths2, d_lengths2, lz77, lstart, lend);
 
@@ -565,7 +574,8 @@ symbols to have smallest output size. This are not necessarily the ideal Huffman
 bit lengths. Returns size of encoded tree and data in bits, not including the
 3-bit block header.
 */
-static uint32_t GetDynamicLengths(ZopfliKatajainenScratch* scratch,
+static uint32_t GetDynamicLengths(const ZopfliContext* ctx,
+                                ZopfliKatajainenScratch* scratch,
                                 const ZopfliLZ77Store* lz77,
                                 size_t lstart, size_t lend,
                                 unsigned* ll_lengths, unsigned* d_lengths) {
@@ -574,16 +584,17 @@ static uint32_t GetDynamicLengths(ZopfliKatajainenScratch* scratch,
 
   ZopfliLZ77GetHistogram(lz77, lstart, lend, ll_counts, d_counts);
   ll_counts[256] = 1;  /* End symbol. */
-  ZopfliCalculateBitLengthsScratch(scratch, ll_counts, ZOPFLI_NUM_LL, 15,
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, ll_counts, ZOPFLI_NUM_LL, 15,
                                    ll_lengths);
-  ZopfliCalculateBitLengthsScratch(scratch, d_counts, ZOPFLI_NUM_D, 15,
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, d_counts, ZOPFLI_NUM_D, 15,
                                    d_lengths);
   PatchDistanceCodesForBuggyDecoders(d_lengths);
-  return TryOptimizeHuffmanForRle(
-      scratch, lz77, lstart, lend, ll_counts, d_counts, ll_lengths, d_lengths);
+  return TryOptimizeHuffmanForRle(ctx, scratch, lz77, lstart, lend, ll_counts,
+                                  d_counts, ll_lengths, d_lengths);
 }
 
-uint32_t ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
+uint32_t ZopfliCalculateBlockSizeScratch(const ZopfliContext* ctx,
+                                       ZopfliKatajainenScratch* scratch,
                                        const ZopfliLZ77Store* lz77,
                                        size_t lstart, size_t lend, int btype) {
   unsigned ll_lengths[ZOPFLI_NUM_LL];
@@ -604,7 +615,7 @@ uint32_t ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
     result += (uint32_t)CalculateBlockSymbolSize(
         ll_lengths, d_lengths, lz77, lstart, lend);
   } else {
-    result += GetDynamicLengths(scratch, lz77, lstart, lend,
+    result += GetDynamicLengths(ctx, scratch, lz77, lstart, lend,
                                 ll_lengths, d_lengths);
   }
 
@@ -616,22 +627,23 @@ uint32_t ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
   ZopfliKatajainenScratch scratch;
   uint32_t result;
   ZopfliInitKatajainenScratch(&scratch);
-  result = ZopfliCalculateBlockSizeScratch(&scratch, lz77, lstart, lend, btype);
-  ZopfliCleanKatajainenScratch(&scratch);
+  result =
+      ZopfliCalculateBlockSizeScratch(NULL, &scratch, lz77, lstart, lend, btype);
+  ZopfliCleanKatajainenScratch(NULL, &scratch);
   return result;
 }
 
 uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
-    ZopfliKatajainenScratch* scratch,
+    const ZopfliContext* ctx, ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend) {
   uint32_t uncompressedcost =
-      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
+      ZopfliCalculateBlockSizeScratch(ctx, scratch, lz77, lstart, lend, 0);
   /* Don't do the expensive fixed cost calculation for larger blocks that are
      unlikely to use it. */
   uint32_t fixedcost = (lz77->size > 1000) ? uncompressedcost :
-      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 1);
+      ZopfliCalculateBlockSizeScratch(ctx, scratch, lz77, lstart, lend, 1);
   uint32_t dyncost =
-      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
+      ZopfliCalculateBlockSizeScratch(ctx, scratch, lz77, lstart, lend, 2);
   return (uncompressedcost < fixedcost && uncompressedcost < dyncost)
       ? uncompressedcost
       : (fixedcost < dyncost ? fixedcost : dyncost);
@@ -642,19 +654,19 @@ uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
   ZopfliKatajainenScratch scratch;
   uint32_t result;
   ZopfliInitKatajainenScratch(&scratch);
-  result = ZopfliCalculateBlockSizeAutoTypeScratch(&scratch, lz77, lstart, lend);
-  ZopfliCleanKatajainenScratch(&scratch);
+  result = ZopfliCalculateBlockSizeAutoTypeScratch(NULL, &scratch, lz77, lstart,
+                                                   lend);
+  ZopfliCleanKatajainenScratch(NULL, &scratch);
   return result;
 }
 
 /* Since an uncompressed block can be max 65535 in size, it actually adds
 multible blocks if needed. */
-static void AddNonCompressedBlock(const ZopfliOptions* options, int final,
+static void AddNonCompressedBlock(const ZopfliContext* ctx, int final,
                                   const uint8_t* in, size_t instart,
                                   size_t inend,
                                   uint8_t* bp, ZopfliBuf* buf) {
   size_t pos = instart;
-  (void)options;
   for (;;) {
     size_t i;
     uint16_t blocksize = 65535;
@@ -666,21 +678,21 @@ static void AddNonCompressedBlock(const ZopfliOptions* options, int final,
 
     nlen = ~blocksize;
 
-    AddBit(final && currentfinal, bp, buf);
+    AddBit(ctx, final && currentfinal, bp, buf);
     /* BTYPE 00 */
-    AddBit(0, bp, buf);
-    AddBit(0, bp, buf);
+    AddBit(ctx, 0, bp, buf);
+    AddBit(ctx, 0, bp, buf);
 
     /* Any bits of input up to the next byte boundary are ignored. */
     *bp = 0;
 
-    ZopfliBufPush(buf, (uint8_t)(blocksize & 0xff));
-    ZopfliBufPush(buf, (uint8_t)((blocksize >> 8) & 0xff));
-    ZopfliBufPush(buf, (uint8_t)(nlen & 0xff));
-    ZopfliBufPush(buf, (uint8_t)((nlen >> 8) & 0xff));
+    ZopfliBufPush(ctx, buf, (uint8_t)(blocksize & 0xff));
+    ZopfliBufPush(ctx, buf, (uint8_t)((blocksize >> 8) & 0xff));
+    ZopfliBufPush(ctx, buf, (uint8_t)(nlen & 0xff));
+    ZopfliBufPush(ctx, buf, (uint8_t)((nlen >> 8) & 0xff));
 
     for (i = 0; i < blocksize; i++) {
-      ZopfliBufPush(buf, in[pos + i]);
+      ZopfliBufPush(ctx, buf, in[pos + i]);
     }
 
     if (currentfinal) break;
@@ -705,8 +717,9 @@ bp: output bit pointer
 out: dynamic output array to append to
 outsize: dynamic output array size
 */
-static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
-                         const ZopfliOptions* options, int btype, int final,
+static void AddLZ77Block(const ZopfliContext* ctx,
+                         ZopfliKatajainenScratch* scratch,
+                         int btype, int final,
                          const ZopfliLZ77Store* lz77,
                          size_t lstart, size_t lend,
                          size_t expected_data_size,
@@ -723,14 +736,14 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
     size_t length = ZopfliLZ77GetByteRange(lz77, lstart, lend);
     size_t pos = lstart == lend ? 0 : lz77->pos[lstart];
     size_t end = pos + length;
-    AddNonCompressedBlock(options, final,
+    AddNonCompressedBlock(ctx, final,
                           lz77->data, pos, end, bp, buf);
     return;
   }
 
-  AddBit(final, bp, buf);
-  AddBit(btype & 1, bp, buf);
-  AddBit((btype & 2) >> 1, bp, buf);
+  AddBit(ctx, final, bp, buf);
+  AddBit(ctx, btype & 1, bp, buf);
+  AddBit(ctx, (btype & 2) >> 1, bp, buf);
 
   if (btype == 1) {
     /* Fixed block. */
@@ -740,47 +753,47 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
     size_t detect_tree_size;
     assert(btype == 2);
 
-    GetDynamicLengths(scratch, lz77, lstart, lend, ll_lengths, d_lengths);
+    GetDynamicLengths(ctx, scratch, lz77, lstart, lend, ll_lengths, d_lengths);
 
     detect_tree_size = buf->size;
-    AddDynamicTree(scratch, ll_lengths, d_lengths, bp, buf);
-    if (options->verbose) {
+    AddDynamicTree(ctx, scratch, ll_lengths, d_lengths, bp, buf);
+    if (ctx->options->verbose) {
       fprintf(stderr, "treesize: %zu\n", buf->size - detect_tree_size);
     }
   }
 
-  ZopfliLengthsToSymbols(ll_lengths, ZOPFLI_NUM_LL, 15, ll_symbols);
-  ZopfliLengthsToSymbols(d_lengths, ZOPFLI_NUM_D, 15, d_symbols);
+  ZopfliLengthsToSymbols(ctx, ll_lengths, ZOPFLI_NUM_LL, 15, ll_symbols);
+  ZopfliLengthsToSymbols(ctx, d_lengths, ZOPFLI_NUM_D, 15, d_symbols);
 
   detect_block_size = buf->size;
-  AddLZ77Data(lz77, lstart, lend, expected_data_size,
+  AddLZ77Data(ctx, lz77, lstart, lend, expected_data_size,
               ll_symbols, ll_lengths, d_symbols, d_lengths,
               bp, buf);
   /* End symbol. */
-  AddHuffmanBits(ll_symbols[256], ll_lengths[256], bp, buf);
+  AddHuffmanBits(ctx, ll_symbols[256], ll_lengths[256], bp, buf);
 
   for (i = lstart; i < lend; i++) {
     uncompressed_size += lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
   }
   compressed_size = buf->size - detect_block_size;
-  if (options->verbose) {
+  if (ctx->options->verbose) {
     fprintf(stderr, "compressed block size: %zu (%zuk) (unc: %zu)\n",
            compressed_size, compressed_size / 1024, uncompressed_size);
   }
 }
 
-static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
-                                 const ZopfliOptions* options, int final,
+static void AddLZ77BlockAutoType(const ZopfliContext* ctx,
+                                 ZopfliKatajainenScratch* scratch, int final,
                                  const ZopfliLZ77Store* lz77,
                                  size_t lstart, size_t lend,
                                  size_t expected_data_size,
                                  uint8_t* bp, ZopfliBuf* buf) {
   uint32_t uncompressedcost =
-      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
+      ZopfliCalculateBlockSizeScratch(ctx, scratch, lz77, lstart, lend, 0);
   uint32_t fixedcost =
-      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 1);
+      ZopfliCalculateBlockSizeScratch(ctx, scratch, lz77, lstart, lend, 1);
   uint32_t dyncost =
-      ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 2);
+      ZopfliCalculateBlockSizeScratch(ctx, scratch, lz77, lstart, lend, 2);
 
   /* Whether to perform the expensive calculation of creating an optimal block
   with fixed huffman tree to check if it is smaller. */
@@ -790,9 +803,9 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
   ZopfliLZ77Store fixedstore;
   if (lstart == lend) {
     /* Smallest empty block is represented by fixed block */
-    AddBits(final, 1, bp, buf);
-    AddBits(1, 2, bp, buf);  /* btype 01 */
-    AddBits(0, 7, bp, buf);  /* end symbol has code 0000000 */
+    AddBits(ctx, final, 1, bp, buf);
+    AddBits(ctx, 1, 2, bp, buf);  /* btype 01 */
+    AddBits(ctx, 0, 7, bp, buf);  /* end symbol has code 0000000 */
     return;
   }
   ZopfliInitLZ77Store(lz77->data, &fixedstore);
@@ -802,30 +815,30 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
     size_t inend = instart + ZopfliLZ77GetByteRange(lz77, lstart, lend);
 
     ZopfliBlockState s;
-    ZopfliInitBlockState(options, instart, inend, 1, &s);
+    ZopfliInitBlockState(ctx, instart, inend, 1, &s);
     ZopfliLZ77OptimalFixed(&s, lz77->data, instart, inend, &fixedstore);
-    fixedcost = ZopfliCalculateBlockSizeScratch(scratch, &fixedstore, 0,
+    fixedcost = ZopfliCalculateBlockSizeScratch(ctx, scratch, &fixedstore, 0,
                                                 fixedstore.size, 1);
     ZopfliCleanBlockState(&s);
   }
 
   if (uncompressedcost < fixedcost && uncompressedcost < dyncost) {
-    AddLZ77Block(scratch, options, 0, final, lz77, lstart, lend,
+    AddLZ77Block(ctx, scratch, 0, final, lz77, lstart, lend,
                  expected_data_size, bp, buf);
   } else if (fixedcost < dyncost) {
     if (expensivefixed) {
-      AddLZ77Block(scratch, options, 1, final, &fixedstore, 0, fixedstore.size,
+      AddLZ77Block(ctx, scratch, 1, final, &fixedstore, 0, fixedstore.size,
                    expected_data_size, bp, buf);
     } else {
-      AddLZ77Block(scratch, options, 1, final, lz77, lstart, lend,
+      AddLZ77Block(ctx, scratch, 1, final, lz77, lstart, lend,
                    expected_data_size, bp, buf);
     }
   } else {
-    AddLZ77Block(scratch, options, 2, final, lz77, lstart, lend,
+    AddLZ77Block(ctx, scratch, 2, final, lz77, lstart, lend,
                  expected_data_size, bp, buf);
   }
 
-  ZopfliCleanLZ77Store(&fixedstore);
+  ZopfliCleanLZ77Store(ctx, &fixedstore);
 }
 
 /*
@@ -837,14 +850,15 @@ previous bytes are used as the initial dictionary for LZ77.
 This function will usually output multiple deflate blocks. If final is 1, then
 the final bit will be set on the last block.
 */
-static void DeflatePart(const ZopfliOptions* options, int btype, int final,
+static void DeflatePart(const ZopfliContext* ctx, int btype, int final,
                         const uint8_t* in, size_t instart, size_t inend,
                         uint8_t* bp, ZopfliBuf* buf) {
+  const ZopfliOptions* options = ctx->options;
   size_t i;
   /* byte coordinates rather than lz77 index */
-  size_t* splitpoints_uncompressed = 0;
+  size_t* splitpoints_uncompressed = NULL;
   size_t npoints = 0;
-  size_t* splitpoints = 0;
+  size_t* splitpoints = NULL;
   uint32_t totalcost = 0;
   ZopfliLZ77Store lz77;
   /* Reused across this part's block-size evaluations and final encoding. */
@@ -854,20 +868,20 @@ static void DeflatePart(const ZopfliOptions* options, int btype, int final,
   given, then however it forces that one. Neither of the lesser types needs
   block splitting as they have no dynamic huffman trees. */
   if (btype == 0) {
-    AddNonCompressedBlock(options, final, in, instart, inend, bp, buf);
+    AddNonCompressedBlock(ctx, final, in, instart, inend, bp, buf);
     return;
   } else if (btype == 1) {
     ZopfliLZ77Store store;
     ZopfliBlockState s;
     ZopfliInitLZ77Store(in, &store);
-    ZopfliInitBlockState(options, instart, inend, 1, &s);
+    ZopfliInitBlockState(ctx, instart, inend, 1, &s);
 
     ZopfliLZ77OptimalFixed(&s, in, instart, inend, &store);
-    AddLZ77Block(&s.katascratch, options, btype, final, &store, 0, store.size, 0,
+    AddLZ77Block(ctx, &s.katascratch, btype, final, &store, 0, store.size, 0,
                  bp, buf);
 
     ZopfliCleanBlockState(&s);
-    ZopfliCleanLZ77Store(&store);
+    ZopfliCleanLZ77Store(ctx, &store);
     return;
   }
 
@@ -877,7 +891,8 @@ static void DeflatePart(const ZopfliOptions* options, int btype, int final,
     ZopfliBlockSplit(options, in, instart, inend,
                      options->blocksplittingmax,
                      &splitpoints_uncompressed, &npoints);
-    splitpoints = (size_t*)ZopfliRealloc(NULL, sizeof(*splitpoints) * npoints);
+    splitpoints =
+        (size_t*)ZopfliRealloc(ctx, NULL, sizeof(*splitpoints) * npoints);
   }
 
   ZopfliInitLZ77Store(in, &lz77);
@@ -888,21 +903,21 @@ static void DeflatePart(const ZopfliOptions* options, int btype, int final,
     ZopfliBlockState s;
     ZopfliLZ77Store store;
     ZopfliInitLZ77Store(in, &store);
-    ZopfliInitBlockState(options, start, end, 1, &s);
+    ZopfliInitBlockState(ctx, start, end, 1, &s);
     ZopfliLZ77Optimal(&s, in, start, end, options->numiterations, &store);
-    totalcost += ZopfliCalculateBlockSizeAutoTypeScratch(&katascratch, &store,
-                                                         0, store.size);
+    totalcost += ZopfliCalculateBlockSizeAutoTypeScratch(ctx, &katascratch,
+                                                         &store, 0, store.size);
 
-    ZopfliAppendLZ77Store(&store, &lz77);
+    ZopfliAppendLZ77Store(ctx, &store, &lz77);
     if (i < npoints) splitpoints[i] = lz77.size;
 
     ZopfliCleanBlockState(&s);
-    ZopfliCleanLZ77Store(&store);
+    ZopfliCleanLZ77Store(ctx, &store);
   }
 
   /* Second block splitting attempt */
   if (options->blocksplitting && npoints > 1) {
-    size_t* splitpoints2 = 0;
+    size_t* splitpoints2 = NULL;
     size_t npoints2 = 0;
     uint32_t totalcost2 = 0;
 
@@ -912,31 +927,31 @@ static void DeflatePart(const ZopfliOptions* options, int btype, int final,
     for (i = 0; i <= npoints2; i++) {
       size_t start = i == 0 ? 0 : splitpoints2[i - 1];
       size_t end = i == npoints2 ? lz77.size : splitpoints2[i];
-      totalcost2 += ZopfliCalculateBlockSizeAutoTypeScratch(&katascratch, &lz77,
-                                                            start, end);
+      totalcost2 += ZopfliCalculateBlockSizeAutoTypeScratch(ctx, &katascratch,
+                                                            &lz77, start, end);
     }
 
     if (totalcost2 < totalcost) {
-      ZopfliRealloc(splitpoints, 0);
+      ZopfliRealloc(ctx, splitpoints, 0);
       splitpoints = splitpoints2;
       npoints = npoints2;
     } else {
-      ZopfliRealloc(splitpoints2, 0);
+      ZopfliRealloc(ctx, splitpoints2, 0);
     }
   }
 
   for (i = 0; i <= npoints; i++) {
     size_t start = i == 0 ? 0 : splitpoints[i - 1];
     size_t end = i == npoints ? lz77.size : splitpoints[i];
-    AddLZ77BlockAutoType(&katascratch, options, i == npoints && final,
+    AddLZ77BlockAutoType(ctx, &katascratch, i == npoints && final,
                          &lz77, start, end, 0,
                          bp, buf);
   }
 
-  ZopfliCleanKatajainenScratch(&katascratch);
-  ZopfliCleanLZ77Store(&lz77);
-  ZopfliRealloc(splitpoints, 0);
-  ZopfliRealloc(splitpoints_uncompressed, 0);
+  ZopfliCleanKatajainenScratch(ctx, &katascratch);
+  ZopfliCleanLZ77Store(ctx, &lz77);
+  ZopfliRealloc(ctx, splitpoints, 0);
+  ZopfliRealloc(ctx, splitpoints_uncompressed, 0);
 }
 
 /* Adopts (out, outsize) into a ZopfliBuf, runs f, then publishes back. The
@@ -946,11 +961,13 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
                        const uint8_t* in, size_t instart, size_t inend,
                        uint8_t* bp, uint8_t** out,
                        size_t* outsize) {
+  ZopfliContext ctx;
   ZopfliBuf buf;
+  ctx.options = options;
   buf.data = *out;
   buf.size = *outsize;
   buf.cap = *outsize;
-  DeflatePart(options, btype, final, in, instart, inend, bp, &buf);
+  DeflatePart(&ctx, btype, final, in, instart, inend, bp, &buf);
   *out = buf.data;
   *outsize = buf.size;
 }
@@ -974,6 +991,8 @@ void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
                       uint8_t* bp, ZopfliBuf* buf) {
   size_t offset = buf->size;
   ZopfliOptions opts = *options;
+  ZopfliContext ctx;
+  ctx.options = &opts;
   assert(opts.numiterations >= 0);
   if (opts.numiterations == 0) opts.numiterations = AutoIterations(insize);
   if (opts.verbose && options->numiterations == 0) {
@@ -994,7 +1013,7 @@ void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
     int masterfinal = (i + mbs >= insize);
     int final2 = final && masterfinal;
     size_t size = masterfinal ? insize - i : mbs;
-    DeflatePart(&opts, btype, final2, in, i, i + size, bp, buf);
+    DeflatePart(&ctx, btype, final2, in, i, i + size, bp, buf);
     i += size;
   } while (i < insize);
   }

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -624,12 +624,13 @@ uint32_t ZopfliCalculateBlockSizeScratch(const ZopfliContext* ctx,
 
 uint32_t ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
                                 size_t lstart, size_t lend, int btype) {
+  const ZopfliContext* ctx = ZopfliDefaultContext();
   ZopfliKatajainenScratch scratch;
   uint32_t result;
   ZopfliInitKatajainenScratch(&scratch);
   result =
-      ZopfliCalculateBlockSizeScratch(NULL, &scratch, lz77, lstart, lend, btype);
-  ZopfliCleanKatajainenScratch(NULL, &scratch);
+      ZopfliCalculateBlockSizeScratch(ctx, &scratch, lz77, lstart, lend, btype);
+  ZopfliCleanKatajainenScratch(ctx, &scratch);
   return result;
 }
 
@@ -651,12 +652,13 @@ uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
 
 uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
                                         size_t lstart, size_t lend) {
+  const ZopfliContext* ctx = ZopfliDefaultContext();
   ZopfliKatajainenScratch scratch;
   uint32_t result;
   ZopfliInitKatajainenScratch(&scratch);
-  result = ZopfliCalculateBlockSizeAutoTypeScratch(NULL, &scratch, lz77, lstart,
+  result = ZopfliCalculateBlockSizeAutoTypeScratch(ctx, &scratch, lz77, lstart,
                                                    lend);
-  ZopfliCleanKatajainenScratch(NULL, &scratch);
+  ZopfliCleanKatajainenScratch(ctx, &scratch);
   return result;
 }
 
@@ -757,7 +759,7 @@ static void AddLZ77Block(const ZopfliContext* ctx,
 
     detect_tree_size = buf->size;
     AddDynamicTree(ctx, scratch, ll_lengths, d_lengths, bp, buf);
-    if (ctx->options->verbose) {
+    if (ctx->options.verbose) {
       fprintf(stderr, "treesize: %zu\n", buf->size - detect_tree_size);
     }
   }
@@ -776,7 +778,7 @@ static void AddLZ77Block(const ZopfliContext* ctx,
     uncompressed_size += lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
   }
   compressed_size = buf->size - detect_block_size;
-  if (ctx->options->verbose) {
+  if (ctx->options.verbose) {
     fprintf(stderr, "compressed block size: %zu (%zuk) (unc: %zu)\n",
            compressed_size, compressed_size / 1024, uncompressed_size);
   }
@@ -853,7 +855,7 @@ the final bit will be set on the last block.
 static void DeflatePart(const ZopfliContext* ctx, int btype, int final,
                         const uint8_t* in, size_t instart, size_t inend,
                         uint8_t* bp, ZopfliBuf* buf) {
-  const ZopfliOptions* options = ctx->options;
+  const ZopfliOptions* options = &ctx->options;
   size_t i;
   /* byte coordinates rather than lz77 index */
   size_t* splitpoints_uncompressed = NULL;
@@ -963,7 +965,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
                        size_t* outsize) {
   ZopfliContext ctx;
   ZopfliBuf buf;
-  ctx.options = options;
+  ctx.options = *options;
   buf.data = *out;
   buf.size = *outsize;
   buf.cap = *outsize;
@@ -990,14 +992,14 @@ void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
                       const uint8_t* in, size_t insize,
                       uint8_t* bp, ZopfliBuf* buf) {
   size_t offset = buf->size;
-  ZopfliOptions opts = *options;
   ZopfliContext ctx;
-  ctx.options = &opts;
-  assert(opts.numiterations >= 0);
-  if (opts.numiterations == 0) opts.numiterations = AutoIterations(insize);
-  if (opts.verbose && options->numiterations == 0) {
+  ctx.options = *options;
+  assert(ctx.options.numiterations >= 0);
+  if (ctx.options.numiterations == 0)
+    ctx.options.numiterations = AutoIterations(insize);
+  if (ctx.options.verbose && options->numiterations == 0) {
     fprintf(stderr, "Auto iterations: %d (input %zu bytes)\n",
-            opts.numiterations, insize);
+            ctx.options.numiterations, insize);
   }
   {
   /* Effective master block size. Clamp to ZOPFLI_COST_MAX_BLOCK_SIZE (and use

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -37,21 +37,20 @@ Given the value of bp and the amount of bytes, the amount of bits represented
 is not simply bytesize * 8 + bp because even representing one bit requires a
 whole byte. It is: (bp == 0) ? (bytesize * 8) : ((bytesize - 1) * 8 + bp)
 */
-static void AddBit(int bit,
-                   unsigned char* bp, unsigned char** out, size_t* outsize) {
-  if (*bp == 0) ZOPFLI_APPEND_DATA(0, out, outsize);
-  (*out)[*outsize - 1] |= bit << *bp;
+static void AddBit(int bit, uint8_t* bp, ZopfliBuf* buf) {
+  if (*bp == 0) ZopfliBufPush(buf, 0);
+  buf->data[buf->size - 1] |= bit << *bp;
   *bp = (*bp + 1) & 7;
 }
 
 static void AddBits(unsigned symbol, unsigned length,
-                    unsigned char* bp, unsigned char** out, size_t* outsize) {
+                    uint8_t* bp, ZopfliBuf* buf) {
   /* TODO(lode): make more efficient (add more bits at once). */
   unsigned i;
   for (i = 0; i < length; i++) {
     unsigned bit = (symbol >> i) & 1;
-    if (*bp == 0) ZOPFLI_APPEND_DATA(0, out, outsize);
-    (*out)[*outsize - 1] |= bit << *bp;
+    if (*bp == 0) ZopfliBufPush(buf, 0);
+    buf->data[buf->size - 1] |= bit << *bp;
     *bp = (*bp + 1) & 7;
   }
 }
@@ -61,14 +60,13 @@ Adds bits, like AddBits, but the order is inverted. The deflate specification
 uses both orders in one standard.
 */
 static void AddHuffmanBits(unsigned symbol, unsigned length,
-                           unsigned char* bp, unsigned char** out,
-                           size_t* outsize) {
+                           uint8_t* bp, ZopfliBuf* buf) {
   /* TODO(lode): make more efficient (add more bits at once). */
   unsigned i;
   for (i = 0; i < length; i++) {
     unsigned bit = (symbol >> (length - i - 1)) & 1;
-    if (*bp == 0) ZOPFLI_APPEND_DATA(0, out, outsize);
-    (*out)[*outsize - 1] |= bit << *bp;
+    if (*bp == 0) ZopfliBufPush(buf, 0);
+    buf->data[buf->size - 1] |= bit << *bp;
     *bp = (*bp + 1) & 7;
   }
 }
@@ -108,8 +106,7 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
                          const unsigned* ll_lengths,
                          const unsigned* d_lengths,
                          int use_16, int use_17, int use_18,
-                         unsigned char* bp,
-                         unsigned char** out, size_t* outsize) {
+                         uint8_t* bp, ZopfliBuf* buf) {
   unsigned lld_total;  /* Total amount of literal, length, distance codes. */
   /* Runlength encoded version of lengths of litlen and dist trees. */
   unsigned* rle = 0;
@@ -125,10 +122,10 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
   unsigned clcl[19];  /* Code length code lengths. */
   unsigned clsymbols[19];
   /* The order in which code length code lengths are encoded as per deflate. */
-  static const unsigned order[19] = {
+  static const uint8_t order[19] = {
     16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15
   };
-  int size_only = !out;
+  int size_only = !buf;
   size_t result_size = 0;
 
   for(i = 0; i < 19; i++) clcounts[i] = 0;
@@ -142,7 +139,7 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
 
   for (i = 0; i < lld_total; i++) {
     /* This is an encoding of a huffman tree, so now the length is a symbol */
-    unsigned char symbol = i < hlit2 ? ll_lengths[i] : d_lengths[i - hlit2];
+    uint8_t symbol = i < hlit2 ? ll_lengths[i] : d_lengths[i - hlit2];
     unsigned count = 1;
     if(use_16 || (symbol == 0 && (use_17 || use_18))) {
       for (j = i + 1; j < lld_total && symbol ==
@@ -216,21 +213,21 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
   while (hclen > 0 && clcounts[order[hclen + 4 - 1]] == 0) hclen--;
 
   if (!size_only) {
-    AddBits(hlit, 5, bp, out, outsize);
-    AddBits(hdist, 5, bp, out, outsize);
-    AddBits(hclen, 4, bp, out, outsize);
+    AddBits(hlit, 5, bp, buf);
+    AddBits(hdist, 5, bp, buf);
+    AddBits(hclen, 4, bp, buf);
 
     for (i = 0; i < hclen + 4; i++) {
-      AddBits(clcl[order[i]], 3, bp, out, outsize);
+      AddBits(clcl[order[i]], 3, bp, buf);
     }
 
     for (i = 0; i < rle_size; i++) {
       unsigned symbol = clsymbols[rle[i]];
-      AddHuffmanBits(symbol, clcl[rle[i]], bp, out, outsize);
+      AddHuffmanBits(symbol, clcl[rle[i]], bp, buf);
       /* Extra bits. */
-      if (rle[i] == 16) AddBits(rle_bits[i], 2, bp, out, outsize);
-      else if (rle[i] == 17) AddBits(rle_bits[i], 3, bp, out, outsize);
-      else if (rle[i] == 18) AddBits(rle_bits[i], 7, bp, out, outsize);
+      if (rle[i] == 16) AddBits(rle_bits[i], 2, bp, buf);
+      else if (rle[i] == 17) AddBits(rle_bits[i], 3, bp, buf);
+      else if (rle[i] == 18) AddBits(rle_bits[i], 7, bp, buf);
     }
   }
 
@@ -245,8 +242,8 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
   result_size += clcounts[18] * 7;
 
   /* Note: in case of "size_only" these are null pointers so no effect. */
-  free(rle);
-  free(rle_bits);
+  ZopfliRealloc(rle, 0);
+  ZopfliRealloc(rle_bits, 0);
 
   return result_size;
 }
@@ -254,8 +251,7 @@ static size_t EncodeTree(ZopfliKatajainenScratch* scratch,
 static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
                            const unsigned* ll_lengths,
                            const unsigned* d_lengths,
-                           unsigned char* bp,
-                           unsigned char** out, size_t* outsize) {
+                           uint8_t* bp, ZopfliBuf* buf) {
   int i;
   int best = 0;
   size_t bestsize = 0;
@@ -263,7 +259,7 @@ static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
   for(i = 0; i < 8; i++) {
     size_t size = EncodeTree(scratch, ll_lengths, d_lengths,
                              i & 1, i & 2, i & 4,
-                             0, 0, 0);
+                             0, 0);
     if (bestsize == 0 || size < bestsize) {
       bestsize = size;
       best = i;
@@ -272,7 +268,7 @@ static void AddDynamicTree(ZopfliKatajainenScratch* scratch,
 
   EncodeTree(scratch, ll_lengths, d_lengths,
              best & 1, best & 2, best & 4,
-             bp, out, outsize);
+             bp, buf);
 }
 
 /*
@@ -287,7 +283,7 @@ static size_t CalculateTreeSize(ZopfliKatajainenScratch* scratch,
   for(i = 0; i < 8; i++) {
     size_t size = EncodeTree(scratch, ll_lengths, d_lengths,
                              i & 1, i & 2, i & 4,
-                             0, 0, 0);
+                             0, 0);
     if (result == 0 || size < result) result = size;
   }
 
@@ -304,8 +300,7 @@ static void AddLZ77Data(const ZopfliLZ77Store* lz77,
                         size_t expected_data_size,
                         const unsigned* ll_symbols, const unsigned* ll_lengths,
                         const unsigned* d_symbols, const unsigned* d_lengths,
-                        unsigned char* bp,
-                        unsigned char** out, size_t* outsize) {
+                        uint8_t* bp, ZopfliBuf* buf) {
   size_t testlength = 0;
   size_t i;
 
@@ -315,7 +310,7 @@ static void AddLZ77Data(const ZopfliLZ77Store* lz77,
     if (dist == 0) {
       assert(litlen < 256);
       assert(ll_lengths[litlen] > 0);
-      AddHuffmanBits(ll_symbols[litlen], ll_lengths[litlen], bp, out, outsize);
+      AddHuffmanBits(ll_symbols[litlen], ll_lengths[litlen], bp, buf);
       testlength++;
     } else {
       unsigned lls = ZopfliGetLengthSymbol(litlen);
@@ -323,14 +318,14 @@ static void AddLZ77Data(const ZopfliLZ77Store* lz77,
       assert(litlen >= 3 && litlen <= 288);
       assert(ll_lengths[lls] > 0);
       assert(d_lengths[ds] > 0);
-      AddHuffmanBits(ll_symbols[lls], ll_lengths[lls], bp, out, outsize);
+      AddHuffmanBits(ll_symbols[lls], ll_lengths[lls], bp, buf);
       AddBits(ZopfliGetLengthExtraBitsValue(litlen),
               ZopfliGetLengthExtraBits(litlen),
-              bp, out, outsize);
-      AddHuffmanBits(d_symbols[ds], d_lengths[ds], bp, out, outsize);
+              bp, buf);
+      AddHuffmanBits(d_symbols[ds], d_lengths[ds], bp, buf);
       AddBits(ZopfliGetDistExtraBitsValue(dist),
               ZopfliGetDistExtraBits(dist),
-              bp, out, outsize);
+              bp, buf);
       testlength += litlen;
     }
   }
@@ -450,7 +445,7 @@ void OptimizeHuffmanForRle(int length, size_t* counts) {
   }
   /* 2) Let's mark all population counts that already can be encoded
   with an rle code.*/
-  good_for_rle = (int*)malloc((unsigned)length * sizeof(int));
+  good_for_rle = (int*)ZopfliRealloc(NULL, (unsigned)length * sizeof(int));
   for (i = 0; i < length; ++i) good_for_rle[i] = 0;
 
   /* Let's not spoil any of the existing good rle codes.
@@ -515,7 +510,7 @@ void OptimizeHuffmanForRle(int length, size_t* counts) {
     }
   }
 
-  free(good_for_rle);
+  ZopfliRealloc(good_for_rle, 0);
 }
 
 /*
@@ -655,38 +650,37 @@ uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
 /* Since an uncompressed block can be max 65535 in size, it actually adds
 multible blocks if needed. */
 static void AddNonCompressedBlock(const ZopfliOptions* options, int final,
-                                  const unsigned char* in, size_t instart,
+                                  const uint8_t* in, size_t instart,
                                   size_t inend,
-                                  unsigned char* bp,
-                                  unsigned char** out, size_t* outsize) {
+                                  uint8_t* bp, ZopfliBuf* buf) {
   size_t pos = instart;
   (void)options;
   for (;;) {
     size_t i;
-    unsigned short blocksize = 65535;
-    unsigned short nlen;
+    uint16_t blocksize = 65535;
+    uint16_t nlen;
     int currentfinal;
 
-    if (pos + blocksize > inend) blocksize = (unsigned short)(inend - pos);
+    if (pos + blocksize > inend) blocksize = (uint16_t)(inend - pos);
     currentfinal = pos + blocksize >= inend;
 
     nlen = ~blocksize;
 
-    AddBit(final && currentfinal, bp, out, outsize);
+    AddBit(final && currentfinal, bp, buf);
     /* BTYPE 00 */
-    AddBit(0, bp, out, outsize);
-    AddBit(0, bp, out, outsize);
+    AddBit(0, bp, buf);
+    AddBit(0, bp, buf);
 
     /* Any bits of input up to the next byte boundary are ignored. */
     *bp = 0;
 
-    ZOPFLI_APPEND_DATA(blocksize % 256, out, outsize);
-    ZOPFLI_APPEND_DATA((blocksize / 256) % 256, out, outsize);
-    ZOPFLI_APPEND_DATA(nlen % 256, out, outsize);
-    ZOPFLI_APPEND_DATA((nlen / 256) % 256, out, outsize);
+    ZopfliBufPush(buf, (uint8_t)(blocksize & 0xff));
+    ZopfliBufPush(buf, (uint8_t)((blocksize >> 8) & 0xff));
+    ZopfliBufPush(buf, (uint8_t)(nlen & 0xff));
+    ZopfliBufPush(buf, (uint8_t)((nlen >> 8) & 0xff));
 
     for (i = 0; i < blocksize; i++) {
-      ZOPFLI_APPEND_DATA(in[pos + i], out, outsize);
+      ZopfliBufPush(buf, in[pos + i]);
     }
 
     if (currentfinal) break;
@@ -716,13 +710,12 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
                          const ZopfliLZ77Store* lz77,
                          size_t lstart, size_t lend,
                          size_t expected_data_size,
-                         unsigned char* bp,
-                         unsigned char** out, size_t* outsize) {
+                         uint8_t* bp, ZopfliBuf* buf) {
   unsigned ll_lengths[ZOPFLI_NUM_LL];
   unsigned d_lengths[ZOPFLI_NUM_D];
   unsigned ll_symbols[ZOPFLI_NUM_LL];
   unsigned d_symbols[ZOPFLI_NUM_D];
-  size_t detect_block_size = *outsize;
+  size_t detect_block_size = buf->size;
   size_t compressed_size;
   size_t uncompressed_size = 0;
   size_t i;
@@ -731,13 +724,13 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
     size_t pos = lstart == lend ? 0 : lz77->pos[lstart];
     size_t end = pos + length;
     AddNonCompressedBlock(options, final,
-                          lz77->data, pos, end, bp, out, outsize);
+                          lz77->data, pos, end, bp, buf);
     return;
   }
 
-  AddBit(final, bp, out, outsize);
-  AddBit(btype & 1, bp, out, outsize);
-  AddBit((btype & 2) >> 1, bp, out, outsize);
+  AddBit(final, bp, buf);
+  AddBit(btype & 1, bp, buf);
+  AddBit((btype & 2) >> 1, bp, buf);
 
   if (btype == 1) {
     /* Fixed block. */
@@ -749,27 +742,27 @@ static void AddLZ77Block(ZopfliKatajainenScratch* scratch,
 
     GetDynamicLengths(scratch, lz77, lstart, lend, ll_lengths, d_lengths);
 
-    detect_tree_size = *outsize;
-    AddDynamicTree(scratch, ll_lengths, d_lengths, bp, out, outsize);
+    detect_tree_size = buf->size;
+    AddDynamicTree(scratch, ll_lengths, d_lengths, bp, buf);
     if (options->verbose) {
-      fprintf(stderr, "treesize: %zu\n", *outsize - detect_tree_size);
+      fprintf(stderr, "treesize: %zu\n", buf->size - detect_tree_size);
     }
   }
 
   ZopfliLengthsToSymbols(ll_lengths, ZOPFLI_NUM_LL, 15, ll_symbols);
   ZopfliLengthsToSymbols(d_lengths, ZOPFLI_NUM_D, 15, d_symbols);
 
-  detect_block_size = *outsize;
+  detect_block_size = buf->size;
   AddLZ77Data(lz77, lstart, lend, expected_data_size,
               ll_symbols, ll_lengths, d_symbols, d_lengths,
-              bp, out, outsize);
+              bp, buf);
   /* End symbol. */
-  AddHuffmanBits(ll_symbols[256], ll_lengths[256], bp, out, outsize);
+  AddHuffmanBits(ll_symbols[256], ll_lengths[256], bp, buf);
 
   for (i = lstart; i < lend; i++) {
     uncompressed_size += lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
   }
-  compressed_size = *outsize - detect_block_size;
+  compressed_size = buf->size - detect_block_size;
   if (options->verbose) {
     fprintf(stderr, "compressed block size: %zu (%zuk) (unc: %zu)\n",
            compressed_size, compressed_size / 1024, uncompressed_size);
@@ -781,8 +774,7 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
                                  const ZopfliLZ77Store* lz77,
                                  size_t lstart, size_t lend,
                                  size_t expected_data_size,
-                                 unsigned char* bp,
-                                 unsigned char** out, size_t* outsize) {
+                                 uint8_t* bp, ZopfliBuf* buf) {
   uint32_t uncompressedcost =
       ZopfliCalculateBlockSizeScratch(scratch, lz77, lstart, lend, 0);
   uint32_t fixedcost =
@@ -798,9 +790,9 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
   ZopfliLZ77Store fixedstore;
   if (lstart == lend) {
     /* Smallest empty block is represented by fixed block */
-    AddBits(final, 1, bp, out, outsize);
-    AddBits(1, 2, bp, out, outsize);  /* btype 01 */
-    AddBits(0, 7, bp, out, outsize);  /* end symbol has code 0000000 */
+    AddBits(final, 1, bp, buf);
+    AddBits(1, 2, bp, buf);  /* btype 01 */
+    AddBits(0, 7, bp, buf);  /* end symbol has code 0000000 */
     return;
   }
   ZopfliInitLZ77Store(lz77->data, &fixedstore);
@@ -819,18 +811,18 @@ static void AddLZ77BlockAutoType(ZopfliKatajainenScratch* scratch,
 
   if (uncompressedcost < fixedcost && uncompressedcost < dyncost) {
     AddLZ77Block(scratch, options, 0, final, lz77, lstart, lend,
-                 expected_data_size, bp, out, outsize);
+                 expected_data_size, bp, buf);
   } else if (fixedcost < dyncost) {
     if (expensivefixed) {
       AddLZ77Block(scratch, options, 1, final, &fixedstore, 0, fixedstore.size,
-                   expected_data_size, bp, out, outsize);
+                   expected_data_size, bp, buf);
     } else {
       AddLZ77Block(scratch, options, 1, final, lz77, lstart, lend,
-                   expected_data_size, bp, out, outsize);
+                   expected_data_size, bp, buf);
     }
   } else {
     AddLZ77Block(scratch, options, 2, final, lz77, lstart, lend,
-                 expected_data_size, bp, out, outsize);
+                 expected_data_size, bp, buf);
   }
 
   ZopfliCleanLZ77Store(&fixedstore);
@@ -845,10 +837,9 @@ previous bytes are used as the initial dictionary for LZ77.
 This function will usually output multiple deflate blocks. If final is 1, then
 the final bit will be set on the last block.
 */
-void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
-                       const unsigned char* in, size_t instart, size_t inend,
-                       unsigned char* bp, unsigned char** out,
-                       size_t* outsize) {
+static void DeflatePart(const ZopfliOptions* options, int btype, int final,
+                        const uint8_t* in, size_t instart, size_t inend,
+                        uint8_t* bp, ZopfliBuf* buf) {
   size_t i;
   /* byte coordinates rather than lz77 index */
   size_t* splitpoints_uncompressed = 0;
@@ -863,7 +854,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
   given, then however it forces that one. Neither of the lesser types needs
   block splitting as they have no dynamic huffman trees. */
   if (btype == 0) {
-    AddNonCompressedBlock(options, final, in, instart, inend, bp, out, outsize);
+    AddNonCompressedBlock(options, final, in, instart, inend, bp, buf);
     return;
   } else if (btype == 1) {
     ZopfliLZ77Store store;
@@ -873,7 +864,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
 
     ZopfliLZ77OptimalFixed(&s, in, instart, inend, &store);
     AddLZ77Block(&s.katascratch, options, btype, final, &store, 0, store.size, 0,
-                 bp, out, outsize);
+                 bp, buf);
 
     ZopfliCleanBlockState(&s);
     ZopfliCleanLZ77Store(&store);
@@ -886,7 +877,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     ZopfliBlockSplit(options, in, instart, inend,
                      options->blocksplittingmax,
                      &splitpoints_uncompressed, &npoints);
-    splitpoints = (size_t*)malloc(sizeof(*splitpoints) * npoints);
+    splitpoints = (size_t*)ZopfliRealloc(NULL, sizeof(*splitpoints) * npoints);
   }
 
   ZopfliInitLZ77Store(in, &lz77);
@@ -926,11 +917,11 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     }
 
     if (totalcost2 < totalcost) {
-      free(splitpoints);
+      ZopfliRealloc(splitpoints, 0);
       splitpoints = splitpoints2;
       npoints = npoints2;
     } else {
-      free(splitpoints2);
+      ZopfliRealloc(splitpoints2, 0);
     }
   }
 
@@ -939,13 +930,29 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
     size_t end = i == npoints ? lz77.size : splitpoints[i];
     AddLZ77BlockAutoType(&katascratch, options, i == npoints && final,
                          &lz77, start, end, 0,
-                         bp, out, outsize);
+                         bp, buf);
   }
 
   ZopfliCleanKatajainenScratch(&katascratch);
   ZopfliCleanLZ77Store(&lz77);
-  free(splitpoints);
-  free(splitpoints_uncompressed);
+  ZopfliRealloc(splitpoints, 0);
+  ZopfliRealloc(splitpoints_uncompressed, 0);
+}
+
+/* Adopts (out, outsize) into a ZopfliBuf, runs f, then publishes back. The
+internal output path grows at the golden ratio; the public (out, outsize) API is
+preserved. */
+void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
+                       const uint8_t* in, size_t instart, size_t inend,
+                       uint8_t* bp, uint8_t** out,
+                       size_t* outsize) {
+  ZopfliBuf buf;
+  buf.data = *out;
+  buf.size = *outsize;
+  buf.cap = *outsize;
+  DeflatePart(options, btype, final, in, instart, inend, bp, &buf);
+  *out = buf.data;
+  *outsize = buf.size;
 }
 
 /* Iteration count for auto mode (numiterations == 0): 10 + 12 per size-doubling
@@ -959,10 +966,13 @@ static int AutoIterations(size_t insize) {
   return iters < 15 ? 15 : iters > 400 ? 400 : iters;
 }
 
-void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
-                   const unsigned char* in, size_t insize,
-                   unsigned char* bp, unsigned char** out, size_t* outsize) {
-  size_t offset = *outsize;
+/* Core deflate onto a golden-ratio-growing ZopfliBuf. The public ZopfliDeflate
+wraps this; the containers call it directly so the whole stream shares one buf
+(and its capacity) instead of crossing the (out, outsize) boundary per call. */
+void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
+                      const uint8_t* in, size_t insize,
+                      uint8_t* bp, ZopfliBuf* buf) {
+  size_t offset = buf->size;
   ZopfliOptions opts = *options;
   assert(opts.numiterations >= 0);
   if (opts.numiterations == 0) opts.numiterations = AutoIterations(insize);
@@ -984,13 +994,12 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
     int masterfinal = (i + mbs >= insize);
     int final2 = final && masterfinal;
     size_t size = masterfinal ? insize - i : mbs;
-    ZopfliDeflatePart(&opts, btype, final2,
-                      in, i, i + size, bp, out, outsize);
+    DeflatePart(&opts, btype, final2, in, i, i + size, bp, buf);
     i += size;
   } while (i < insize);
   }
   if (options->verbose) {
-    size_t comp = *outsize - offset;
+    size_t comp = buf->size - offset;
     /* Percent removed with 2 decimals, integer-only (basis points). */
     long bp = insize ? (long)(((long long)insize - (long long)comp) * 10000
                               / (long long)insize) : 0;
@@ -1000,4 +1009,16 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
             insize, comp,
             bp < 0 ? "-" : "", abp / 100, abp % 100);
   }
+}
+
+void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
+                   const uint8_t* in, size_t insize,
+                   uint8_t* bp, uint8_t** out, size_t* outsize) {
+  ZopfliBuf buf;
+  buf.data = *out;
+  buf.size = *outsize;
+  buf.cap = *outsize;
+  ZopfliDeflateBuf(options, btype, final, in, insize, bp, &buf);
+  *out = buf.data;
+  *outsize = buf.size;
 }

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -60,8 +60,18 @@ out: pointer to the dynamic output array to which the result is appended. Must
 outsize: pointer to the dynamic output array size.
 */
 void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
-                   const unsigned char* in, size_t insize,
-                   unsigned char* bp, unsigned char** out, size_t* outsize);
+                   const uint8_t* in, size_t insize,
+                   uint8_t* bp, uint8_t** out, size_t* outsize);
+
+/*
+Like ZopfliDeflate, but appends to a golden-ratio-growing ZopfliBuf instead of an
+(out, outsize) pair. Internal: lets the gzip/zlib containers share one growable
+buffer (and its capacity) with the deflate stream rather than crossing the
+(out, outsize) boundary on every call.
+*/
+void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
+                      const uint8_t* in, size_t insize,
+                      uint8_t* bp, ZopfliBuf* buf);
 
 /*
 Like ZopfliDeflate, but allows to specify start and end byte with instart and
@@ -69,8 +79,8 @@ inend. Only that part is compressed, but earlier bytes are still used for the
 back window.
 */
 void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
-                       const unsigned char* in, size_t instart, size_t inend,
-                       unsigned char* bp, unsigned char** out,
+                       const uint8_t* in, size_t instart, size_t inend,
+                       uint8_t* bp, uint8_t** out,
                        size_t* outsize);
 
 /*

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -97,7 +97,8 @@ uint32_t ZopfliCalculateBlockSize(const ZopfliLZ77Store* lz77,
 As ZopfliCalculateBlockSize, but reuses caller-owned scratch (thread-safe when
 each thread passes its own).
 */
-uint32_t ZopfliCalculateBlockSizeScratch(ZopfliKatajainenScratch* scratch,
+uint32_t ZopfliCalculateBlockSizeScratch(const ZopfliContext* ctx,
+                                         ZopfliKatajainenScratch* scratch,
                                          const ZopfliLZ77Store* lz77,
                                          size_t lstart, size_t lend, int btype);
 
@@ -111,7 +112,7 @@ uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,
 As ZopfliCalculateBlockSizeAutoType, but reuses caller-owned scratch.
 */
 uint32_t ZopfliCalculateBlockSizeAutoTypeScratch(
-    ZopfliKatajainenScratch* scratch,
+    const ZopfliContext* ctx, ZopfliKatajainenScratch* scratch,
     const ZopfliLZ77Store* lz77, size_t lstart, size_t lend);
 
 /*

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -73,7 +73,7 @@ static const unsigned long crc32_table[256] = {
 };
 
 /* Returns the CRC32 */
-static unsigned long CRC(const unsigned char* data, size_t size) {
+static unsigned long CRC(const uint8_t* data, size_t size) {
   unsigned long result = 0xffffffffu;
   for (; size > 0; size--) {
     result = crc32_table[(result ^ *(data++)) & 0xff] ^ (result >> 8);
@@ -83,38 +83,46 @@ static unsigned long CRC(const unsigned char* data, size_t size) {
 
 /* Compresses the data according to the gzip specification, RFC 1952. */
 void ZopfliGzipCompress(const ZopfliOptions* options,
-                        const unsigned char* in, size_t insize,
-                        unsigned char** out, size_t* outsize) {
+                        const uint8_t* in, size_t insize,
+                        uint8_t** out, size_t* outsize) {
   unsigned long crcvalue = CRC(in, insize);
-  unsigned char bp = 0;
+  uint8_t bp = 0;
+  ZopfliBuf buf;
 
-  ZOPFLI_APPEND_DATA(31, out, outsize);  /* ID1 */
-  ZOPFLI_APPEND_DATA(139, out, outsize);  /* ID2 */
-  ZOPFLI_APPEND_DATA(8, out, outsize);  /* CM */
-  ZOPFLI_APPEND_DATA(0, out, outsize);  /* FLG */
+  buf.data = *out;
+  buf.size = *outsize;
+  buf.cap = *outsize;
+
+  ZopfliBufPush(&buf, 31);  /* ID1 */
+  ZopfliBufPush(&buf, 139);  /* ID2 */
+  ZopfliBufPush(&buf, 8);  /* CM */
+  ZopfliBufPush(&buf, 0);  /* FLG */
   /* MTIME */
-  ZOPFLI_APPEND_DATA(0, out, outsize);
-  ZOPFLI_APPEND_DATA(0, out, outsize);
-  ZOPFLI_APPEND_DATA(0, out, outsize);
-  ZOPFLI_APPEND_DATA(0, out, outsize);
+  ZopfliBufPush(&buf, 0);
+  ZopfliBufPush(&buf, 0);
+  ZopfliBufPush(&buf, 0);
+  ZopfliBufPush(&buf, 0);
 
-  ZOPFLI_APPEND_DATA(2, out, outsize);  /* XFL, 2 indicates best compression. */
-  ZOPFLI_APPEND_DATA(3, out, outsize);  /* OS follows Unix conventions. */
+  ZopfliBufPush(&buf, 2);  /* XFL, 2 indicates best compression. */
+  ZopfliBufPush(&buf, 3);  /* OS follows Unix conventions. */
 
-  ZopfliDeflate(options, 2 /* Dynamic block */, 1,
-                in, insize, &bp, out, outsize);
+  ZopfliDeflateBuf(options, 2 /* Dynamic block */, 1,
+                   in, insize, &bp, &buf);
 
   /* CRC */
-  ZOPFLI_APPEND_DATA(crcvalue % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((crcvalue >> 8) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((crcvalue >> 16) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((crcvalue >> 24) % 256, out, outsize);
+  ZopfliBufPush(&buf, (uint8_t)(crcvalue & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((crcvalue >> 8) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((crcvalue >> 16) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((crcvalue >> 24) & 0xff));
 
   /* ISIZE */
-  ZOPFLI_APPEND_DATA(insize % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((insize >> 8) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((insize >> 16) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((insize >> 24) % 256, out, outsize);
+  ZopfliBufPush(&buf, (uint8_t)(insize & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((insize >> 8) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((insize >> 16) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((insize >> 24) & 0xff));
+
+  *out = buf.data;
+  *outsize = buf.size;
 
   if (options->verbose) {
     /* Percent removed with 2 decimals, integer-only (basis points). */

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -23,10 +23,11 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 #include <stdio.h>
 
+#include "context.h"
 #include "deflate.h"
 
 /* CRC polynomial: 0xedb88320 */
-static const unsigned long crc32_table[256] = {
+static const uint32_t crc32_table[256] = {
            0u, 1996959894u, 3993919788u, 2567524794u,  124634137u, 1886057615u,
   3915621685u, 2657392035u,  249268274u, 2044508324u, 3772115230u, 2547177864u,
    162941995u, 2125561021u, 3887607047u, 2428444049u,  498536548u, 1789927666u,
@@ -73,8 +74,8 @@ static const unsigned long crc32_table[256] = {
 };
 
 /* Returns the CRC32 */
-static unsigned long CRC(const uint8_t* data, size_t size) {
-  unsigned long result = 0xffffffffu;
+static uint32_t CRC(const uint8_t* data, size_t size) {
+  uint32_t result = 0xffffffffu;
   for (; size > 0; size--) {
     result = crc32_table[(result ^ *(data++)) & 0xff] ^ (result >> 8);
   }
@@ -85,41 +86,43 @@ static unsigned long CRC(const uint8_t* data, size_t size) {
 void ZopfliGzipCompress(const ZopfliOptions* options,
                         const uint8_t* in, size_t insize,
                         uint8_t** out, size_t* outsize) {
-  unsigned long crcvalue = CRC(in, insize);
+  uint32_t crcvalue = CRC(in, insize);
   uint8_t bp = 0;
+  ZopfliContext ctx;
   ZopfliBuf buf;
 
+  ctx.options = options;
   buf.data = *out;
   buf.size = *outsize;
   buf.cap = *outsize;
 
-  ZopfliBufPush(&buf, 31);  /* ID1 */
-  ZopfliBufPush(&buf, 139);  /* ID2 */
-  ZopfliBufPush(&buf, 8);  /* CM */
-  ZopfliBufPush(&buf, 0);  /* FLG */
+  ZopfliBufPush(&ctx, &buf, 31);  /* ID1 */
+  ZopfliBufPush(&ctx, &buf, 139);  /* ID2 */
+  ZopfliBufPush(&ctx, &buf, 8);  /* CM */
+  ZopfliBufPush(&ctx, &buf, 0);  /* FLG */
   /* MTIME */
-  ZopfliBufPush(&buf, 0);
-  ZopfliBufPush(&buf, 0);
-  ZopfliBufPush(&buf, 0);
-  ZopfliBufPush(&buf, 0);
+  ZopfliBufPush(&ctx, &buf, 0);
+  ZopfliBufPush(&ctx, &buf, 0);
+  ZopfliBufPush(&ctx, &buf, 0);
+  ZopfliBufPush(&ctx, &buf, 0);
 
-  ZopfliBufPush(&buf, 2);  /* XFL, 2 indicates best compression. */
-  ZopfliBufPush(&buf, 3);  /* OS follows Unix conventions. */
+  ZopfliBufPush(&ctx, &buf, 2);  /* XFL, 2 indicates best compression. */
+  ZopfliBufPush(&ctx, &buf, 3);  /* OS follows Unix conventions. */
 
   ZopfliDeflateBuf(options, 2 /* Dynamic block */, 1,
                    in, insize, &bp, &buf);
 
   /* CRC */
-  ZopfliBufPush(&buf, (uint8_t)(crcvalue & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((crcvalue >> 8) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((crcvalue >> 16) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((crcvalue >> 24) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)(crcvalue & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((crcvalue >> 8) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((crcvalue >> 16) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((crcvalue >> 24) & 0xff));
 
   /* ISIZE */
-  ZopfliBufPush(&buf, (uint8_t)(insize & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((insize >> 8) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((insize >> 16) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((insize >> 24) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)(insize & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((insize >> 8) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((insize >> 16) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((insize >> 24) & 0xff));
 
   *out = buf.data;
   *outsize = buf.size;

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -91,7 +91,7 @@ void ZopfliGzipCompress(const ZopfliOptions* options,
   ZopfliContext ctx;
   ZopfliBuf buf;
 
-  ctx.options = options;
+  ctx.options = *options;
   buf.data = *out;
   buf.size = *outsize;
   buf.cap = *outsize;

--- a/src/zopfli/gzip_container.h
+++ b/src/zopfli/gzip_container.h
@@ -40,8 +40,8 @@ out: pointer to the dynamic output array to which the result is appended. Must
 outsize: pointer to the dynamic output array size.
 */
 void ZopfliGzipCompress(const ZopfliOptions* options,
-                        const unsigned char* in, size_t insize,
-                        unsigned char** out, size_t* outsize);
+                        const uint8_t* in, size_t insize,
+                        uint8_t** out, size_t* outsize);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/zopfli/hash.c
+++ b/src/zopfli/hash.c
@@ -28,23 +28,26 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 
 /* Empty/uninitialized 16-bit hash slot. Real positions and hash values are
 <= HASH_MASK (32767), so 0xFFFF can never collide with a valid entry. */
-#define ZOPFLI_HASH_EMPTY ((unsigned short)-1)
+#define ZOPFLI_HASH_EMPTY ((uint16_t)-1)
 
 void ZopfliAllocHash(size_t window_size, ZopfliHash* h) {
   /* head/head2 are indexed by the masked hash value, so only HASH_MASK + 1
   buckets are ever used (not 65536). */
-  h->head = (unsigned short*)malloc(sizeof(*h->head) * (HASH_MASK + 1));
-  h->prev = (unsigned short*)malloc(sizeof(*h->prev) * window_size);
-  h->hashval = (unsigned short*)malloc(sizeof(*h->hashval) * window_size);
+  h->head = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->head) * (HASH_MASK + 1));
+  h->prev = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->prev) * window_size);
+  h->hashval =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->hashval) * window_size);
 
 #ifdef ZOPFLI_HASH_SAME
-  h->same = (unsigned short*)malloc(sizeof(*h->same) * window_size);
+  h->same = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->same) * window_size);
 #endif
 
 #ifdef ZOPFLI_HASH_SAME_HASH
-  h->head2 = (unsigned short*)malloc(sizeof(*h->head2) * (HASH_MASK + 1));
-  h->prev2 = (unsigned short*)malloc(sizeof(*h->prev2) * window_size);
-  h->hashval2 = (unsigned short*)malloc(sizeof(*h->hashval2) * window_size);
+  h->head2 =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->head2) * (HASH_MASK + 1));
+  h->prev2 = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->prev2) * window_size);
+  h->hashval2 =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->hashval2) * window_size);
 #endif
 }
 
@@ -57,7 +60,7 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
   }
   for (i = 0; i < window_size; i++) {
     /* If prev[j] == j, then prev[j] is uninitialized. */
-    h->prev[i] = (unsigned short)i;
+    h->prev[i] = (uint16_t)i;
     h->hashval[i] = ZOPFLI_HASH_EMPTY;
   }
 
@@ -73,25 +76,25 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
     h->head2[i] = ZOPFLI_HASH_EMPTY;
   }
   for (i = 0; i < window_size; i++) {
-    h->prev2[i] = (unsigned short)i;
+    h->prev2[i] = (uint16_t)i;
     h->hashval2[i] = ZOPFLI_HASH_EMPTY;
   }
 #endif
 }
 
 void ZopfliCleanHash(ZopfliHash* h) {
-  free(h->head);
-  free(h->prev);
-  free(h->hashval);
+  ZopfliRealloc(h->head, 0);
+  ZopfliRealloc(h->prev, 0);
+  ZopfliRealloc(h->hashval, 0);
 
 #ifdef ZOPFLI_HASH_SAME_HASH
-  free(h->head2);
-  free(h->prev2);
-  free(h->hashval2);
+  ZopfliRealloc(h->head2, 0);
+  ZopfliRealloc(h->prev2, 0);
+  ZopfliRealloc(h->hashval2, 0);
 #endif
 
 #ifdef ZOPFLI_HASH_SAME
-  free(h->same);
+  ZopfliRealloc(h->same, 0);
 #endif
 }
 
@@ -100,13 +103,13 @@ Update the sliding hash value with the given byte. All calls to this function
 must be made on consecutive input characters. Since the hash value exists out
 of multiple input bytes, a few warmups with this function are needed initially.
 */
-static void UpdateHashValue(ZopfliHash* h, unsigned char c) {
+static void UpdateHashValue(ZopfliHash* h, uint8_t c) {
   h->val = (((h->val) << HASH_SHIFT) ^ (c)) & HASH_MASK;
 }
 
-void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
+void ZopfliUpdateHash(const uint8_t* array, size_t pos, size_t end,
                 ZopfliHash* h) {
-  unsigned short hpos = pos & ZOPFLI_WINDOW_MASK;
+  uint16_t hpos = pos & ZOPFLI_WINDOW_MASK;
 #ifdef ZOPFLI_HASH_SAME
   size_t amount = 0;
 #endif
@@ -127,10 +130,10 @@ void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
     amount = h->same[(pos - 1) & ZOPFLI_WINDOW_MASK] - 1;
   }
   while (pos + amount + 1 < end &&
-      array[pos] == array[pos + amount + 1] && amount < (unsigned short)(-1)) {
+      array[pos] == array[pos + amount + 1] && amount < (uint16_t)(-1)) {
     amount++;
   }
-  h->same[hpos] = (unsigned short)amount;
+  h->same[hpos] = (uint16_t)amount;
 #endif
 
 #ifdef ZOPFLI_HASH_SAME_HASH
@@ -145,7 +148,7 @@ void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
 #endif
 }
 
-void ZopfliWarmupHash(const unsigned char* array, size_t pos, size_t end,
+void ZopfliWarmupHash(const uint8_t* array, size_t pos, size_t end,
                 ZopfliHash* h) {
   UpdateHashValue(h, array[pos + 0]);
   if (pos + 1 < end) UpdateHashValue(h, array[pos + 1]);

--- a/src/zopfli/hash.c
+++ b/src/zopfli/hash.c
@@ -30,24 +30,27 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 <= HASH_MASK (32767), so 0xFFFF can never collide with a valid entry. */
 #define ZOPFLI_HASH_EMPTY ((uint16_t)-1)
 
-void ZopfliAllocHash(size_t window_size, ZopfliHash* h) {
+void ZopfliAllocHash(const ZopfliContext* ctx, size_t window_size,
+                     ZopfliHash* h) {
   /* head/head2 are indexed by the masked hash value, so only HASH_MASK + 1
   buckets are ever used (not 65536). */
-  h->head = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->head) * (HASH_MASK + 1));
-  h->prev = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->prev) * window_size);
+  h->head =
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->head) * (HASH_MASK + 1));
+  h->prev = (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->prev) * window_size);
   h->hashval =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->hashval) * window_size);
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->hashval) * window_size);
 
 #ifdef ZOPFLI_HASH_SAME
-  h->same = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->same) * window_size);
+  h->same = (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->same) * window_size);
 #endif
 
 #ifdef ZOPFLI_HASH_SAME_HASH
   h->head2 =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->head2) * (HASH_MASK + 1));
-  h->prev2 = (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->prev2) * window_size);
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->head2) * (HASH_MASK + 1));
+  h->prev2 =
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->prev2) * window_size);
   h->hashval2 =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(*h->hashval2) * window_size);
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*h->hashval2) * window_size);
 #endif
 }
 
@@ -82,19 +85,19 @@ void ZopfliResetHash(size_t window_size, ZopfliHash* h) {
 #endif
 }
 
-void ZopfliCleanHash(ZopfliHash* h) {
-  ZopfliRealloc(h->head, 0);
-  ZopfliRealloc(h->prev, 0);
-  ZopfliRealloc(h->hashval, 0);
+void ZopfliCleanHash(const ZopfliContext* ctx, ZopfliHash* h) {
+  ZopfliRealloc(ctx, h->head, 0);
+  ZopfliRealloc(ctx, h->prev, 0);
+  ZopfliRealloc(ctx, h->hashval, 0);
 
 #ifdef ZOPFLI_HASH_SAME_HASH
-  ZopfliRealloc(h->head2, 0);
-  ZopfliRealloc(h->prev2, 0);
-  ZopfliRealloc(h->hashval2, 0);
+  ZopfliRealloc(ctx, h->head2, 0);
+  ZopfliRealloc(ctx, h->prev2, 0);
+  ZopfliRealloc(ctx, h->hashval2, 0);
 #endif
 
 #ifdef ZOPFLI_HASH_SAME
-  ZopfliRealloc(h->same, 0);
+  ZopfliRealloc(ctx, h->same, 0);
 #endif
 }
 

--- a/src/zopfli/hash.h
+++ b/src/zopfli/hash.h
@@ -54,13 +54,14 @@ typedef struct ZopfliHash {
 } ZopfliHash;
 
 /* Allocates ZopfliHash memory. */
-void ZopfliAllocHash(size_t window_size, ZopfliHash* h);
+void ZopfliAllocHash(const ZopfliContext* ctx, size_t window_size,
+                     ZopfliHash* h);
 
 /* Resets all fields of ZopfliHash. */
 void ZopfliResetHash(size_t window_size, ZopfliHash* h);
 
 /* Frees ZopfliHash memory. */
-void ZopfliCleanHash(ZopfliHash* h);
+void ZopfliCleanHash(const ZopfliContext* ctx, ZopfliHash* h);
 
 /*
 Updates the hash values based on the current position in the array. All calls

--- a/src/zopfli/hash.h
+++ b/src/zopfli/hash.h
@@ -27,29 +27,29 @@ The hash for ZopfliFindLongestMatch of lz77.c.
 #include "util.h"
 
 /*
-head/hashval are unsigned short: hash values are masked to [0, HASH_MASK] (15
+head/hashval are uint16_t: hash values are masked to [0, HASH_MASK] (15
 bits) and stored values are window positions (<= 32767) or the (unsigned
 short)-1 empty sentinel, so 16 bits suffice. This roughly halves the hash
 allocation (and head/head2 are also right-sized to HASH_MASK + 1 buckets), which
 cuts memory and improves locality on small-cache targets. See ZopfliAllocHash.
 */
 typedef struct ZopfliHash {
-  unsigned short* head;  /* Hash value to index of its most recent occurrence. */
-  unsigned short* prev;  /* Index to index of prev. occurrence of same hash. */
-  unsigned short* hashval;  /* Index to hash value at this index. */
+  uint16_t* head;  /* Hash value to index of its most recent occurrence. */
+  uint16_t* prev;  /* Index to index of prev. occurrence of same hash. */
+  uint16_t* hashval;  /* Index to hash value at this index. */
   int val;  /* Current hash value. */
 
 #ifdef ZOPFLI_HASH_SAME_HASH
   /* Fields with similar purpose as the above hash, but for the second hash with
   a value that is calculated differently.  */
-  unsigned short* head2;  /* Hash value to index of its most recent occurrence.*/
-  unsigned short* prev2;  /* Index to index of prev. occurrence of same hash. */
-  unsigned short* hashval2;  /* Index to hash value at this index. */
+  uint16_t* head2;  /* Hash value to index of its most recent occurrence.*/
+  uint16_t* prev2;  /* Index to index of prev. occurrence of the same hash. */
+  uint16_t* hashval2;  /* Index to hash value at this index. */
   int val2;  /* Current hash value. */
 #endif
 
 #ifdef ZOPFLI_HASH_SAME
-  unsigned short* same;  /* Amount of repetitions of same byte after this .*/
+  uint16_t* same;  /* Number of repetitions of same byte after this .*/
 #endif
 } ZopfliHash;
 
@@ -66,7 +66,7 @@ void ZopfliCleanHash(ZopfliHash* h);
 Updates the hash values based on the current position in the array. All calls
 to this must be made for consecutive bytes.
 */
-void ZopfliUpdateHash(const unsigned char* array, size_t pos, size_t end,
+void ZopfliUpdateHash(const uint8_t* array, size_t pos, size_t end,
                       ZopfliHash* h);
 
 /*
@@ -74,7 +74,7 @@ Prepopulates hash:
 Fills in the initial values in the hash, before ZopfliUpdateHash can be used
 correctly.
 */
-void ZopfliWarmupHash(const unsigned char* array, size_t pos, size_t end,
+void ZopfliWarmupHash(const uint8_t* array, size_t pos, size_t end,
                       ZopfliHash* h);
 
 #endif  /* ZOPFLI_HASH_H_ */

--- a/src/zopfli/katajainen.c
+++ b/src/zopfli/katajainen.c
@@ -25,6 +25,7 @@ Jyrki Katajainen, Alistair Moffat, Andrew Turpin".
 */
 
 #include "katajainen.h"
+#include "util.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -171,7 +172,7 @@ of weight, so all keys are distinct and the order is unique. Inlined shell sort
 static void SortLeaves(Node* leaves, int num) {
   /* Knuth gaps ((3^k - 1) / 2). Capped at 121: the start gap is < num and num
      <= 288 (ZOPFLI_NUM_LL), so larger gaps never apply. Still correct if not. */
-  static const int kGaps[] = { 1, 4, 13, 40, 121 };
+  static const uint8_t kGaps[] = { 1, 4, 13, 40, 121 };
   int g = (int)(sizeof(kGaps) / sizeof(kGaps[0])) - 1;
   /* Start at the largest gap smaller than num. */
   for (; g > 0 && kGaps[g] >= num; g--) { }
@@ -198,16 +199,14 @@ void ZopfliInitKatajainenScratch(ZopfliKatajainenScratch* scratch) {
 }
 
 void ZopfliCleanKatajainenScratch(ZopfliKatajainenScratch* scratch) {
-  free(scratch->leaves);
-  free(scratch->nodes);
-  free(scratch->lists);
+  ZopfliRealloc(scratch->leaves, 0);
+  ZopfliRealloc(scratch->nodes, 0);
+  ZopfliRealloc(scratch->lists, 0);
 }
 
 static Node* EnsureNodes(void** buf, size_t* cap, size_t need) {
   if (need > *cap) {
-    void* p = realloc(*buf, need * sizeof(Node));
-    if (!p) exit(EXIT_FAILURE);
-    *buf = p;
+    *buf = ZopfliRealloc(*buf, need * sizeof(Node));
     *cap = need;
   }
   return (Node*)*buf;
@@ -285,8 +284,8 @@ int ZopfliLengthLimitedCodeLengthsScratch(
   pool.next = nodes;
 
   if ((size_t)maxbits > scratch->lists_cap) {
-    free(scratch->lists);
-    scratch->lists = malloc((size_t)maxbits * 2 * sizeof(Node*));
+    ZopfliRealloc(scratch->lists, 0);
+    scratch->lists = ZopfliRealloc(NULL, (size_t)maxbits * 2 * sizeof(Node*));
     scratch->lists_cap = scratch->lists ? (size_t)maxbits : 0;
   }
   lists = (Node* (*)[2])scratch->lists;

--- a/src/zopfli/katajainen.c
+++ b/src/zopfli/katajainen.c
@@ -198,22 +198,24 @@ void ZopfliInitKatajainenScratch(ZopfliKatajainenScratch* scratch) {
   scratch->lists_cap = 0;
 }
 
-void ZopfliCleanKatajainenScratch(ZopfliKatajainenScratch* scratch) {
-  ZopfliRealloc(scratch->leaves, 0);
-  ZopfliRealloc(scratch->nodes, 0);
-  ZopfliRealloc(scratch->lists, 0);
+void ZopfliCleanKatajainenScratch(const ZopfliContext* ctx,
+                                  ZopfliKatajainenScratch* scratch) {
+  ZopfliRealloc(ctx, scratch->leaves, 0);
+  ZopfliRealloc(ctx, scratch->nodes, 0);
+  ZopfliRealloc(ctx, scratch->lists, 0);
 }
 
-static Node* EnsureNodes(void** buf, size_t* cap, size_t need) {
+static Node* EnsureNodes(const ZopfliContext* ctx, void** buf, size_t* cap,
+                         size_t need) {
   if (need > *cap) {
-    *buf = ZopfliRealloc(*buf, need * sizeof(Node));
+    *buf = ZopfliRealloc(ctx, *buf, need * sizeof(Node));
     *cap = need;
   }
   return (Node*)*buf;
 }
 
 int ZopfliLengthLimitedCodeLengthsScratch(
-    ZopfliKatajainenScratch* scratch,
+    const ZopfliContext* ctx, ZopfliKatajainenScratch* scratch,
     const size_t* frequencies, int n, int maxbits, unsigned* bitlengths) {
   NodePool pool;
   int i;
@@ -226,7 +228,8 @@ int ZopfliLengthLimitedCodeLengthsScratch(
   Node* (*lists)[2];
 
   /* One leaf per symbol. Only numsymbols leaves will be used. */
-  Node* leaves = EnsureNodes(&scratch->leaves, &scratch->leaves_cap, (size_t)n);
+  Node* leaves =
+      EnsureNodes(ctx, &scratch->leaves, &scratch->leaves_cap, (size_t)n);
 
   /* Initialize all bitlengths at 0. */
   for (i = 0; i < n; i++) {
@@ -279,13 +282,14 @@ int ZopfliLengthLimitedCodeLengthsScratch(
   }
 
   /* Initialize node memory pool. */
-  nodes = EnsureNodes(&scratch->nodes, &scratch->nodes_cap,
+  nodes = EnsureNodes(ctx, &scratch->nodes, &scratch->nodes_cap,
                       (size_t)maxbits * 2 * (size_t)numsymbols);
   pool.next = nodes;
 
   if ((size_t)maxbits > scratch->lists_cap) {
-    ZopfliRealloc(scratch->lists, 0);
-    scratch->lists = ZopfliRealloc(NULL, (size_t)maxbits * 2 * sizeof(Node*));
+    ZopfliRealloc(ctx, scratch->lists, 0);
+    scratch->lists =
+        ZopfliRealloc(ctx, NULL, (size_t)maxbits * 2 * sizeof(Node*));
     scratch->lists_cap = scratch->lists ? (size_t)maxbits : 0;
   }
   lists = (Node* (*)[2])scratch->lists;
@@ -305,12 +309,13 @@ int ZopfliLengthLimitedCodeLengthsScratch(
 }
 
 int ZopfliLengthLimitedCodeLengths(
-    const size_t* frequencies, int n, int maxbits, unsigned* bitlengths) {
+    const ZopfliContext* ctx, const size_t* frequencies, int n, int maxbits,
+    unsigned* bitlengths) {
   ZopfliKatajainenScratch scratch;
   int result;
   ZopfliInitKatajainenScratch(&scratch);
   result = ZopfliLengthLimitedCodeLengthsScratch(
-      &scratch, frequencies, n, maxbits, bitlengths);
-  ZopfliCleanKatajainenScratch(&scratch);
+      ctx, &scratch, frequencies, n, maxbits, bitlengths);
+  ZopfliCleanKatajainenScratch(ctx, &scratch);
   return result;
 }

--- a/src/zopfli/katajainen.h
+++ b/src/zopfli/katajainen.h
@@ -23,6 +23,8 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 #include <string.h>
 
+#include "util.h"  /* ZopfliContext (forward typedef) for the allocator */
+
 /*
 Reusable scratch buffers for ZopfliLengthLimitedCodeLengths, so the hot
 per-block-evaluation path does not malloc/free on every call. Owned by the
@@ -40,7 +42,8 @@ typedef struct ZopfliKatajainenScratch {
 } ZopfliKatajainenScratch;
 
 void ZopfliInitKatajainenScratch(ZopfliKatajainenScratch* scratch);
-void ZopfliCleanKatajainenScratch(ZopfliKatajainenScratch* scratch);
+void ZopfliCleanKatajainenScratch(const ZopfliContext* ctx,
+                                  ZopfliKatajainenScratch* scratch);
 
 /*
 Outputs minimum-redundancy length-limited code bitlengths for symbols with the
@@ -57,7 +60,8 @@ bitlengths: Output, the bitlengths for the symbol prefix codes.
 return: 0 for OK, non-0 for error.
 */
 int ZopfliLengthLimitedCodeLengths(
-    const size_t* frequencies, int n, int maxbits, unsigned* bitlengths);
+    const ZopfliContext* ctx, const size_t* frequencies, int n, int maxbits,
+    unsigned* bitlengths);
 
 /*
 As ZopfliLengthLimitedCodeLengths, but reuses caller-owned scratch buffers
@@ -65,7 +69,7 @@ instead of allocating per call. Thread-safe as long as each thread passes its
 own scratch.
 */
 int ZopfliLengthLimitedCodeLengthsScratch(
-    ZopfliKatajainenScratch* scratch,
+    const ZopfliContext* ctx, ZopfliKatajainenScratch* scratch,
     const size_t* frequencies, int n, int maxbits, unsigned* bitlengths);
 
 #endif  /* ZOPFLI_KATAJAINEN_H_ */

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -26,7 +26,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include <stdio.h>
 #include <stdlib.h>
 
-void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store) {
+void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store) {
   store->size = 0;
   store->cap = 0;
   store->litlens = 0;
@@ -38,11 +38,11 @@ void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store) {
 }
 
 void ZopfliCleanLZ77Store(ZopfliLZ77Store* store) {
-  free(store->litlens);
-  free(store->dists);
-  free(store->pos);
-  free(store->ll_counts);
-  free(store->d_counts);
+  ZopfliRealloc(store->litlens, 0);
+  ZopfliRealloc(store->dists, 0);
+  ZopfliRealloc(store->pos, 0);
+  ZopfliRealloc(store->ll_counts, 0);
+  ZopfliRealloc(store->d_counts, 0);
 }
 
 static size_t CeilDiv(size_t a, size_t b) {
@@ -59,20 +59,18 @@ static void ZopfliReserveLZ77Store(ZopfliLZ77Store* store, size_t need) {
   size_t newcap, llc, dc;
   if (need <= store->cap) return;
   newcap = store->cap ? store->cap : 16;
-  while (newcap < need) newcap *= 2;
+  while (newcap < need) newcap = ZOPFLI_GROW_CAP(newcap);
   llc = ZOPFLI_NUM_LL * CeilDiv(newcap, ZOPFLI_NUM_LL);
   dc = ZOPFLI_NUM_D * CeilDiv(newcap, ZOPFLI_NUM_D);
-  store->litlens = (unsigned short*)realloc(
+  store->litlens = (uint16_t*)ZopfliRealloc(
       store->litlens, sizeof(*store->litlens) * newcap);
-  store->dists = (unsigned short*)realloc(
+  store->dists = (uint16_t*)ZopfliRealloc(
       store->dists, sizeof(*store->dists) * newcap);
-  store->pos = (size_t*)realloc(store->pos, sizeof(*store->pos) * newcap);
-  store->ll_counts = (uint32_t*)realloc(
+  store->pos = (size_t*)ZopfliRealloc(store->pos, sizeof(*store->pos) * newcap);
+  store->ll_counts = (uint32_t*)ZopfliRealloc(
       store->ll_counts, sizeof(*store->ll_counts) * llc);
-  store->d_counts = (uint32_t*)realloc(
+  store->d_counts = (uint32_t*)ZopfliRealloc(
       store->d_counts, sizeof(*store->d_counts) * dc);
-  if (!store->litlens || !store->dists || !store->pos) exit(-1);
-  if (!store->ll_counts || !store->d_counts) exit(-1);
   store->cap = newcap;
 }
 
@@ -88,16 +86,14 @@ void ZopfliCopyLZ77Store(
   ZopfliCleanLZ77Store(dest);
   ZopfliInitLZ77Store(source->data, dest);
   dest->litlens =
-      (unsigned short*)malloc(sizeof(*dest->litlens) * source->size);
-  dest->dists = (unsigned short*)malloc(sizeof(*dest->dists) * source->size);
-  dest->pos = (size_t*)malloc(sizeof(*dest->pos) * source->size);
-  dest->ll_counts = (uint32_t*)malloc(sizeof(*dest->ll_counts) * llsize);
-  dest->d_counts = (uint32_t*)malloc(sizeof(*dest->d_counts) * dsize);
-
-  /* Allocation failed. */
-  if (!dest->litlens || !dest->dists) exit(-1);
-  if (!dest->pos) exit(-1);
-  if (!dest->ll_counts || !dest->d_counts) exit(-1);
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(*dest->litlens) * source->size);
+  dest->dists =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(*dest->dists) * source->size);
+  dest->pos = (size_t*)ZopfliRealloc(NULL, sizeof(*dest->pos) * source->size);
+  dest->ll_counts =
+      (uint32_t*)ZopfliRealloc(NULL, sizeof(*dest->ll_counts) * llsize);
+  dest->d_counts =
+      (uint32_t*)ZopfliRealloc(NULL, sizeof(*dest->d_counts) * dsize);
 
   dest->size = source->size;
   dest->cap = source->size;
@@ -118,7 +114,7 @@ void ZopfliCopyLZ77Store(
 Appends the length and distance to the LZ77 arrays of the ZopfliLZ77Store.
 context must be a ZopfliLZ77Store*.
 */
-void ZopfliStoreLitLenDist(unsigned short length, unsigned short dist,
+void ZopfliStoreLitLenDist(uint16_t length, uint16_t dist,
                            size_t pos, ZopfliLZ77Store* store) {
   size_t i;
   size_t origsize = store->size;
@@ -247,7 +243,8 @@ void ZopfliInitBlockState(const ZopfliOptions* options,
   ZopfliInitKatajainenScratch(&s->katascratch);
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (add_lmc) {
-    s->lmc = (ZopfliLongestMatchCache*)malloc(sizeof(ZopfliLongestMatchCache));
+    s->lmc = (ZopfliLongestMatchCache*)ZopfliRealloc(
+        NULL, sizeof(ZopfliLongestMatchCache));
     ZopfliInitCache(blockend - blockstart, s->lmc);
   } else {
     s->lmc = 0;
@@ -260,7 +257,7 @@ void ZopfliCleanBlockState(ZopfliBlockState* s) {
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (s->lmc) {
     ZopfliCleanCache(s->lmc);
-    free(s->lmc);
+    ZopfliRealloc(s->lmc, 0);
   }
 #endif
 }
@@ -294,8 +291,8 @@ static int GetLengthScore(int length, int distance) {
   return distance > 1024 ? length - 1 : length;
 }
 
-void ZopfliVerifyLenDist(const unsigned char* data, size_t datasize, size_t pos,
-                         unsigned short dist, unsigned short length) {
+void ZopfliVerifyLenDist(const uint8_t* data, size_t datasize, size_t pos,
+                         uint16_t dist, uint16_t length) {
 
   /* TODO(lode): make this only run in a debug compile, it's for assert only. */
   size_t i;
@@ -320,8 +317,8 @@ Selects the GetMatch implementation:
   - Other (smaller) targets -- 32/16/8-bit non-x86, e.g. ARMv5/ARMv7, AVR: the
     aligned word + match-splice path below. There memcmp would emit a per-iter
     bcmp call and an unaligned word cast could fault.
-ZOPFLI_FORCE_SPLICE=N forces the splice path with an N-byte (4/2/1) native word,
-for verifying it on x86. The splice math is little-endian only.
+ZOPFLI_FORCE_SPLICE forces the splice path on (for verifying it on x86). The
+splice math is little-endian only.
 */
 #if defined(ZOPFLI_FORCE_SPLICE)
 # define ZOPFLI_GM_SPLICE 1
@@ -329,24 +326,6 @@ for verifying it on x86. The splice math is little-endian only.
       !defined(_M_X64) && !defined(ZOPFLI_NATIVE_64BIT) && \
       defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 # define ZOPFLI_GM_SPLICE 1
-#endif
-
-#if defined(ZOPFLI_GM_SPLICE)
-/* Native word for the splice path. The loop processes two of these per
-iteration (2x the native width: 8/4/2 bytes on 32/16/8-bit targets). */
-# if defined(ZOPFLI_FORCE_SPLICE) && ZOPFLI_FORCE_SPLICE == 4
-typedef uint32_t ZopfliNativeWord;
-# elif defined(ZOPFLI_FORCE_SPLICE) && ZOPFLI_FORCE_SPLICE == 2
-typedef uint16_t ZopfliNativeWord;
-# elif defined(ZOPFLI_FORCE_SPLICE) && ZOPFLI_FORCE_SPLICE == 1
-typedef uint8_t ZopfliNativeWord;
-# elif defined(ZOPFLI_NATIVE_32BIT)
-typedef uint32_t ZopfliNativeWord;
-# elif defined(ZOPFLI_NATIVE_16BIT)
-typedef uint16_t ZopfliNativeWord;
-# else
-typedef uint8_t ZopfliNativeWord;
-# endif
 #endif
 
 /*
@@ -357,11 +336,11 @@ the earlier copy being compared.
 Compares wide chunks, then resolves the mismatching chunk one byte at a time.
 The bounds guard keeps every wide read inside the buffer.
 */
-static const unsigned char* GetMatch(const unsigned char* scan,
-                                     const unsigned char* match,
-                                     const unsigned char* end) {
+static const uint8_t* GetMatch(const uint8_t* scan,
+                                     const uint8_t* match,
+                                     const uint8_t* end) {
 #if defined(ZOPFLI_GM_SPLICE)
-  typedef ZopfliNativeWord W;
+  typedef ZopfliNativeWord W;       /* splice word, two per iteration */
   const uintptr_t ws = sizeof(W);   /* native word */
   const uintptr_t step = 2 * ws;    /* bytes compared per iteration */
   uintptr_t off;
@@ -382,7 +361,7 @@ static const unsigned char* GetMatch(const unsigned char* scan,
     /* match is misaligned by off: read aligned words from the match side and
     splice adjacent ones with the constant shift, carrying the high word as the
     accumulator so each iteration loads only the two new words. */
-    const unsigned char* mp = match - off;
+    const uint8_t* mp = match - off;
     const unsigned lo = (unsigned)(off * CHAR_BIT);
     const unsigned hi = (unsigned)(ws * CHAR_BIT) - lo;
     W acc = *(const W*)mp;
@@ -418,16 +397,16 @@ information from the cache.
 */
 static int TryGetFromLongestMatchCache(ZopfliBlockState* s,
     size_t pos, size_t* limit,
-    unsigned short* sublen, unsigned short* distance, unsigned short* length) {
+    uint16_t* sublen, uint16_t* distance, uint16_t* length) {
   /* The LMC cache starts at the beginning of the block rather than the
      beginning of the whole array. */
   size_t lmcpos = pos - s->blockstart;
 
   /* Length > 0 and dist 0 is invalid combination, which indicates on purpose
      that this cache value is not filled in yet. */
-  unsigned char cache_available = s->lmc && (s->lmc->length[lmcpos] == 0 ||
+  uint8_t cache_available = s->lmc && (s->lmc->length[lmcpos] == 0 ||
       s->lmc->dist[lmcpos] != 0);
-  unsigned char limit_ok_for_cache = cache_available &&
+  uint8_t limit_ok_for_cache = cache_available &&
       (*limit == ZOPFLI_MAX_MATCH || s->lmc->length[lmcpos] <= *limit ||
       (sublen && ZopfliMaxCachedSublen(s->lmc,
           lmcpos, s->lmc->length[lmcpos]) >= *limit));
@@ -436,7 +415,7 @@ static int TryGetFromLongestMatchCache(ZopfliBlockState* s,
     if (!sublen || s->lmc->length[lmcpos]
         <= ZopfliMaxCachedSublen(s->lmc, lmcpos, s->lmc->length[lmcpos])) {
       *length = s->lmc->length[lmcpos];
-      if (*length > *limit) *length = (unsigned short)*limit;
+      if (*length > *limit) *length = (uint16_t)*limit;
       if (sublen) {
         ZopfliCacheToSublen(s->lmc, lmcpos, *length, sublen);
         *distance = sublen[*length];
@@ -462,15 +441,15 @@ possible.
 */
 static void StoreInLongestMatchCache(ZopfliBlockState* s,
     size_t pos, size_t limit, size_t size,
-    const unsigned short* sublen,
-    unsigned short distance, unsigned short length) {
+    const uint16_t* sublen,
+    uint16_t distance, uint16_t length) {
   /* The LMC cache starts at the beginning of the block rather than the
      beginning of the whole array. */
   size_t lmcpos = pos - s->blockstart;
 
   /* Length > 0 and dist 0 is invalid combination, which indicates on purpose
      that this cache value is not filled in yet. */
-  unsigned char cache_available = s->lmc && (s->lmc->length[lmcpos] == 0 ||
+  uint8_t cache_available = s->lmc && (s->lmc->length[lmcpos] == 0 ||
       s->lmc->dist[lmcpos] != 0);
 
   /* Cache full-limit matches, and also end-of-block positions where the limit
@@ -489,24 +468,24 @@ static void StoreInLongestMatchCache(ZopfliBlockState* s,
 #endif
 
 void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
-    const unsigned char* array,
+    const uint8_t* array,
     size_t pos, size_t size, size_t limit,
-    unsigned short* sublen, unsigned short* distance, unsigned short* length) {
-  unsigned short hpos = pos & ZOPFLI_WINDOW_MASK, p, pp;
-  unsigned short bestdist = 0;
-  unsigned short bestlength = 1;
-  const unsigned char* scan;
-  const unsigned char* match;
-  const unsigned char* arrayend;
+    uint16_t* sublen, uint16_t* distance, uint16_t* length) {
+  uint16_t hpos = pos & ZOPFLI_WINDOW_MASK, p, pp;
+  uint16_t bestdist = 0;
+  uint16_t bestlength = 1;
+  const uint8_t* scan;
+  const uint8_t* match;
+  const uint8_t* arrayend;
 #if ZOPFLI_MAX_CHAIN_HITS < ZOPFLI_WINDOW_SIZE
   int chain_counter = ZOPFLI_MAX_CHAIN_HITS;  /* For quitting early. */
 #endif
 
-  unsigned dist = 0;  /* Not unsigned short on purpose. */
+  unsigned dist = 0;  /* Not uint16_t on purpose. */
 
-  unsigned short* hhead = h->head;
-  unsigned short* hprev = h->prev;
-  unsigned short* hhashval = h->hashval;
+  uint16_t* hhead = h->head;
+  uint16_t* hprev = h->prev;
+  uint16_t* hhashval = h->hashval;
   int hval = h->val;
   /* hhashval is read only by asserts (line ~511), which NDEBUG strips. */
   (void)hhashval;
@@ -550,7 +529,7 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
 
   /* Go through all distances. */
   while (dist < ZOPFLI_WINDOW_SIZE) {
-    unsigned short currentlength = 0;
+    uint16_t currentlength = 0;
 
     assert(p < ZOPFLI_WINDOW_SIZE);
     assert(p == hprev[pp]);
@@ -567,22 +546,22 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
           || *(scan + bestlength) == *(match + bestlength)) {
 
 #ifdef ZOPFLI_HASH_SAME
-        unsigned short same0 = h->same[pos & ZOPFLI_WINDOW_MASK];
+        uint16_t same0 = h->same[pos & ZOPFLI_WINDOW_MASK];
         if (same0 > 2 && *scan == *match) {
-          unsigned short same1 = h->same[(pos - dist) & ZOPFLI_WINDOW_MASK];
-          unsigned short same = ZOPFLI_MIN(same0, same1);
-          same = (unsigned short)ZOPFLI_MIN(same, limit);
+          uint16_t same1 = h->same[(pos - dist) & ZOPFLI_WINDOW_MASK];
+          uint16_t same = ZOPFLI_MIN(same0, same1);
+          same = (uint16_t)ZOPFLI_MIN(same, limit);
           scan += same;
           match += same;
         }
 #endif
         scan = GetMatch(scan, match, arrayend);
-        currentlength = (unsigned short)(scan - &array[pos]);  /* found len. */
+        currentlength = (uint16_t)(scan - &array[pos]);  /* found len. */
       }
 
       if (currentlength > bestlength) {
         if (sublen) {
-          unsigned short j;
+          uint16_t j;
           for (j = bestlength + 1; j <= currentlength; j++) {
             sublen[j] = dist;
           }
@@ -629,16 +608,16 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
   assert(pos + *length <= size);
 }
 
-void ZopfliLZ77Greedy(ZopfliBlockState* s, const unsigned char* in,
+void ZopfliLZ77Greedy(ZopfliBlockState* s, const uint8_t* in,
                       size_t instart, size_t inend,
                       ZopfliLZ77Store* store, ZopfliHash* h) {
   size_t i = 0, j;
-  unsigned short leng;
-  unsigned short dist;
+  uint16_t leng;
+  uint16_t dist;
   int lengthscore;
   size_t windowstart = instart > ZOPFLI_WINDOW_SIZE
       ? instart - ZOPFLI_WINDOW_SIZE : 0;
-  unsigned short dummysublen[259];
+  uint16_t dummysublen[259];
 
 #ifdef ZOPFLI_LAZY_MATCHING
   /* Lazy matching. */

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -37,12 +37,12 @@ void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store) {
   store->d_counts = 0;
 }
 
-void ZopfliCleanLZ77Store(ZopfliLZ77Store* store) {
-  ZopfliRealloc(store->litlens, 0);
-  ZopfliRealloc(store->dists, 0);
-  ZopfliRealloc(store->pos, 0);
-  ZopfliRealloc(store->ll_counts, 0);
-  ZopfliRealloc(store->d_counts, 0);
+void ZopfliCleanLZ77Store(const ZopfliContext* ctx, ZopfliLZ77Store* store) {
+  ZopfliRealloc(ctx, store->litlens, 0);
+  ZopfliRealloc(ctx, store->dists, 0);
+  ZopfliRealloc(ctx, store->pos, 0);
+  ZopfliRealloc(ctx, store->ll_counts, 0);
+  ZopfliRealloc(ctx, store->d_counts, 0);
 }
 
 static size_t CeilDiv(size_t a, size_t b) {
@@ -55,7 +55,8 @@ existing allocation (geometric growth). The ll_counts/d_counts lengths are
 deterministic functions of the symbol capacity, so one capacity covers all
 five arrays.
 */
-static void ZopfliReserveLZ77Store(ZopfliLZ77Store* store, size_t need) {
+static void ZopfliReserveLZ77Store(const ZopfliContext* ctx,
+                                   ZopfliLZ77Store* store, size_t need) {
   size_t newcap, llc, dc;
   if (need <= store->cap) return;
   newcap = store->cap ? store->cap : 16;
@@ -63,14 +64,15 @@ static void ZopfliReserveLZ77Store(ZopfliLZ77Store* store, size_t need) {
   llc = ZOPFLI_NUM_LL * CeilDiv(newcap, ZOPFLI_NUM_LL);
   dc = ZOPFLI_NUM_D * CeilDiv(newcap, ZOPFLI_NUM_D);
   store->litlens = (uint16_t*)ZopfliRealloc(
-      store->litlens, sizeof(*store->litlens) * newcap);
+      ctx, store->litlens, sizeof(*store->litlens) * newcap);
   store->dists = (uint16_t*)ZopfliRealloc(
-      store->dists, sizeof(*store->dists) * newcap);
-  store->pos = (size_t*)ZopfliRealloc(store->pos, sizeof(*store->pos) * newcap);
+      ctx, store->dists, sizeof(*store->dists) * newcap);
+  store->pos =
+      (size_t*)ZopfliRealloc(ctx, store->pos, sizeof(*store->pos) * newcap);
   store->ll_counts = (uint32_t*)ZopfliRealloc(
-      store->ll_counts, sizeof(*store->ll_counts) * llc);
+      ctx, store->ll_counts, sizeof(*store->ll_counts) * llc);
   store->d_counts = (uint32_t*)ZopfliRealloc(
-      store->d_counts, sizeof(*store->d_counts) * dc);
+      ctx, store->d_counts, sizeof(*store->d_counts) * dc);
   store->cap = newcap;
 }
 
@@ -78,22 +80,23 @@ void ZopfliResetLZ77Store(ZopfliLZ77Store* store) {
   store->size = 0;
 }
 
-void ZopfliCopyLZ77Store(
+void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
     const ZopfliLZ77Store* source, ZopfliLZ77Store* dest) {
   size_t i;
   size_t llsize = ZOPFLI_NUM_LL * CeilDiv(source->size, ZOPFLI_NUM_LL);
   size_t dsize = ZOPFLI_NUM_D * CeilDiv(source->size, ZOPFLI_NUM_D);
-  ZopfliCleanLZ77Store(dest);
+  ZopfliCleanLZ77Store(ctx, dest);
   ZopfliInitLZ77Store(source->data, dest);
   dest->litlens =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(*dest->litlens) * source->size);
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->litlens) * source->size);
   dest->dists =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(*dest->dists) * source->size);
-  dest->pos = (size_t*)ZopfliRealloc(NULL, sizeof(*dest->pos) * source->size);
+      (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->dists) * source->size);
+  dest->pos =
+      (size_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->pos) * source->size);
   dest->ll_counts =
-      (uint32_t*)ZopfliRealloc(NULL, sizeof(*dest->ll_counts) * llsize);
+      (uint32_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->ll_counts) * llsize);
   dest->d_counts =
-      (uint32_t*)ZopfliRealloc(NULL, sizeof(*dest->d_counts) * dsize);
+      (uint32_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->d_counts) * dsize);
 
   dest->size = source->size;
   dest->cap = source->size;
@@ -114,14 +117,14 @@ void ZopfliCopyLZ77Store(
 Appends the length and distance to the LZ77 arrays of the ZopfliLZ77Store.
 context must be a ZopfliLZ77Store*.
 */
-void ZopfliStoreLitLenDist(uint16_t length, uint16_t dist,
-                           size_t pos, ZopfliLZ77Store* store) {
+void ZopfliStoreLitLenDist(const ZopfliContext* ctx, uint16_t length,
+                           uint16_t dist, size_t pos, ZopfliLZ77Store* store) {
   size_t i;
   size_t origsize = store->size;
   size_t llstart = ZOPFLI_NUM_LL * (origsize / ZOPFLI_NUM_LL);
   size_t dstart = ZOPFLI_NUM_D * (origsize / ZOPFLI_NUM_D);
 
-  ZopfliReserveLZ77Store(store, origsize + 1);
+  ZopfliReserveLZ77Store(ctx, store, origsize + 1);
 
   /* Everytime the index wraps around, a new cumulative histogram is made: we're
   keeping one histogram value per LZ77 symbol rather than a full histogram for
@@ -155,11 +158,12 @@ void ZopfliStoreLitLenDist(uint16_t length, uint16_t dist,
   store->size = origsize + 1;
 }
 
-void ZopfliAppendLZ77Store(const ZopfliLZ77Store* store,
+void ZopfliAppendLZ77Store(const ZopfliContext* ctx,
+                           const ZopfliLZ77Store* store,
                            ZopfliLZ77Store* target) {
   size_t i;
   for (i = 0; i < store->size; i++) {
-    ZopfliStoreLitLenDist(store->litlens[i], store->dists[i],
+    ZopfliStoreLitLenDist(ctx, store->litlens[i], store->dists[i],
                           store->pos[i], target);
   }
 }
@@ -234,30 +238,37 @@ void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
   }
 }
 
-void ZopfliInitBlockState(const ZopfliOptions* options,
+void ZopfliInitBlockState(const ZopfliContext* ctx,
                           size_t blockstart, size_t blockend, int add_lmc,
                           ZopfliBlockState* s) {
-  s->options = options;
+  s->ctx = ctx;
   s->blockstart = blockstart;
   s->blockend = blockend;
   ZopfliInitKatajainenScratch(&s->katascratch);
+  /* Squeeze working buffers; allocated lazily by ZopfliLZ77Optimal[Fixed]. */
+  s->costs = NULL;
+  s->length_array = NULL;
+  s->dist_array = NULL;
+  s->path = NULL;
+  s->pathsize = 0;
+  s->pathcap = 0;
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (add_lmc) {
     s->lmc = (ZopfliLongestMatchCache*)ZopfliRealloc(
-        NULL, sizeof(ZopfliLongestMatchCache));
-    ZopfliInitCache(blockend - blockstart, s->lmc);
+        ctx, NULL, sizeof(ZopfliLongestMatchCache));
+    ZopfliInitCache(ctx, blockend - blockstart, s->lmc);
   } else {
-    s->lmc = 0;
+    s->lmc = NULL;
   }
 #endif
 }
 
 void ZopfliCleanBlockState(ZopfliBlockState* s) {
-  ZopfliCleanKatajainenScratch(&s->katascratch);
+  ZopfliCleanKatajainenScratch(s->ctx, &s->katascratch);
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   if (s->lmc) {
-    ZopfliCleanCache(s->lmc);
-    ZopfliRealloc(s->lmc, 0);
+    ZopfliCleanCache(s->ctx, s->lmc);
+    ZopfliRealloc(s->ctx, s->lmc, 0);
   }
 #endif
 }
@@ -648,7 +659,7 @@ void ZopfliLZ77Greedy(ZopfliBlockState* s, const uint8_t* in,
     if (match_available) {
       match_available = 0;
       if (lengthscore > prevlengthscore + 1) {
-        ZopfliStoreLitLenDist(in[i - 1], 0, i - 1, store);
+        ZopfliStoreLitLenDist(s->ctx, in[i - 1], 0, i - 1, store);
         if (lengthscore >= ZOPFLI_MIN_MATCH && leng < ZOPFLI_MAX_MATCH) {
           match_available = 1;
           prev_length = leng;
@@ -662,7 +673,7 @@ void ZopfliLZ77Greedy(ZopfliBlockState* s, const uint8_t* in,
         lengthscore = prevlengthscore;
         /* Add to output. */
         ZopfliVerifyLenDist(in, inend, i - 1, dist, leng);
-        ZopfliStoreLitLenDist(leng, dist, i - 1, store);
+        ZopfliStoreLitLenDist(s->ctx, leng, dist, i - 1, store);
         for (j = 2; j < leng; j++) {
           assert(i < inend);
           i++;
@@ -683,10 +694,10 @@ void ZopfliLZ77Greedy(ZopfliBlockState* s, const uint8_t* in,
     /* Add to output. */
     if (lengthscore >= ZOPFLI_MIN_MATCH) {
       ZopfliVerifyLenDist(in, inend, i, dist, leng);
-      ZopfliStoreLitLenDist(leng, dist, i, store);
+      ZopfliStoreLitLenDist(s->ctx, leng, dist, i, store);
     } else {
       leng = 1;
-      ZopfliStoreLitLenDist(in[i], 0, i, store);
+      ZopfliStoreLitLenDist(s->ctx, in[i], 0, i, store);
     }
     for (j = 1; j < leng; j++) {
       assert(i < inend);

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -313,45 +313,97 @@ void ZopfliVerifyLenDist(const unsigned char* data, size_t datasize, size_t pos,
 }
 
 /*
-Finds how long the match of scan and match is. Can be used to find how many
-bytes starting from scan, and from match, are equal. Returns the last byte
-after scan, which is still equal to the correspondinb byte after match.
-scan is the position to compare
-match is the earlier position to compare.
-end is the last possible byte, beyond which to stop looking.
-safe_end is a few (8) bytes before end, for comparing multiple bytes at once.
+Selects the GetMatch implementation:
+  - x86 and 64-bit targets: memcmp over 16-byte chunks. memcmp with a constant
+    size inlines to a wide compare (SSE on x86, ldp on aarch64) and needs no
+    alignment.
+  - Other (smaller) targets -- 32/16/8-bit non-x86, e.g. ARMv5/ARMv7, AVR: the
+    aligned word + match-splice path below. There memcmp would emit a per-iter
+    bcmp call and an unaligned word cast could fault.
+ZOPFLI_FORCE_SPLICE=N forces the splice path with an N-byte (4/2/1) native word,
+for verifying it on x86. The splice math is little-endian only.
+*/
+#if defined(ZOPFLI_FORCE_SPLICE)
+# define ZOPFLI_GM_SPLICE 1
+#elif !defined(__i386__) && !defined(__x86_64__) && !defined(_M_IX86) && \
+      !defined(_M_X64) && !defined(ZOPFLI_NATIVE_64BIT) && \
+      defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+# define ZOPFLI_GM_SPLICE 1
+#endif
+
+#if defined(ZOPFLI_GM_SPLICE)
+/* Native word for the splice path. The loop processes two of these per
+iteration (2x the native width: 8/4/2 bytes on 32/16/8-bit targets). */
+# if defined(ZOPFLI_FORCE_SPLICE) && ZOPFLI_FORCE_SPLICE == 4
+typedef uint32_t ZopfliNativeWord;
+# elif defined(ZOPFLI_FORCE_SPLICE) && ZOPFLI_FORCE_SPLICE == 2
+typedef uint16_t ZopfliNativeWord;
+# elif defined(ZOPFLI_FORCE_SPLICE) && ZOPFLI_FORCE_SPLICE == 1
+typedef uint8_t ZopfliNativeWord;
+# elif defined(ZOPFLI_NATIVE_32BIT)
+typedef uint32_t ZopfliNativeWord;
+# elif defined(ZOPFLI_NATIVE_16BIT)
+typedef uint16_t ZopfliNativeWord;
+# else
+typedef uint8_t ZopfliNativeWord;
+# endif
+#endif
+
+/*
+Returns the first position >= scan where scan and match differ, looking no
+further than end; the match length is the returned pointer minus scan. match is
+the earlier copy being compared.
+
+Compares wide chunks, then resolves the mismatching chunk one byte at a time.
+The bounds guard keeps every wide read inside the buffer.
 */
 static const unsigned char* GetMatch(const unsigned char* scan,
                                      const unsigned char* match,
-                                     const unsigned char* end,
-                                     const unsigned char* safe_end) {
+                                     const unsigned char* end) {
+#if defined(ZOPFLI_GM_SPLICE)
+  typedef ZopfliNativeWord W;
+  const uintptr_t ws = sizeof(W);   /* native word */
+  const uintptr_t step = 2 * ws;    /* bytes compared per iteration */
+  uintptr_t off;
 
-  if (sizeof(size_t) == 8) {
-    /* 8 checks at once per array bounds check (size_t is 64-bit). */
-    while (scan < safe_end && *((size_t*)scan) == *((size_t*)match)) {
-      scan += 8;
-      match += 8;
-    }
-  } else if (sizeof(unsigned int) == 4) {
-    /* 4 checks at once per array bounds check (unsigned int is 32-bit). */
-    while (scan < safe_end
-        && *((unsigned int*)scan) == *((unsigned int*)match)) {
-      scan += 4;
-      match += 4;
-    }
-  } else {
-    /* do 8 checks at once per array bounds check. */
-    while (scan < safe_end && *scan == *match && *++scan == *++match
-          && *++scan == *++match && *++scan == *++match
-          && *++scan == *++match && *++scan == *++match
-          && *++scan == *++match && *++scan == *++match) {
-      scan++; match++;
-    }
+  /* Align scan to a native-word boundary, comparing the head byte by byte. */
+  for (; ((uintptr_t)scan & (ws - 1)) != 0; ++scan, ++match) {
+    if (scan == end || *scan != *match) return scan;
   }
 
-  /* The remaining few bytes. */
-  while (scan != end && *scan == *match) {
-    scan++; match++;
+  off = (uintptr_t)match & (ws - 1);
+  if (off == 0) {
+    /* match is aligned too: two aligned word compares per iteration. */
+    for (; (uintptr_t)(end - scan) >= step; scan += step, match += step) {
+      if (*(const W*)scan != *(const W*)match) break;
+      if (*(const W*)(scan + ws) != *(const W*)(match + ws)) break;
+    }
+  } else if ((uintptr_t)(end - scan) >= step + ws) {
+    /* match is misaligned by off: read aligned words from the match side and
+    splice adjacent ones with the constant shift, carrying the high word as the
+    accumulator so each iteration loads only the two new words. */
+    const unsigned char* mp = match - off;
+    const unsigned lo = (unsigned)(off * CHAR_BIT);
+    const unsigned hi = (unsigned)(ws * CHAR_BIT) - lo;
+    W acc = *(const W*)mp;
+    for (; (uintptr_t)(end - scan) >= step + ws;
+         mp += step, scan += step, match += step) {
+      W n1 = *(const W*)(mp + ws);
+      W n2 = *(const W*)(mp + step);
+      if (*(const W*)scan != (W)((acc >> lo) | (n1 << hi))) break;
+      if (*(const W*)(scan + ws) != (W)((n1 >> lo) | (n2 << hi))) break;
+      acc = n2;
+    }
+  }
+#else
+  /* memcmp avoids unaligned word-cast faults; constant size still inlines. */
+  for (; (size_t)(end - scan) >= 16 && memcmp(scan, match, 16) == 0;
+       scan += 16, match += 16) {
+  }
+#endif
+
+  /* The remaining bytes, and any mismatching chunk, one byte at a time. */
+  for (; scan != end && *scan == *match; scan++, match++) {
   }
 
   return scan;
@@ -446,7 +498,6 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
   const unsigned char* scan;
   const unsigned char* match;
   const unsigned char* arrayend;
-  const unsigned char* arrayend_safe;
 #if ZOPFLI_MAX_CHAIN_HITS < ZOPFLI_WINDOW_SIZE
   int chain_counter = ZOPFLI_MAX_CHAIN_HITS;  /* For quitting early. */
 #endif
@@ -487,7 +538,6 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
     limit = size - pos;
   }
   arrayend = &array[pos] + limit;
-  arrayend_safe = arrayend - 8;
 
   assert(hval < 65536);
 
@@ -526,7 +576,7 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
           match += same;
         }
 #endif
-        scan = GetMatch(scan, match, arrayend, arrayend_safe);
+        scan = GetMatch(scan, match, arrayend);
         currentlength = (unsigned short)(scan - &array[pos]);  /* found len. */
       }
 

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -68,7 +68,7 @@ This is currently a bit under-used (with mainly only the longest match cache),
 but is kept for easy future expansion.
 */
 typedef struct ZopfliBlockState {
-  const ZopfliOptions* options;
+  const ZopfliContext* ctx;
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
   /* Cache for length/distance pairs found so far. */
@@ -83,17 +83,31 @@ typedef struct ZopfliBlockState {
   block-size evaluations don't malloc/free per call. Per block state, so
   thread-safe. */
   ZopfliKatajainenScratch katascratch;
+
+  /* Optimal-parse working buffers for the squeeze pass. Allocated once per
+  ZopfliLZ77Optimal[Fixed] call and reused across its iterations; carried here
+  so the DP helpers reach them via the block state instead of long parameter
+  lists. costs/length_array/dist_array are sized to the block (blocksize + 1);
+  path is the traced result, grown on demand. */
+  ZopfliCost* costs;
+  uint16_t* length_array;
+  uint16_t* dist_array;
+  uint16_t* path;
+  size_t pathsize;
+  size_t pathcap;
 } ZopfliBlockState;
 
 void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store);
-void ZopfliCleanLZ77Store(ZopfliLZ77Store* store);
+void ZopfliCleanLZ77Store(const ZopfliContext* ctx, ZopfliLZ77Store* store);
 /* Empties the store (size 0) but keeps its allocation, so it can be refilled
 without reallocating. */
 void ZopfliResetLZ77Store(ZopfliLZ77Store* store);
-void ZopfliCopyLZ77Store(const ZopfliLZ77Store* source, ZopfliLZ77Store* dest);
-void ZopfliStoreLitLenDist(uint16_t length, uint16_t dist,
-                           size_t pos, ZopfliLZ77Store* store);
-void ZopfliAppendLZ77Store(const ZopfliLZ77Store* store,
+void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
+                         const ZopfliLZ77Store* source, ZopfliLZ77Store* dest);
+void ZopfliStoreLitLenDist(const ZopfliContext* ctx, uint16_t length,
+                           uint16_t dist, size_t pos, ZopfliLZ77Store* store);
+void ZopfliAppendLZ77Store(const ZopfliContext* ctx,
+                           const ZopfliLZ77Store* store,
                            ZopfliLZ77Store* target);
 /* Gets the amount of raw bytes that this range of LZ77 symbols spans. */
 size_t ZopfliLZ77GetByteRange(const ZopfliLZ77Store* lz77,
@@ -105,7 +119,7 @@ void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
                             size_t lstart, size_t lend,
                             size_t* ll_counts, size_t* d_counts);
 
-void ZopfliInitBlockState(const ZopfliOptions* options,
+void ZopfliInitBlockState(const ZopfliContext* ctx,
                           size_t blockstart, size_t blockend, int add_lmc,
                           ZopfliBlockState* s);
 void ZopfliCleanBlockState(ZopfliBlockState* s);

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -45,13 +45,13 @@ ZopfliCleanLZ77Store to destroy it, and ZopfliStoreLitLenDist to append values.
 
 */
 typedef struct ZopfliLZ77Store {
-  unsigned short* litlens;  /* Lit or len. */
-  unsigned short* dists;  /* If 0: indicates literal in corresponding litlens,
+  uint16_t* litlens;  /* Lit or len. */
+  uint16_t* dists;  /* If 0: indicates literal in corresponding litlens,
       if > 0: length in corresponding litlens, this is the distance. */
   size_t size;
   size_t cap;  /* Allocated capacity in lz77 symbols, for reuse across runs. */
 
-  const unsigned char* data;  /* original data */
+  const uint8_t* data;  /* original data */
   size_t* pos;  /* position in data where this LZ77 command begins */
 
   /* Cumulative histograms wrapping around per chunk. Each chunk has the amount
@@ -61,26 +61,6 @@ typedef struct ZopfliLZ77Store {
   uint32_t* ll_counts;
   uint32_t* d_counts;
 } ZopfliLZ77Store;
-
-void ZopfliInitLZ77Store(const unsigned char* data, ZopfliLZ77Store* store);
-void ZopfliCleanLZ77Store(ZopfliLZ77Store* store);
-/* Empties the store (size 0) but keeps its allocation, so it can be refilled
-without reallocating. */
-void ZopfliResetLZ77Store(ZopfliLZ77Store* store);
-void ZopfliCopyLZ77Store(const ZopfliLZ77Store* source, ZopfliLZ77Store* dest);
-void ZopfliStoreLitLenDist(unsigned short length, unsigned short dist,
-                           size_t pos, ZopfliLZ77Store* store);
-void ZopfliAppendLZ77Store(const ZopfliLZ77Store* store,
-                           ZopfliLZ77Store* target);
-/* Gets the amount of raw bytes that this range of LZ77 symbols spans. */
-size_t ZopfliLZ77GetByteRange(const ZopfliLZ77Store* lz77,
-                              size_t lstart, size_t lend);
-/* Gets the histogram of lit/len and dist symbols in the given range, using the
-cumulative histograms, so faster than adding one by one for large range. Does
-not add the one end symbol of value 256. */
-void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
-                            size_t lstart, size_t lend,
-                            size_t* ll_counts, size_t* d_counts);
 
 /*
 Some state information for compressing a block.
@@ -105,6 +85,26 @@ typedef struct ZopfliBlockState {
   ZopfliKatajainenScratch katascratch;
 } ZopfliBlockState;
 
+void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store);
+void ZopfliCleanLZ77Store(ZopfliLZ77Store* store);
+/* Empties the store (size 0) but keeps its allocation, so it can be refilled
+without reallocating. */
+void ZopfliResetLZ77Store(ZopfliLZ77Store* store);
+void ZopfliCopyLZ77Store(const ZopfliLZ77Store* source, ZopfliLZ77Store* dest);
+void ZopfliStoreLitLenDist(uint16_t length, uint16_t dist,
+                           size_t pos, ZopfliLZ77Store* store);
+void ZopfliAppendLZ77Store(const ZopfliLZ77Store* store,
+                           ZopfliLZ77Store* target);
+/* Gets the amount of raw bytes that this range of LZ77 symbols spans. */
+size_t ZopfliLZ77GetByteRange(const ZopfliLZ77Store* lz77,
+                              size_t lstart, size_t lend);
+/* Gets the histogram of lit/len and dist symbols in the given range, using the
+cumulative histograms, so faster than adding one by one for large range. Does
+not add the one end symbol of value 256. */
+void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
+                            size_t lstart, size_t lend,
+                            size_t* ll_counts, size_t* d_counts);
+
 void ZopfliInitBlockState(const ZopfliOptions* options,
                           size_t blockstart, size_t blockend, int add_lmc,
                           ZopfliBlockState* s);
@@ -127,15 +127,15 @@ sublen: output array of 259 elements, or null. Has, for each length, the
     for convenience that the array is made 3 longer).
 */
 void ZopfliFindLongestMatch(
-    ZopfliBlockState *s, const ZopfliHash* h, const unsigned char* array,
+    ZopfliBlockState *s, const ZopfliHash* h, const uint8_t* array,
     size_t pos, size_t size, size_t limit,
-    unsigned short* sublen, unsigned short* distance, unsigned short* length);
+    uint16_t* sublen, uint16_t* distance, uint16_t* length);
 
 /*
 Verifies if length and dist are indeed valid, only used for assertion.
 */
-void ZopfliVerifyLenDist(const unsigned char* data, size_t datasize, size_t pos,
-                         unsigned short dist, unsigned short length);
+void ZopfliVerifyLenDist(const uint8_t* data, size_t datasize, size_t pos,
+                         uint16_t dist, uint16_t length);
 
 /*
 Does LZ77 using an algorithm similar to gzip, with lazy matching, rather than
@@ -144,7 +144,7 @@ The result is placed in the ZopfliLZ77Store.
 If instart is larger than 0, it uses values before instart as starting
 dictionary.
 */
-void ZopfliLZ77Greedy(ZopfliBlockState* s, const unsigned char* in,
+void ZopfliLZ77Greedy(ZopfliBlockState* s, const uint8_t* in,
                       size_t instart, size_t inend,
                       ZopfliLZ77Store* store, ZopfliHash* h);
 

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -587,8 +587,8 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     cost = ZopfliCalculateBlockSizeScratch(s->ctx, &s->katascratch,
                                            &currentstore, 0,
                                            currentstore.size, 2);
-    if (s->ctx->options->verbose_more
-        || (s->ctx->options->verbose && cost < bestcost)) {
+    if (s->ctx->options.verbose_more
+        || (s->ctx->options.verbose && cost < bestcost)) {
       fprintf(stderr, "Iteration %d: %d bit\n", i, (int) cost);
     }
     if (cost < bestcost) {

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -24,6 +24,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include <stdint.h>
 #include <stdio.h>
 
+#include "context.h"
 #include "deflate.h"
 #include "symbols.h"
 #include "tree.h"
@@ -216,10 +217,10 @@ Applies the optimal-parse cost update for a run of match lengths [klo, khi] that
 all share one distance, at block index j. Shared by the cached-run fast path and
 the freshly found-match path, so there is a single cost-update implementation.
 */
-static void UpdateCostForRange(ZopfliCost* costs, uint16_t* length_array,
-    uint16_t* dist_array, size_t j, size_t klo, size_t khi,
-    uint16_t dist, ZopfliCost dcost, const CostCache* cache,
+static void UpdateCostForRange(ZopfliBlockState* s, size_t j, size_t klo,
+    size_t khi, uint16_t dist, ZopfliCost dcost, const CostCache* cache,
     ZopfliCost costsj, ZopfliCost mincostaddcostj) {
+  ZopfliCost* costs = s->costs;
   size_t k;
   for (k = klo; k <= khi; k++) {
     ZopfliCost newCost;
@@ -229,8 +230,8 @@ static void UpdateCostForRange(ZopfliCost* costs, uint16_t* length_array,
     if (newCost < costs[j + k]) {
       assert(k <= ZOPFLI_MAX_MATCH);
       costs[j + k] = newCost;
-      length_array[j + k] = (uint16_t)k;
-      dist_array[j + k] = dist;
+      s->length_array[j + k] = (uint16_t)k;
+      s->dist_array[j + k] = dist;
     }
   }
 }
@@ -251,11 +252,11 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
                                     const uint8_t* in,
                                     size_t instart, size_t inend,
                                     const CostCache* cache,
-                                    uint16_t* length_array,
-                                    uint16_t* dist_array,
-                                    ZopfliHash* h, ZopfliCost* costs,
-                                    int build_hash) {
+                                    ZopfliHash* h, int build_hash) {
   /* Best cost to get here so far. */
+  ZopfliCost* costs = s->costs;
+  uint16_t* length_array = s->length_array;
+  uint16_t* dist_array = s->dist_array;
   size_t blocksize = inend - instart;
   size_t i = 0, k, kend;
   uint16_t leng;
@@ -362,7 +363,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
             size_t khi = ZOPFLI_MIN(runlen, kend);
             if (klo <= khi) {
               ZopfliCost dcost = cache->d_cost[ZopfliGetDistSymbol(rundist)];
-              UpdateCostForRange(costs, length_array, dist_array, j, klo, khi,
+              UpdateCostForRange(s, j, klo, khi,
                                  rundist, dcost, cache, costs[j],
                                  mincostaddcostj);
             }
@@ -390,7 +391,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       ZopfliCost dcost;
       while (khi + 1 <= kend && sublen[khi + 1] == rundist) khi++;
       dcost = cache->d_cost[ZopfliGetDistSymbol(rundist)];
-      UpdateCostForRange(costs, length_array, dist_array, j, k, khi,
+      UpdateCostForRange(s, j, k, khi,
                          rundist, dcost, cache, costs[j], mincostaddcostj);
       k = khi + 1;
     }
@@ -408,18 +409,18 @@ length_array. The length_array must contain the optimal length to reach that
 byte. The path will be filled with the lengths to use, so its data size will be
 the number of lz77 symbols.
 */
-static void TraceBackwards(size_t size, const uint16_t* length_array,
-                           uint16_t** path, size_t* pathsize,
-                           size_t* pathcap) {
+static void TraceBackwards(ZopfliBlockState* s, size_t size) {
+  const uint16_t* length_array = s->length_array;
   size_t index = size;
-  *pathsize = 0;  /* Reuse the buffer (kept allocated) across iterations. */
+  s->pathsize = 0;  /* Reuse the buffer (kept allocated) across iterations. */
   if (size == 0) return;
   for (;;) {
-    if (*pathsize == *pathcap) {
-      *pathcap = *pathcap ? ZOPFLI_GROW_CAP(*pathcap) : 16;
-      *path = (uint16_t*)ZopfliRealloc(*path, *pathcap * sizeof(**path));
+    if (s->pathsize == s->pathcap) {
+      s->pathcap = s->pathcap ? ZOPFLI_GROW_CAP(s->pathcap) : 16;
+      s->path = (uint16_t*)ZopfliRealloc(s->ctx, s->path,
+                                         s->pathcap * sizeof(*s->path));
     }
-    (*path)[(*pathsize)++] = length_array[index];
+    s->path[s->pathsize++] = length_array[index];
     assert(length_array[index] <= index);
     assert(length_array[index] <= ZOPFLI_MAX_MATCH);
     assert(length_array[index] != 0);
@@ -428,10 +429,10 @@ static void TraceBackwards(size_t size, const uint16_t* length_array,
   }
 
   /* Mirror result. */
-  for (index = 0; index < *pathsize / 2; index++) {
-    uint16_t temp = (*path)[index];
-    (*path)[index] = (*path)[*pathsize - index - 1];
-    (*path)[*pathsize - index - 1] = temp;
+  for (index = 0; index < s->pathsize / 2; index++) {
+    uint16_t temp = s->path[index];
+    s->path[index] = s->path[s->pathsize - index - 1];
+    s->path[s->pathsize - index - 1] = temp;
   }
 }
 
@@ -440,25 +441,25 @@ Outputs the lz77 symbols for the chosen path. Distances were already computed
 during GetBestLengths (dist_array, parallel to length_array), so unlike the
 forward pass, this needs no hash and no match recalculation.
 */
-static void FollowPath(const uint8_t* in, size_t instart, size_t inend,
-                       const uint16_t* path, size_t pathsize,
-                       const uint16_t* dist_array,
+static void FollowPath(ZopfliBlockState* s,
+                       const uint8_t* in, size_t instart, size_t inend,
                        ZopfliLZ77Store* store) {
+  const uint16_t* dist_array = s->dist_array;
   size_t i, pos = instart;
   size_t cur = 0;  /* Position within the block, i.e. pos - instart. */
 
   if (instart == inend) return;
 
-  for (i = 0; i < pathsize; i++) {
-    uint16_t length = path[i];
+  for (i = 0; i < s->pathsize; i++) {
+    uint16_t length = s->path[i];
     assert(pos < inend);
     if (length >= ZOPFLI_MIN_MATCH) {
       uint16_t dist = dist_array[cur + length];
       ZopfliVerifyLenDist(in, inend, pos, dist, length);
-      ZopfliStoreLitLenDist(length, dist, pos, store);
+      ZopfliStoreLitLenDist(s->ctx, length, dist, pos, store);
     } else {
       length = 1;
-      ZopfliStoreLitLenDist(in[pos], 0, pos, store);
+      ZopfliStoreLitLenDist(s->ctx, in[pos], 0, pos, store);
     }
     assert(pos + length <= inend);
     cur += length;
@@ -497,26 +498,47 @@ s: the block state
 in: the input data array
 instart: where to start
 inend: where to stop (not inclusive)
-path: pointer to dynamically allocated memory to store the path
-pathsize: pointer to the size of the dynamic path array
-length_array: array of size (inend - instart) used to store lengths
 cache: precomputed fixed-point cost model for this squeeze run
 store: place to output the LZ77 data
+The working buffers (costs/length_array/dist_array/path) live in the block state.
 returns the cost that was, according to the cost model, needed to get to the end.
     This is not the actual cost.
 */
 static ZopfliCost LZ77OptimalRun(ZopfliBlockState* s,
     const uint8_t* in, size_t instart, size_t inend,
-    uint16_t** path, size_t* pathsize, size_t* pathcap,
-    uint16_t* length_array, uint16_t* dist_array,
     const CostCache* cache, ZopfliLZ77Store* store,
-    ZopfliHash* h, ZopfliCost* costs, int build_hash) {
-  ZopfliCost cost = GetBestLengths(s, in, instart, inend, cache,
-                length_array, dist_array, h, costs, build_hash);
-  TraceBackwards(inend - instart, length_array, path, pathsize, pathcap);
-  FollowPath(in, instart, inend, *path, *pathsize, dist_array, store);
+    ZopfliHash* h, int build_hash) {
+  ZopfliCost cost = GetBestLengths(s, in, instart, inend, cache, h, build_hash);
+  TraceBackwards(s, inend - instart);
+  FollowPath(s, in, instart, inend, store);
   assert(cost < ZOPFLI_COST_SENTINEL);
   return cost;
+}
+
+/* Allocates the per-run squeeze working buffers into the block state, sized to
+the block; path grows on demand in TraceBackwards. Paired with FreeBlockBuffers
+at the end of the squeeze call. */
+static void AllocBlockBuffers(ZopfliBlockState* s, size_t blocksize) {
+  s->costs = (ZopfliCost*)ZopfliRealloc(
+      s->ctx, NULL, sizeof(*s->costs) * (blocksize + 1));
+  s->length_array = (uint16_t*)ZopfliRealloc(
+      s->ctx, NULL, sizeof(*s->length_array) * (blocksize + 1));
+  s->dist_array = (uint16_t*)ZopfliRealloc(
+      s->ctx, NULL, sizeof(*s->dist_array) * (blocksize + 1));
+  s->path = NULL;
+  s->pathsize = 0;
+  s->pathcap = 0;
+}
+
+static void FreeBlockBuffers(ZopfliBlockState* s) {
+  ZopfliRealloc(s->ctx, s->costs, 0);
+  ZopfliRealloc(s->ctx, s->length_array, 0);
+  ZopfliRealloc(s->ctx, s->dist_array, 0);
+  ZopfliRealloc(s->ctx, s->path, 0);
+  s->costs = NULL;
+  s->length_array = NULL;
+  s->dist_array = NULL;
+  s->path = NULL;
 }
 
 void ZopfliLZ77Optimal(ZopfliBlockState *s,
@@ -525,20 +547,11 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
                        ZopfliLZ77Store* store) {
   /* Dist to get to here with smallest cost. */
   size_t blocksize = inend - instart;
-  uint16_t* length_array =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
-  uint16_t* dist_array =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
-  uint16_t* path = 0;
-  size_t pathsize = 0;
-  size_t pathcap = 0;
   ZopfliLZ77Store currentstore;
   ZopfliHash hash;
   ZopfliHash* h = &hash;
   SymbolStats stats, beststats, laststats;
   int i;
-  ZopfliCost* costs =
-      (ZopfliCost*)ZopfliRealloc(NULL, sizeof(*costs) * (blocksize + 1));
   int shift = ZopfliGetCostShift(blocksize);
   CostCache cache;
   uint32_t cost;
@@ -552,7 +565,8 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   InitRanState(&ran_state);
   InitStats(&stats);
   ZopfliInitLZ77Store(in, &currentstore);
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, h);
+  ZopfliAllocHash(s->ctx, ZOPFLI_WINDOW_SIZE, h);
+  AllocBlockBuffers(s, blocksize);
 
   /* Do regular deflate, then loop multiple shortest path runs, each time using
   the statistics of the previous run. */
@@ -568,18 +582,18 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   for (i = 0; i < numiterations; i++) {
     ZopfliResetLZ77Store(&currentstore);
     BuildStatCostCache(&stats, shift, &cache);
-    LZ77OptimalRun(s, in, instart, inend, &path, &pathsize, &pathcap,
-                   length_array, dist_array, &cache, &currentstore, h, costs,
-                   build_hash);
+    LZ77OptimalRun(s, in, instart, inend, &cache, &currentstore, h, build_hash);
     if (i == 0) build_hash = !(s->lmc && s->lmc->all_complete);
-    cost = ZopfliCalculateBlockSizeScratch(&s->katascratch, &currentstore, 0,
+    cost = ZopfliCalculateBlockSizeScratch(s->ctx, &s->katascratch,
+                                           &currentstore, 0,
                                            currentstore.size, 2);
-    if (s->options->verbose_more || (s->options->verbose && cost < bestcost)) {
+    if (s->ctx->options->verbose_more
+        || (s->ctx->options->verbose && cost < bestcost)) {
       fprintf(stderr, "Iteration %d: %d bit\n", i, (int) cost);
     }
     if (cost < bestcost) {
       /* Copy to the output store. */
-      ZopfliCopyLZ77Store(&currentstore, store);
+      ZopfliCopyLZ77Store(s->ctx, &currentstore, store);
       CopyStats(&stats, &beststats);
       bestcost = cost;
     }
@@ -602,12 +616,9 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     lastcost = cost;
   }
 
-  ZopfliRealloc(length_array, 0);
-  ZopfliRealloc(dist_array, 0);
-  ZopfliRealloc(path, 0);
-  ZopfliRealloc(costs, 0);
-  ZopfliCleanLZ77Store(&currentstore);
-  ZopfliCleanHash(h);
+  FreeBlockBuffers(s);
+  ZopfliCleanLZ77Store(s->ctx, &currentstore);
+  ZopfliCleanHash(s->ctx, h);
 }
 
 void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
@@ -617,20 +628,12 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
 {
   /* Dist to get to here with smallest cost. */
   size_t blocksize = inend - instart;
-  uint16_t* length_array =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
-  uint16_t* dist_array =
-      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
-  uint16_t* path = 0;
-  size_t pathsize = 0;
-  size_t pathcap = 0;
   ZopfliHash hash;
   ZopfliHash* h = &hash;
-  ZopfliCost* costs =
-      (ZopfliCost*)ZopfliRealloc(NULL, sizeof(*costs) * (blocksize + 1));
   CostCache cache;
 
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, h);
+  ZopfliAllocHash(s->ctx, ZOPFLI_WINDOW_SIZE, h);
+  AllocBlockBuffers(s, blocksize);
 
   s->blockstart = instart;
   s->blockend = inend;
@@ -638,12 +641,8 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   /* Shortest path for fixed tree This one should give the shortest possible
   result for fixed tree, no repeated runs are needed since the tree is known. */
   BuildFixedCostCache(ZopfliGetCostShift(blocksize), &cache);
-  LZ77OptimalRun(s, in, instart, inend, &path, &pathsize, &pathcap,
-                 length_array, dist_array, &cache, store, h, costs, 1);
+  LZ77OptimalRun(s, in, instart, inend, &cache, store, h, 1);
 
-  ZopfliRealloc(length_array, 0);
-  ZopfliRealloc(dist_array, 0);
-  ZopfliRealloc(path, 0);
-  ZopfliRealloc(costs, 0);
-  ZopfliCleanHash(h);
+  FreeBlockBuffers(s);
+  ZopfliCleanHash(s->ctx, h);
 }

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -24,7 +24,6 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include <stdint.h>
 #include <stdio.h>
 
-#include "blocksplitter.h"
 #include "deflate.h"
 #include "symbols.h"
 #include "tree.h"
@@ -48,6 +47,28 @@ typedef struct SymbolStats {
   uint32_t ll_symbols[ZOPFLI_NUM_LL];
   uint32_t d_symbols[ZOPFLI_NUM_D];
 } SymbolStats;
+
+typedef struct RanState {
+  unsigned int m_w, m_z;
+} RanState;
+
+/*
+Fixed-point cost model for the optimal parse. Costs are bit lengths scaled by
+2^shift. The tables are precomputed once per forward pass so the hot inner loop
+is a couple of integer lookups and an add instead of a function call. Length and
+distance contributions are kept separate because a match's distance is only
+known per candidate length.
+*/
+typedef struct CostCache {
+  /* Cost of a literal byte, indexed by the byte value. */
+  ZopfliCost lit_cost[256];
+  /* Cost of a match's length, indexed by the length (3..ZOPFLI_MAX_MATCH). */
+  ZopfliCost ll_cost[ZOPFLI_MAX_MATCH + 1];
+  /* Cost of a match's distance, indexed by its distance symbol (0..29). */
+  ZopfliCost d_cost[ZOPFLI_NUM_D];
+  /* Smallest cost any match can have; lets the inner loop skip work. */
+  ZopfliCost mincost;
+} CostCache;
 
 /* Sets everything to 0. */
 static void InitStats(SymbolStats* stats) {
@@ -83,10 +104,6 @@ static void AddStatFreqsHalf(const SymbolStats* stats1,
   result->litlens[256] = 1;  /* End symbol. */
 }
 
-typedef struct RanState {
-  unsigned int m_w, m_z;
-} RanState;
-
 static void InitRanState(RanState* state) {
   state->m_w = 1;
   state->m_z = 2;
@@ -117,24 +134,6 @@ static void ClearStatFreqs(SymbolStats* stats) {
   for (i = 0; i < ZOPFLI_NUM_LL; i++) stats->litlens[i] = 0;
   for (i = 0; i < ZOPFLI_NUM_D; i++) stats->dists[i] = 0;
 }
-
-/*
-Fixed-point cost model for the optimal parse. Costs are bit lengths scaled by
-2^shift. The tables are precomputed once per forward pass so the hot inner loop
-is a couple of integer lookups and an add instead of a function call. Length and
-distance contributions are kept separate because a match's distance is only
-known per candidate length.
-*/
-typedef struct CostCache {
-  /* Cost of a literal byte, indexed by the byte value. */
-  ZopfliCost lit_cost[256];
-  /* Cost of a match's length, indexed by the length (3..ZOPFLI_MAX_MATCH). */
-  ZopfliCost ll_cost[ZOPFLI_MAX_MATCH + 1];
-  /* Cost of a match's distance, indexed by its distance symbol (0..29). */
-  ZopfliCost d_cost[ZOPFLI_NUM_D];
-  /* Smallest cost any match can have; lets the inner loop skip work. */
-  ZopfliCost mincost;
-} CostCache;
 
 int ZopfliGetCostShift(size_t blocksize) {
   /* A single position costs at most ~32 bits, so a whole block costs less than
@@ -215,11 +214,11 @@ static void BuildFixedCostCache(int shift, CostCache* c) {
 /*
 Applies the optimal-parse cost update for a run of match lengths [klo, khi] that
 all share one distance, at block index j. Shared by the cached-run fast path and
-the freshly-found-match path so there is a single cost-update implementation.
+the freshly found-match path, so there is a single cost-update implementation.
 */
-static void UpdateCostForRange(ZopfliCost* costs, unsigned short* length_array,
-    unsigned short* dist_array, size_t j, size_t klo, size_t khi,
-    unsigned short dist, ZopfliCost dcost, const CostCache* cache,
+static void UpdateCostForRange(ZopfliCost* costs, uint16_t* length_array,
+    uint16_t* dist_array, size_t j, size_t klo, size_t khi,
+    uint16_t dist, ZopfliCost dcost, const CostCache* cache,
     ZopfliCost costsj, ZopfliCost mincostaddcostj) {
   size_t k;
   for (k = klo; k <= khi; k++) {
@@ -230,7 +229,7 @@ static void UpdateCostForRange(ZopfliCost* costs, unsigned short* length_array,
     if (newCost < costs[j + k]) {
       assert(k <= ZOPFLI_MAX_MATCH);
       costs[j + k] = newCost;
-      length_array[j + k] = (unsigned short)k;
+      length_array[j + k] = (uint16_t)k;
       dist_array[j + k] = dist;
     }
   }
@@ -249,19 +248,19 @@ length_array: output array of size (inend - instart) which will receive the best
 returns the cost that was, according to the cost model, needed to get to the end.
 */
 static ZopfliCost GetBestLengths(ZopfliBlockState *s,
-                                    const unsigned char* in,
+                                    const uint8_t* in,
                                     size_t instart, size_t inend,
                                     const CostCache* cache,
-                                    unsigned short* length_array,
-                                    unsigned short* dist_array,
+                                    uint16_t* length_array,
+                                    uint16_t* dist_array,
                                     ZopfliHash* h, ZopfliCost* costs,
                                     int build_hash) {
   /* Best cost to get here so far. */
   size_t blocksize = inend - instart;
   size_t i = 0, k, kend;
-  unsigned short leng;
-  unsigned short dist;
-  unsigned short sublen[259];
+  uint16_t leng;
+  uint16_t dist;
+  uint16_t sublen[259];
   size_t windowstart = instart > ZOPFLI_WINDOW_SIZE
       ? instart - ZOPFLI_WINDOW_SIZE : 0;
   ZopfliCost result;
@@ -353,13 +352,13 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
         run's threshold is cachedlen, so the klo > kend test always terminates
         before reading past it. */
         if (cachedlen >= ZOPFLI_MIN_MATCH) {
-          const unsigned char* run =
+          const uint8_t* run =
               &s->lmc->pool[(size_t)s->lmc->run_off[lmcpos] * 3];
           size_t klo;
           kend = ZOPFLI_MIN((size_t)cachedlen, inend - i);
           for (klo = 3; klo <= kend; run += 3) {
             size_t runlen = (size_t)run[0] + 3;
-            unsigned short rundist = (unsigned short)(run[1] + 256 * run[2]);
+            uint16_t rundist = (uint16_t)(run[1] + 256 * run[2]);
             size_t khi = ZOPFLI_MIN(runlen, kend);
             if (klo <= khi) {
               ZopfliCost dcost = cache->d_cost[ZopfliGetDistSymbol(rundist)];
@@ -386,7 +385,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
     kend = ZOPFLI_MIN(leng, inend - i);
     k = 3;
     while (k <= kend) {
-      unsigned short rundist = sublen[k];
+      uint16_t rundist = sublen[k];
       size_t khi = k;
       ZopfliCost dcost;
       while (khi + 1 <= kend && sublen[khi + 1] == rundist) khi++;
@@ -404,17 +403,23 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
 }
 
 /*
-Calculates the optimal path of lz77 lengths to use, from the calculated
+Calculates the optimal path of lz77 lengths to use from the calculated
 length_array. The length_array must contain the optimal length to reach that
 byte. The path will be filled with the lengths to use, so its data size will be
-the amount of lz77 symbols.
+the number of lz77 symbols.
 */
-static void TraceBackwards(size_t size, const unsigned short* length_array,
-                           unsigned short** path, size_t* pathsize) {
+static void TraceBackwards(size_t size, const uint16_t* length_array,
+                           uint16_t** path, size_t* pathsize,
+                           size_t* pathcap) {
   size_t index = size;
+  *pathsize = 0;  /* Reuse the buffer (kept allocated) across iterations. */
   if (size == 0) return;
   for (;;) {
-    ZOPFLI_APPEND_DATA(length_array[index], path, pathsize);
+    if (*pathsize == *pathcap) {
+      *pathcap = *pathcap ? ZOPFLI_GROW_CAP(*pathcap) : 16;
+      *path = (uint16_t*)ZopfliRealloc(*path, *pathcap * sizeof(**path));
+    }
+    (*path)[(*pathsize)++] = length_array[index];
     assert(length_array[index] <= index);
     assert(length_array[index] <= ZOPFLI_MAX_MATCH);
     assert(length_array[index] != 0);
@@ -424,7 +429,7 @@ static void TraceBackwards(size_t size, const unsigned short* length_array,
 
   /* Mirror result. */
   for (index = 0; index < *pathsize / 2; index++) {
-    unsigned short temp = (*path)[index];
+    uint16_t temp = (*path)[index];
     (*path)[index] = (*path)[*pathsize - index - 1];
     (*path)[*pathsize - index - 1] = temp;
   }
@@ -433,11 +438,11 @@ static void TraceBackwards(size_t size, const unsigned short* length_array,
 /*
 Outputs the lz77 symbols for the chosen path. Distances were already computed
 during GetBestLengths (dist_array, parallel to length_array), so unlike the
-forward pass this needs no hash and no match recalculation.
+forward pass, this needs no hash and no match recalculation.
 */
-static void FollowPath(const unsigned char* in, size_t instart, size_t inend,
-                       const unsigned short* path, size_t pathsize,
-                       const unsigned short* dist_array,
+static void FollowPath(const uint8_t* in, size_t instart, size_t inend,
+                       const uint16_t* path, size_t pathsize,
+                       const uint16_t* dist_array,
                        ZopfliLZ77Store* store) {
   size_t i, pos = instart;
   size_t cur = 0;  /* Position within the block, i.e. pos - instart. */
@@ -445,10 +450,10 @@ static void FollowPath(const unsigned char* in, size_t instart, size_t inend,
   if (instart == inend) return;
 
   for (i = 0; i < pathsize; i++) {
-    unsigned short length = path[i];
+    uint16_t length = path[i];
     assert(pos < inend);
     if (length >= ZOPFLI_MIN_MATCH) {
-      unsigned short dist = dist_array[cur + length];
+      uint16_t dist = dist_array[cur + length];
       ZopfliVerifyLenDist(in, inend, pos, dist, length);
       ZopfliStoreLitLenDist(length, dist, pos, store);
     } else {
@@ -501,41 +506,39 @@ returns the cost that was, according to the cost model, needed to get to the end
     This is not the actual cost.
 */
 static ZopfliCost LZ77OptimalRun(ZopfliBlockState* s,
-    const unsigned char* in, size_t instart, size_t inend,
-    unsigned short** path, size_t* pathsize,
-    unsigned short* length_array, unsigned short* dist_array,
+    const uint8_t* in, size_t instart, size_t inend,
+    uint16_t** path, size_t* pathsize, size_t* pathcap,
+    uint16_t* length_array, uint16_t* dist_array,
     const CostCache* cache, ZopfliLZ77Store* store,
     ZopfliHash* h, ZopfliCost* costs, int build_hash) {
   ZopfliCost cost = GetBestLengths(s, in, instart, inend, cache,
                 length_array, dist_array, h, costs, build_hash);
-  free(*path);
-  *path = 0;
-  *pathsize = 0;
-  TraceBackwards(inend - instart, length_array, path, pathsize);
+  TraceBackwards(inend - instart, length_array, path, pathsize, pathcap);
   FollowPath(in, instart, inend, *path, *pathsize, dist_array, store);
   assert(cost < ZOPFLI_COST_SENTINEL);
   return cost;
 }
 
 void ZopfliLZ77Optimal(ZopfliBlockState *s,
-                       const unsigned char* in, size_t instart, size_t inend,
+                       const uint8_t* in, size_t instart, size_t inend,
                        int numiterations,
                        ZopfliLZ77Store* store) {
   /* Dist to get to here with smallest cost. */
   size_t blocksize = inend - instart;
-  unsigned short* length_array =
-      (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
-  unsigned short* dist_array =
-      (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
-  unsigned short* path = 0;
+  uint16_t* length_array =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
+  uint16_t* dist_array =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
+  uint16_t* path = 0;
   size_t pathsize = 0;
+  size_t pathcap = 0;
   ZopfliLZ77Store currentstore;
   ZopfliHash hash;
   ZopfliHash* h = &hash;
   SymbolStats stats, beststats, laststats;
   int i;
   ZopfliCost* costs =
-      (ZopfliCost*)malloc(sizeof(*costs) * (blocksize + 1));
+      (ZopfliCost*)ZopfliRealloc(NULL, sizeof(*costs) * (blocksize + 1));
   int shift = ZopfliGetCostShift(blocksize);
   CostCache cache;
   uint32_t cost;
@@ -545,10 +548,6 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   RanState ran_state;
   int lastrandomstep = -1;
   int build_hash;
-
-  if (!costs) exit(-1); /* Allocation failed. */
-  if (!length_array) exit(-1); /* Allocation failed. */
-  if (!dist_array) exit(-1); /* Allocation failed. */
 
   InitRanState(&ran_state);
   InitStats(&stats);
@@ -569,8 +568,9 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   for (i = 0; i < numiterations; i++) {
     ZopfliResetLZ77Store(&currentstore);
     BuildStatCostCache(&stats, shift, &cache);
-    LZ77OptimalRun(s, in, instart, inend, &path, &pathsize, length_array,
-                   dist_array, &cache, &currentstore, h, costs, build_hash);
+    LZ77OptimalRun(s, in, instart, inend, &path, &pathsize, &pathcap,
+                   length_array, dist_array, &cache, &currentstore, h, costs,
+                   build_hash);
     if (i == 0) build_hash = !(s->lmc && s->lmc->all_complete);
     cost = ZopfliCalculateBlockSizeScratch(&s->katascratch, &currentstore, 0,
                                            currentstore.size, 2);
@@ -602,36 +602,33 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     lastcost = cost;
   }
 
-  free(length_array);
-  free(dist_array);
-  free(path);
-  free(costs);
+  ZopfliRealloc(length_array, 0);
+  ZopfliRealloc(dist_array, 0);
+  ZopfliRealloc(path, 0);
+  ZopfliRealloc(costs, 0);
   ZopfliCleanLZ77Store(&currentstore);
   ZopfliCleanHash(h);
 }
 
 void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
-                            const unsigned char* in,
+                            const uint8_t* in,
                             size_t instart, size_t inend,
                             ZopfliLZ77Store* store)
 {
   /* Dist to get to here with smallest cost. */
   size_t blocksize = inend - instart;
-  unsigned short* length_array =
-      (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
-  unsigned short* dist_array =
-      (unsigned short*)malloc(sizeof(unsigned short) * (blocksize + 1));
-  unsigned short* path = 0;
+  uint16_t* length_array =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
+  uint16_t* dist_array =
+      (uint16_t*)ZopfliRealloc(NULL, sizeof(uint16_t) * (blocksize + 1));
+  uint16_t* path = 0;
   size_t pathsize = 0;
+  size_t pathcap = 0;
   ZopfliHash hash;
   ZopfliHash* h = &hash;
   ZopfliCost* costs =
-      (ZopfliCost*)malloc(sizeof(*costs) * (blocksize + 1));
+      (ZopfliCost*)ZopfliRealloc(NULL, sizeof(*costs) * (blocksize + 1));
   CostCache cache;
-
-  if (!costs) exit(-1); /* Allocation failed. */
-  if (!length_array) exit(-1); /* Allocation failed. */
-  if (!dist_array) exit(-1); /* Allocation failed. */
 
   ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, h);
 
@@ -641,12 +638,12 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   /* Shortest path for fixed tree This one should give the shortest possible
   result for fixed tree, no repeated runs are needed since the tree is known. */
   BuildFixedCostCache(ZopfliGetCostShift(blocksize), &cache);
-  LZ77OptimalRun(s, in, instart, inend, &path, &pathsize,
+  LZ77OptimalRun(s, in, instart, inend, &path, &pathsize, &pathcap,
                  length_array, dist_array, &cache, store, h, costs, 1);
 
-  free(length_array);
-  free(dist_array);
-  free(path);
-  free(costs);
+  ZopfliRealloc(length_array, 0);
+  ZopfliRealloc(dist_array, 0);
+  ZopfliRealloc(path, 0);
+  ZopfliRealloc(costs, 0);
   ZopfliCleanHash(h);
 }

--- a/src/zopfli/squeeze.h
+++ b/src/zopfli/squeeze.h
@@ -46,7 +46,7 @@ If instart is larger than 0, it uses values before instart as starting
 dictionary.
 */
 void ZopfliLZ77Optimal(ZopfliBlockState *s,
-                       const unsigned char* in, size_t instart, size_t inend,
+                       const uint8_t* in, size_t instart, size_t inend,
                        int numiterations,
                        ZopfliLZ77Store* store);
 
@@ -61,7 +61,7 @@ If instart is larger than 0, it uses values before instart as starting
 dictionary.
 */
 void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
-                            const unsigned char* in,
+                            const uint8_t* in,
                             size_t instart, size_t inend,
                             ZopfliLZ77Store* store);
 

--- a/src/zopfli/symbols.h
+++ b/src/zopfli/symbols.h
@@ -56,7 +56,7 @@ ZOPFLI_INLINE int ZopfliGetDistSymbol(int dist) {
 
 /* Gets the amount of extra bits for the given length, cfr. the DEFLATE spec. */
 ZOPFLI_INLINE int ZopfliGetLengthExtraBits(int l) {
-  static const int table[259] = {
+  static const uint8_t table[259] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -79,7 +79,7 @@ ZOPFLI_INLINE int ZopfliGetLengthExtraBits(int l) {
 
 /* Gets value of the extra bits for the given length, cfr. the DEFLATE spec. */
 ZOPFLI_INLINE int ZopfliGetLengthExtraBitsValue(int l) {
-  static const int table[259] = {
+  static const uint8_t table[259] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 2, 3, 0,
     1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
     6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6,
@@ -101,7 +101,7 @@ Gets the symbol for the given length, cfr. the DEFLATE spec.
 Returns the symbol in the range [257-285] (inclusive)
 */
 ZOPFLI_INLINE int ZopfliGetLengthSymbol(int l) {
-  static const int table[259] = {
+  static const uint16_t table[259] = {
     0, 0, 0, 257, 258, 259, 260, 261, 262, 263, 264,
     265, 265, 266, 266, 267, 267, 268, 268,
     269, 269, 269, 269, 270, 270, 270, 270,
@@ -140,7 +140,7 @@ ZOPFLI_INLINE int ZopfliGetLengthSymbol(int l) {
 
 /* Gets the amount of extra bits for the given length symbol. */
 ZOPFLI_INLINE int ZopfliGetLengthSymbolExtraBits(int s) {
-  static const int table[29] = {
+  static const uint8_t table[29] = {
     0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
     3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0
   };
@@ -149,7 +149,7 @@ ZOPFLI_INLINE int ZopfliGetLengthSymbolExtraBits(int s) {
 
 /* Gets the amount of extra bits for the given distance symbol. */
 ZOPFLI_INLINE int ZopfliGetDistSymbolExtraBits(int s) {
-  static const int table[30] = {
+  static const uint8_t table[30] = {
     0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8,
     9, 9, 10, 10, 11, 11, 12, 12, 13, 13
   };

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -28,12 +28,12 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include "katajainen.h"
 #include "util.h"
 
-void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
-                            unsigned* symbols) {
+void ZopfliLengthsToSymbols(const ZopfliContext* ctx, const unsigned* lengths,
+                            size_t n, unsigned maxbits, unsigned* symbols) {
   size_t* bl_count =
-      (size_t*)ZopfliRealloc(NULL, sizeof(size_t) * (maxbits + 1));
+      (size_t*)ZopfliRealloc(ctx, NULL, sizeof(size_t) * (maxbits + 1));
   size_t* next_code =
-      (size_t*)ZopfliRealloc(NULL, sizeof(size_t) * (maxbits + 1));
+      (size_t*)ZopfliRealloc(ctx, NULL, sizeof(size_t) * (maxbits + 1));
   unsigned bits, i;
   unsigned code;
 
@@ -67,8 +67,8 @@ void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
     }
   }
 
-  ZopfliRealloc(bl_count, 0);
-  ZopfliRealloc(next_code, 0);
+  ZopfliRealloc(ctx, bl_count, 0);
+  ZopfliRealloc(ctx, next_code, 0);
 }
 
 /*
@@ -114,19 +114,21 @@ void ZopfliCalculateEntropy(const size_t* count, size_t n,
   }
 }
 
-void ZopfliCalculateBitLengthsScratch(ZopfliKatajainenScratch* scratch,
+void ZopfliCalculateBitLengthsScratch(const ZopfliContext* ctx,
+                                      ZopfliKatajainenScratch* scratch,
                                       const size_t* count, size_t n, int maxbits,
                                       unsigned* bitlengths) {
   int error = ZopfliLengthLimitedCodeLengthsScratch(
-      scratch, count, (int)n, maxbits, bitlengths);
+      ctx, scratch, count, (int)n, maxbits, bitlengths);
   (void) error;
   assert(!error);
 }
 
-void ZopfliCalculateBitLengths(const size_t* count, size_t n, int maxbits,
-                               unsigned* bitlengths) {
+void ZopfliCalculateBitLengths(const ZopfliContext* ctx, const size_t* count,
+                               size_t n, int maxbits, unsigned* bitlengths) {
   ZopfliKatajainenScratch scratch;
   ZopfliInitKatajainenScratch(&scratch);
-  ZopfliCalculateBitLengthsScratch(&scratch, count, n, maxbits, bitlengths);
-  ZopfliCleanKatajainenScratch(&scratch);
+  ZopfliCalculateBitLengthsScratch(ctx, &scratch, count, n, maxbits,
+                                   bitlengths);
+  ZopfliCleanKatajainenScratch(ctx, &scratch);
 }

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -30,8 +30,10 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
                             unsigned* symbols) {
-  size_t* bl_count = (size_t*)malloc(sizeof(size_t) * (maxbits + 1));
-  size_t* next_code = (size_t*)malloc(sizeof(size_t) * (maxbits + 1));
+  size_t* bl_count =
+      (size_t*)ZopfliRealloc(NULL, sizeof(size_t) * (maxbits + 1));
+  size_t* next_code =
+      (size_t*)ZopfliRealloc(NULL, sizeof(size_t) * (maxbits + 1));
   unsigned bits, i;
   unsigned code;
 
@@ -65,8 +67,8 @@ void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
     }
   }
 
-  free(bl_count);
-  free(next_code);
+  ZopfliRealloc(bl_count, 0);
+  ZopfliRealloc(next_code, 0);
 }
 
 /*

--- a/src/zopfli/tree.h
+++ b/src/zopfli/tree.h
@@ -34,22 +34,23 @@ Utilities for creating and using Huffman trees.
 Calculates the bitlengths for the Huffman tree, based on the counts of each
 symbol.
 */
-void ZopfliCalculateBitLengths(const size_t* count, size_t n, int maxbits,
-                               unsigned *bitlengths);
+void ZopfliCalculateBitLengths(const ZopfliContext* ctx, const size_t* count,
+                               size_t n, int maxbits, unsigned *bitlengths);
 
 /*
 As ZopfliCalculateBitLengths, but reuses caller-owned scratch (thread-safe when
 each thread passes its own).
 */
-void ZopfliCalculateBitLengthsScratch(ZopfliKatajainenScratch* scratch,
+void ZopfliCalculateBitLengthsScratch(const ZopfliContext* ctx,
+                                      ZopfliKatajainenScratch* scratch,
                                       const size_t* count, size_t n, int maxbits,
                                       unsigned *bitlengths);
 
 /*
 Converts a series of Huffman tree bitlengths, to the bit values of the symbols.
 */
-void ZopfliLengthsToSymbols(const unsigned* lengths, size_t n, unsigned maxbits,
-                            unsigned* symbols);
+void ZopfliLengthsToSymbols(const ZopfliContext* ctx, const unsigned* lengths,
+                            size_t n, unsigned maxbits, unsigned* symbols);
 
 /*
 Calculates the entropy (ideal bit length) of each symbol from its count, as

--- a/src/zopfli/util.c
+++ b/src/zopfli/util.c
@@ -20,6 +20,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 #include "util.h"
 
+#include "context.h"
 #include "zopfli.h"
 
 #include <assert.h>
@@ -35,25 +36,38 @@ static void* ZopfliOutOfMemory(size_t size) {
   return NULL;  /* unreachable (exit is noreturn); satisfies MSVC's checker */
 }
 
-void* ZopfliRealloc(void* ptr, size_t size) {
-  /* size 0 -> portable free (NULL); ptr NULL -> realloc acts as malloc. */
-  void* result = size == 0 ? (free(ptr), NULL) : realloc(ptr, size);
+/* Default allocator: the realloc-style contract every zrealloc hook follows.
+size 0 frees ptr and returns NULL (portable, unlike realloc(ptr, 0)); ptr NULL
+allocates. OOM handling lives in ZopfliRealloc, not here. */
+static void* ZopfliDefaultRealloc(void* alloc_context, void* ptr, size_t size) {
+  (void)alloc_context;
+  return size == 0 ? (free(ptr), NULL) : realloc(ptr, size);
+}
+
+void* ZopfliRealloc(const ZopfliContext* ctx, void* ptr, size_t size) {
+  /* Dispatch to the context's allocator (the default when unset or ctx is
+  NULL), then apply the uniform out-of-memory check. */
+  void* (*ra)(void*, void*, size_t) =
+      ctx && ctx->options->zrealloc ? ctx->options->zrealloc
+                                    : ZopfliDefaultRealloc;
+  void* alloc_context = ctx ? ctx->options->alloc_context : NULL;
+  void* result = ra(alloc_context, ptr, size);
   return size != 0 && !result ? ZopfliOutOfMemory(size) : result;
 }
 
-void ZopfliBufPush(ZopfliBuf* b, uint8_t value) {
+void ZopfliBufPush(const ZopfliContext* ctx, ZopfliBuf* b, uint8_t value) {
   if (b->size == b->cap) {
     b->cap = b->cap ? ZOPFLI_GROW_CAP(b->cap) : 16;
-    b->data = (uint8_t*)ZopfliRealloc(b->data, b->cap);
+    b->data = (uint8_t*)ZopfliRealloc(ctx, b->data, b->cap);
   }
   b->data[b->size++] = value;
 }
 
 void ZopfliInitOptions(ZopfliOptions* options) {
-  options->verbose = 0;
-  options->verbose_more = 0;
-  options->numiterations = 0;  /* 0 = auto (size-dependent). */
+  /* Zero everything (numiterations 0 = auto; alloc_context NULL), then set the
+  non-zero defaults and point zrealloc at the internal default allocator. */
+  memset(options, 0, sizeof(*options));
   options->blocksplitting = 1;
-  options->blocksplittinglast = 0;
   options->blocksplittingmax = 15;
+  options->zrealloc = ZopfliDefaultRealloc;
 }

--- a/src/zopfli/util.c
+++ b/src/zopfli/util.c
@@ -15,6 +15,7 @@ limitations under the License.
 
 Author: lode.vandevenne@gmail.com (Lode Vandevenne)
 Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
+Author: afalls@qvxlabs.com (Ardavon Falls)
 */
 
 #include "util.h"
@@ -24,6 +25,29 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+/* Reports an allocation failure and aborts; callers never see a failed
+ZopfliRealloc and need no out-of-memory checks of their own. Returns void* (it
+never returns, since exit() is noreturn) so it slots into the ternary below. */
+static void* ZopfliOutOfMemory(size_t size) {
+  fprintf(stderr, "Error: out of memory allocating %zu bytes\n", size);
+  exit(-1);
+  return NULL;  /* unreachable (exit is noreturn); satisfies MSVC's checker */
+}
+
+void* ZopfliRealloc(void* ptr, size_t size) {
+  /* size 0 -> portable free (NULL); ptr NULL -> realloc acts as malloc. */
+  void* result = size == 0 ? (free(ptr), NULL) : realloc(ptr, size);
+  return size != 0 && !result ? ZopfliOutOfMemory(size) : result;
+}
+
+void ZopfliBufPush(ZopfliBuf* b, uint8_t value) {
+  if (b->size == b->cap) {
+    b->cap = b->cap ? ZOPFLI_GROW_CAP(b->cap) : 16;
+    b->data = (uint8_t*)ZopfliRealloc(b->data, b->cap);
+  }
+  b->data[b->size++] = value;
+}
 
 void ZopfliInitOptions(ZopfliOptions* options) {
   options->verbose = 0;

--- a/src/zopfli/util.c
+++ b/src/zopfli/util.c
@@ -32,7 +32,7 @@ ZopfliRealloc and need no out-of-memory checks of their own. Returns void* (it
 never returns, since exit() is noreturn) so it slots into the ternary below. */
 static void* ZopfliOutOfMemory(size_t size) {
   fprintf(stderr, "Error: out of memory allocating %zu bytes\n", size);
-  exit(-1);
+  exit(EXIT_FAILURE);
   return NULL;  /* unreachable (exit is noreturn); satisfies MSVC's checker */
 }
 

--- a/src/zopfli/util.c
+++ b/src/zopfli/util.c
@@ -36,22 +36,29 @@ static void* ZopfliOutOfMemory(size_t size) {
   return NULL;  /* unreachable (exit is noreturn); satisfies MSVC's checker */
 }
 
-/* Default allocator: the realloc-style contract every zrealloc hook follows.
+/* Default allocator: in the realloc-style contract every zrealloc hook follows.
 size 0 frees ptr and returns NULL (portable, unlike realloc(ptr, 0)); ptr NULL
 allocates. OOM handling lives in ZopfliRealloc, not here. */
-static void* ZopfliDefaultRealloc(void* alloc_context, void* ptr, size_t size) {
+void* ZopfliDefaultRealloc(void* alloc_context, void* ptr, size_t size) {
   (void)alloc_context;
   return size == 0 ? (free(ptr), NULL) : realloc(ptr, size);
 }
 
+/* Context backed by the default allocator, for allocations outside any
+caller-supplied options (CLI helpers, option-less size calculators, tests), so
+every allocation can pass a non-NULL context. */
+const ZopfliContext* ZopfliDefaultContext(void) {
+  static const ZopfliContext kDefaultContext = {
+    { 0, 0, 0, 1, 0, 15, ZopfliDefaultRealloc, NULL }
+  };
+  return &kDefaultContext;
+}
+
 void* ZopfliRealloc(const ZopfliContext* ctx, void* ptr, size_t size) {
-  /* Dispatch to the context's allocator (the default when unset or ctx is
-  NULL), then apply the uniform out-of-memory check. */
-  void* (*ra)(void*, void*, size_t) =
-      ctx && ctx->options->zrealloc ? ctx->options->zrealloc
-                                    : ZopfliDefaultRealloc;
-  void* alloc_context = ctx ? ctx->options->alloc_context : NULL;
-  void* result = ra(alloc_context, ptr, size);
+  /* ctx is never NULL; its options always name an allocator hook. */
+  void* result;
+  assert(ctx && ctx->options.zrealloc);
+  result = ctx->options.zrealloc(ctx->options.alloc_context, ptr, size);
   return size != 0 && !result ? ZopfliOutOfMemory(size) : result;
 }
 

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -26,6 +26,7 @@ basic deflate specification values and generic program options.
 #ifndef ZOPFLI_UTIL_H_
 #define ZOPFLI_UTIL_H_
 
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
@@ -48,6 +49,17 @@ uses the _BitScanReverse intrinsic (anything else falls back to a loop). */
 #endif
 #if !defined(ZOPFLI_HAS_BUILTIN_CLZ) && defined(_MSC_VER)
 # include <intrin.h>
+#endif
+
+/* Native machine word width, used to size GetMatch's word-at-a-time scan.
+ZOPFLI_NATIVE_64BIT when size_t is 64-bit, ZOPFLI_NATIVE_32BIT when unsigned int
+is 32-bit, ZOPFLI_NATIVE_16BIT when it is 16-bit; smaller targets define none. */
+#if SIZE_MAX == 0xFFFFFFFFFFFFFFFFu
+# define ZOPFLI_NATIVE_64BIT 1
+#elif UINT_MAX == 0xFFFFFFFFu
+# define ZOPFLI_NATIVE_32BIT 1
+#elif UINT_MAX == 0xFFFFu
+# define ZOPFLI_NATIVE_16BIT 1
 #endif
 
 /* Minimum and maximum length that can be encoded in deflate. */

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -190,22 +190,24 @@ Precondition: allocated size of data is at least a power of two greater than or
 equal than *size.
 */
 #ifdef __cplusplus /* C++ cannot assign void* from malloc to *data */
-#define ZOPFLI_APPEND_DATA(/* T */ value, /* T** */ data, /* size_t* */ size) {\
+#define ZOPFLI_APPEND_DATA(ctx, /* T */ value, /* T** */ data, \
+                           /* size_t* */ size) {\
   if (!((*size) & ((*size) - 1))) {\
     /*double alloc size if it's a power of two*/\
     void** data_void = reinterpret_cast<void**>(data);\
-    *data_void = (*size) == 0 ? ZopfliRealloc(NULL, sizeof(**data))\
-                  : ZopfliRealloc((*data), (*size) * 2 * sizeof(**data));\
+    *data_void = (*size) == 0 ? ZopfliRealloc(ctx, NULL, sizeof(**data))\
+                  : ZopfliRealloc(ctx, (*data), (*size) * 2 * sizeof(**data));\
   }\
   (*data)[(*size)] = (value);\
   (*size)++;\
 }
 #else /* C gives problems with strict-aliasing rules for (void**) cast */
-#define ZOPFLI_APPEND_DATA(/* T */ value, /* T** */ data, /* size_t* */ size) {\
+#define ZOPFLI_APPEND_DATA(ctx, /* T */ value, /* T** */ data, \
+                           /* size_t* */ size) {\
   if (!((*size) & ((*size) - 1))) {\
     /*double alloc size if it's a power of two*/\
-    (*data) = (*size) == 0 ? ZopfliRealloc(NULL, sizeof(**data))\
-                  : ZopfliRealloc((*data), (*size) * 2 * sizeof(**data));\
+    (*data) = (*size) == 0 ? ZopfliRealloc(ctx, NULL, sizeof(**data))\
+                  : ZopfliRealloc(ctx, (*data), (*size) * 2 * sizeof(**data));\
   }\
   (*data)[(*size)] = (value);\
   (*size)++;\
@@ -259,12 +261,17 @@ ZOPFLI_INLINE int ZopfliCLZ32(uint32_t x) {
 #endif
 }
 
+/* Forward typedef: the body of ZopfliContext lives in context.h. Allocation
+routes through ctx's allocator hook; a NULL ctx uses the standard library. */
+typedef struct ZopfliContext ZopfliContext;
+
 /* Appends one byte, growing by the golden ratio when full. */
-void ZopfliBufPush(ZopfliBuf* b, uint8_t value);
+void ZopfliBufPush(const ZopfliContext* ctx, ZopfliBuf* b, uint8_t value);
 
 /* Single allocation primitive (malloc/realloc/free unified). size == 0 frees ptr
 and returns NULL (portable, unlike raw realloc(ptr, 0)); ptr == NULL allocates.
-Gives one seam for a custom/embedded allocator. */
-void* ZopfliRealloc(void* ptr, size_t size);
+Routes through ctx's custom allocator when set, else the standard library; ctx
+may be NULL. Aborts on genuine allocation failure. */
+void* ZopfliRealloc(const ZopfliContext* ctx, void* ptr, size_t size);
 
 #endif  /* ZOPFLI_UTIL_H_ */

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -111,16 +111,6 @@ added, so it cannot overflow.
 #define ZOPFLI_LARGE_COST UINT32_MAX
 
 /*
-Integer type for the squeeze optimal-parse cost accumulator. Kept 32-bit so the
-hot per-byte costs[] array and its add/compare stay single-word, which matters
-on 32-bit processors. `int` is 32-bit on every ILP32 and LP64 target of
-interest, so no width detection is needed. Costs are stored in fixed point with
-a per-block shift (see squeeze.c); the shift is chosen so the worst-case
-accumulated cost cannot overflow this type.
-*/
-typedef int ZopfliCost;
-
-/*
 For longest match cache. max 256. Uses huge amounts of memory but makes it
 faster. Uses this many times three bytes per single byte of the input data.
 This is so because longest match finding has to find the exact distance
@@ -177,10 +167,16 @@ varies from file to file.
 #define ZOPFLI_LAZY_MATCHING
 
 /* Integer min and absolute difference. Function-like macros so they work for
-any integer type used in the hot path (int/size_t/unsigned/unsigned short)
+any integer type used in the hot path (int/size_t/unsigned/uint16_t)
 without truncation. Args are evaluated twice: pass side-effect-free operands. */
 #define ZOPFLI_MIN(a, b) ((a) < (b) ? (a) : (b))
 #define ZOPFLI_ABS_DIFF(x, y) ((x) > (y) ? (x) - (y) : (y) - (x))
+
+/* Next capacity for a growing buffer: ~1.6x (golden-ratio family, < 2 so a good
+allocator can reuse previously freed blocks, lowering peak memory). All size_t
+(no 32-bit truncation) and overflow-safe; the +1 guarantees progress from tiny
+capacities. */
+#define ZOPFLI_GROW_CAP(cap) ((cap) + ((cap) >> 1) + ((cap) >> 3) + 1)
 
 /*
 Appends value to dynamically allocated memory, doubling its allocation size
@@ -198,8 +194,8 @@ equal than *size.
   if (!((*size) & ((*size) - 1))) {\
     /*double alloc size if it's a power of two*/\
     void** data_void = reinterpret_cast<void**>(data);\
-    *data_void = (*size) == 0 ? malloc(sizeof(**data))\
-                              : realloc((*data), (*size) * 2 * sizeof(**data));\
+    *data_void = (*size) == 0 ? ZopfliRealloc(NULL, sizeof(**data))\
+                  : ZopfliRealloc((*data), (*size) * 2 * sizeof(**data));\
   }\
   (*data)[(*size)] = (value);\
   (*size)++;\
@@ -208,13 +204,45 @@ equal than *size.
 #define ZOPFLI_APPEND_DATA(/* T */ value, /* T** */ data, /* size_t* */ size) {\
   if (!((*size) & ((*size) - 1))) {\
     /*double alloc size if it's a power of two*/\
-    (*data) = (*size) == 0 ? malloc(sizeof(**data))\
-                           : realloc((*data), (*size) * 2 * sizeof(**data));\
+    (*data) = (*size) == 0 ? ZopfliRealloc(NULL, sizeof(**data))\
+                  : ZopfliRealloc((*data), (*size) * 2 * sizeof(**data));\
   }\
   (*data)[(*size)] = (value);\
   (*size)++;\
 }
 #endif
+
+/* The native machine word as an exact-width unsigned type (selected by the
+ZOPFLI_NATIVE_* width macros above). */
+#if defined(ZOPFLI_NATIVE_64BIT)
+typedef uint64_t ZopfliNativeWord;
+#elif defined(ZOPFLI_NATIVE_32BIT)
+typedef uint32_t ZopfliNativeWord;
+#elif defined(ZOPFLI_NATIVE_16BIT)
+typedef uint16_t ZopfliNativeWord;
+#else
+typedef uint8_t ZopfliNativeWord;
+#endif
+
+/*
+Integer type for the squeeze optimal-parse cost accumulator. Kept 32-bit so the
+hot per-byte costs[] array and its add/compare stay single-word, which matters
+on 32-bit processors. `int` is 32-bit on every ILP32 and LP64 target of
+interest, so no width detection is needed. Costs are stored in fixed point with
+a per-block shift (see squeeze.c); the shift is chosen so the worst-case
+accumulated cost cannot overflow this type.
+*/
+typedef int ZopfliCost;
+
+/* Growable byte buffer: capacity tracked explicitly so it grows at the golden
+ratio (ZOPFLI_GROW_CAP) rather than doubling, and can be reset (size = 0) and
+reused without reallocating. The output stream uses this internally; public APIs
+keep the (out, outsize) pair via adopt/publish at the boundary. */
+typedef struct ZopfliBuf {
+  uint8_t* data;
+  size_t size;
+  size_t cap;
+} ZopfliBuf;
 
 /* Number of leading zero bits in a 32-bit value; x must be nonzero. */
 ZOPFLI_INLINE int ZopfliCLZ32(uint32_t x) {
@@ -230,5 +258,13 @@ ZOPFLI_INLINE int ZopfliCLZ32(uint32_t x) {
   return n;
 #endif
 }
+
+/* Appends one byte, growing by the golden ratio when full. */
+void ZopfliBufPush(ZopfliBuf* b, uint8_t value);
+
+/* Single allocation primitive (malloc/realloc/free unified). size == 0 frees ptr
+and returns NULL (portable, unlike raw realloc(ptr, 0)); ptr == NULL allocates.
+Gives one seam for a custom/embedded allocator. */
+void* ZopfliRealloc(void* ptr, size_t size);
 
 #endif  /* ZOPFLI_UTIL_H_ */

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -268,10 +268,17 @@ typedef struct ZopfliContext ZopfliContext;
 /* Appends one byte, growing by the golden ratio when full. */
 void ZopfliBufPush(const ZopfliContext* ctx, ZopfliBuf* b, uint8_t value);
 
-/* Single allocation primitive (malloc/realloc/free unified). size == 0 frees ptr
-and returns NULL (portable, unlike raw realloc(ptr, 0)); ptr == NULL allocates.
-Routes through ctx's custom allocator when set, else the standard library; ctx
-may be NULL. Aborts on genuine allocation failure. */
+/* Default allocator (plain realloc/free) installed into options->zrealloc by
+ZopfliInitOptions. size 0 frees ptr -> NULL (portable, unlike realloc(ptr, 0));
+ptr NULL allocates. Exposed so embedders can wrap it. */
+void* ZopfliDefaultRealloc(void* alloc_context, void* ptr, size_t size);
+
+/* Default-allocator context for allocations outside any caller options. */
+const ZopfliContext* ZopfliDefaultContext(void);
+
+/* Single allocation primitive (malloc/realloc/free unified). size 0 frees ptr,
+ptr NULL allocates. Routes through ctx->options->zrealloc; ctx must be non-NULL
+(use ZopfliDefaultContext when there are no options). Aborts on real OOM. */
 void* ZopfliRealloc(const ZopfliContext* ctx, void* ptr, size_t size);
 
 #endif  /* ZOPFLI_UTIL_H_ */

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -53,7 +53,7 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
                         const uint8_t* in, size_t insize,
                         uint8_t** out, size_t* outsize) {
   uint8_t bitpointer = 0;
-  unsigned checksum = adler32(in, (unsigned)insize);
+  unsigned checksum = adler32(in, insize);
   unsigned cmf = 120;  /* CM 8, CINFO 7. See zlib spec.*/
   unsigned flevel = 3;
   unsigned fdict = 0;
@@ -63,7 +63,7 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
   ZopfliBuf buf;
   cmfflg += fcheck;
 
-  ctx.options = options;
+  ctx.options = *options;
   buf.data = *out;
   buf.size = *outsize;
   buf.cap = *outsize;

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -23,6 +23,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 #include <stdio.h>
 
+#include "context.h"
 #include "deflate.h"
 
 
@@ -58,23 +59,25 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
   unsigned fdict = 0;
   unsigned cmfflg = 256 * cmf + fdict * 32 + flevel * 64;
   unsigned fcheck = 31 - cmfflg % 31;
+  ZopfliContext ctx;
   ZopfliBuf buf;
   cmfflg += fcheck;
 
+  ctx.options = options;
   buf.data = *out;
   buf.size = *outsize;
   buf.cap = *outsize;
 
-  ZopfliBufPush(&buf, (uint8_t)((cmfflg >> 8) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)(cmfflg & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((cmfflg >> 8) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)(cmfflg & 0xff));
 
   ZopfliDeflateBuf(options, 2 /* dynamic block */, 1 /* final */,
                    in, insize, &bitpointer, &buf);
 
-  ZopfliBufPush(&buf, (uint8_t)((checksum >> 24) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((checksum >> 16) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)((checksum >> 8) & 0xff));
-  ZopfliBufPush(&buf, (uint8_t)(checksum & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((checksum >> 24) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((checksum >> 16) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)((checksum >> 8) & 0xff));
+  ZopfliBufPush(&ctx, &buf, (uint8_t)(checksum & 0xff));
 
   *out = buf.data;
   *outsize = buf.size;

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -27,7 +27,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 
 /* Calculates the adler32 checksum of the data */
-static unsigned adler32(const unsigned char* data, size_t size)
+static unsigned adler32(const uint8_t* data, size_t size)
 {
   static const unsigned sums_overflow = 5550;
   unsigned s1 = 1;
@@ -49,27 +49,35 @@ static unsigned adler32(const unsigned char* data, size_t size)
 }
 
 void ZopfliZlibCompress(const ZopfliOptions* options,
-                        const unsigned char* in, size_t insize,
-                        unsigned char** out, size_t* outsize) {
-  unsigned char bitpointer = 0;
+                        const uint8_t* in, size_t insize,
+                        uint8_t** out, size_t* outsize) {
+  uint8_t bitpointer = 0;
   unsigned checksum = adler32(in, (unsigned)insize);
   unsigned cmf = 120;  /* CM 8, CINFO 7. See zlib spec.*/
   unsigned flevel = 3;
   unsigned fdict = 0;
   unsigned cmfflg = 256 * cmf + fdict * 32 + flevel * 64;
   unsigned fcheck = 31 - cmfflg % 31;
+  ZopfliBuf buf;
   cmfflg += fcheck;
 
-  ZOPFLI_APPEND_DATA(cmfflg / 256, out, outsize);
-  ZOPFLI_APPEND_DATA(cmfflg % 256, out, outsize);
+  buf.data = *out;
+  buf.size = *outsize;
+  buf.cap = *outsize;
 
-  ZopfliDeflate(options, 2 /* dynamic block */, 1 /* final */,
-                in, insize, &bitpointer, out, outsize);
+  ZopfliBufPush(&buf, (uint8_t)((cmfflg >> 8) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)(cmfflg & 0xff));
 
-  ZOPFLI_APPEND_DATA((checksum >> 24) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((checksum >> 16) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA((checksum >> 8) % 256, out, outsize);
-  ZOPFLI_APPEND_DATA(checksum % 256, out, outsize);
+  ZopfliDeflateBuf(options, 2 /* dynamic block */, 1 /* final */,
+                   in, insize, &bitpointer, &buf);
+
+  ZopfliBufPush(&buf, (uint8_t)((checksum >> 24) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((checksum >> 16) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)((checksum >> 8) & 0xff));
+  ZopfliBufPush(&buf, (uint8_t)(checksum & 0xff));
+
+  *out = buf.data;
+  *outsize = buf.size;
 
   if (options->verbose) {
     /* Percent removed with 2 decimals, integer-only (basis points). */

--- a/src/zopfli/zlib_container.h
+++ b/src/zopfli/zlib_container.h
@@ -40,8 +40,8 @@ out: pointer to the dynamic output array to which the result is appended. Must
 outsize: pointer to the dynamic output array size.
 */
 void ZopfliZlibCompress(const ZopfliOptions* options,
-                        const unsigned char* in, size_t insize,
-                        unsigned char** out, size_t* outsize);
+                        const uint8_t* in, size_t insize,
+                        uint8_t** out, size_t* outsize);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/zopfli/zopfli.h
+++ b/src/zopfli/zopfli.h
@@ -21,6 +21,7 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #define ZOPFLI_ZOPFLI_H_
 
 #include <stddef.h>
+#include <stdint.h> /* for uint8_t */
 #include <stdlib.h> /* for size_t */
 
 #ifdef __cplusplus

--- a/src/zopfli/zopfli.h
+++ b/src/zopfli/zopfli.h
@@ -27,6 +27,13 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 extern "C" {
 #endif
 
+/* Output format */
+typedef enum {
+  ZOPFLI_FORMAT_GZIP,
+  ZOPFLI_FORMAT_ZLIB,
+  ZOPFLI_FORMAT_DEFLATE
+} ZopfliFormat;
+
 /*
 Options used throughout the program.
 */
@@ -65,13 +72,6 @@ typedef struct ZopfliOptions {
 /* Initializes options with default values. */
 void ZopfliInitOptions(ZopfliOptions* options);
 
-/* Output format */
-typedef enum {
-  ZOPFLI_FORMAT_GZIP,
-  ZOPFLI_FORMAT_ZLIB,
-  ZOPFLI_FORMAT_DEFLATE
-} ZopfliFormat;
-
 /*
 Compresses according to the given output format and appends the result to the
 output.
@@ -83,8 +83,8 @@ out: pointer to the dynamic output array to which the result is appended. Must
 outsize: pointer to the dynamic output array size
 */
 void ZopfliCompress(const ZopfliOptions* options, ZopfliFormat output_type,
-                    const unsigned char* in, size_t insize,
-                    unsigned char** out, size_t* outsize);
+                    const uint8_t* in, size_t insize,
+                    uint8_t** out, size_t* outsize);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/zopfli/zopfli.h
+++ b/src/zopfli/zopfli.h
@@ -67,13 +67,23 @@ typedef struct ZopfliOptions {
   extreme results that hurt compression on some files). Default value: 15.
   */
   int blocksplittingmax;
+
+  /*
+  Custom allocator, realloc-style: size 0 frees ptr and returns NULL; ptr NULL
+  allocates; returns NULL only on real failure. alloc_context is passed back
+  unchanged as the first argument. ZopfliInitOptions sets this to an internal
+  default allocator (plain realloc/free); a NULL zrealloc also falls back to it.
+  All of zopfli's allocations route through this.
+  */
+  void* (*zrealloc)(void* alloc_context, void* ptr, size_t size);
+  void* alloc_context;
 } ZopfliOptions;
 
 /* Initializes options with default values. */
 void ZopfliInitOptions(ZopfliOptions* options);
 
 /*
-Compresses according to the given output format and appends the result to the
+Compresses, according to the given output format, and appends the result to the
 output.
 
 options: global program options

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -85,13 +85,13 @@ static int LoadFile(const char* filename,
   }
   *outsize = (size_t)filesize;
 
-  *out = (uint8_t*)ZopfliRealloc(NULL, *outsize ? *outsize : 1);
+  *out = (uint8_t*)ZopfliRealloc(NULL, NULL, *outsize ? *outsize : 1);
 
   if (*outsize) {
     size_t testsize = fread(*out, 1, *outsize, file);
     if (testsize != *outsize) {
       /* It could be a directory */
-      ZopfliRealloc(*out, 0);
+      ZopfliRealloc(NULL, *out, 0);
       *out = 0;
       *outsize = 0;
       fclose(file);
@@ -146,8 +146,8 @@ static void CompressFile(const ZopfliOptions* options,
     fwrite(out, 1, outsize, stdout);
   }
 
-  ZopfliRealloc(out, 0);
-  ZopfliRealloc(in, 0);
+  ZopfliRealloc(NULL, out, 0);
+  ZopfliRealloc(NULL, in, 0);
 }
 
 /*
@@ -155,7 +155,7 @@ Add two strings together. Size does not matter. Result must be freed.
 */
 static char* AddStrings(const char* str1, const char* str2) {
   size_t len = strlen(str1) + strlen(str2);
-  char* result = (char*)ZopfliRealloc(NULL, len + 1);
+  char* result = (char*)ZopfliRealloc(NULL, NULL, len + 1);
   strcpy(result, str1);
   strcat(result, str2);
   return result;
@@ -230,7 +230,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Saving to: %s\n", outfilename);
       }
       CompressFile(&options, output_type, filename, outfilename);
-      ZopfliRealloc(outfilename, 0);
+      ZopfliRealloc(NULL, outfilename, 0);
     }
   }
 

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -85,13 +85,14 @@ static int LoadFile(const char* filename,
   }
   *outsize = (size_t)filesize;
 
-  *out = (uint8_t*)ZopfliRealloc(NULL, NULL, *outsize ? *outsize : 1);
+  *out = (uint8_t*)ZopfliRealloc(ZopfliDefaultContext(), NULL,
+                                 *outsize ? *outsize : 1);
 
   if (*outsize) {
     size_t testsize = fread(*out, 1, *outsize, file);
     if (testsize != *outsize) {
       /* It could be a directory */
-      ZopfliRealloc(NULL, *out, 0);
+      ZopfliRealloc(ZopfliDefaultContext(), *out, 0);
       *out = 0;
       *outsize = 0;
       fclose(file);
@@ -146,8 +147,14 @@ static void CompressFile(const ZopfliOptions* options,
     fwrite(out, 1, outsize, stdout);
   }
 
-  ZopfliRealloc(NULL, out, 0);
-  ZopfliRealloc(NULL, in, 0);
+  /* out came from ZopfliCompress via options->zrealloc, so free it through the
+  same hook (free() when unset). in is the CLI's own default-allocator buffer. */
+  if (options->zrealloc) {
+    options->zrealloc(options->alloc_context, out, 0);
+  } else {
+    free(out);
+  }
+  ZopfliRealloc(ZopfliDefaultContext(), in, 0);
 }
 
 /*
@@ -155,7 +162,7 @@ Add two strings together. Size does not matter. Result must be freed.
 */
 static char* AddStrings(const char* str1, const char* str2) {
   size_t len = strlen(str1) + strlen(str2);
-  char* result = (char*)ZopfliRealloc(NULL, NULL, len + 1);
+  char* result = (char*)ZopfliRealloc(ZopfliDefaultContext(), NULL, len + 1);
   strcpy(result, str1);
   strcat(result, str2);
   return result;
@@ -230,7 +237,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Saving to: %s\n", outfilename);
       }
       CompressFile(&options, output_type, filename, outfilename);
-      ZopfliRealloc(NULL, outfilename, 0);
+      ZopfliRealloc(ZopfliDefaultContext(), outfilename, 0);
     }
   }
 

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -60,7 +60,7 @@ Loads a file into a memory array. Returns 1 on success, 0 if file doesn't exist
 or couldn't be opened.
 */
 static int LoadFile(const char* filename,
-                    unsigned char** out, size_t* outsize) {
+                    uint8_t** out, size_t* outsize) {
   FILE* file;
   long long filesize;
 
@@ -85,17 +85,13 @@ static int LoadFile(const char* filename,
   }
   *outsize = (size_t)filesize;
 
-  *out = (unsigned char*)malloc(*outsize ? *outsize : 1);
-  if (!*out) {
-    fprintf(stderr, "Error: out of memory loading file.\n");
-    exit(EXIT_FAILURE);
-  }
+  *out = (uint8_t*)ZopfliRealloc(NULL, *outsize ? *outsize : 1);
 
   if (*outsize) {
     size_t testsize = fread(*out, 1, *outsize, file);
     if (testsize != *outsize) {
       /* It could be a directory */
-      free(*out);
+      ZopfliRealloc(*out, 0);
       *out = 0;
       *outsize = 0;
       fclose(file);
@@ -111,7 +107,7 @@ static int LoadFile(const char* filename,
 Saves a file from a memory array, overwriting the file if it existed.
 */
 static void SaveFile(const char* filename,
-                     const unsigned char* in, size_t insize) {
+                     const uint8_t* in, size_t insize) {
   FILE* file = fopen(filename, "wb" );
   if (file == NULL) {
       fprintf(stderr,"Error: Cannot write to output file, terminating.\n");
@@ -129,9 +125,9 @@ static void CompressFile(const ZopfliOptions* options,
                          ZopfliFormat output_type,
                          const char* infilename,
                          const char* outfilename) {
-  unsigned char* in;
+  uint8_t* in;
   size_t insize;
-  unsigned char* out = 0;
+  uint8_t* out = 0;
   size_t outsize = 0;
   if (!LoadFile(infilename, &in, &insize)) {
     fprintf(stderr, "Invalid filename: %s\n", infilename);
@@ -150,8 +146,8 @@ static void CompressFile(const ZopfliOptions* options,
     fwrite(out, 1, outsize, stdout);
   }
 
-  free(out);
-  free(in);
+  ZopfliRealloc(out, 0);
+  ZopfliRealloc(in, 0);
 }
 
 /*
@@ -159,8 +155,7 @@ Add two strings together. Size does not matter. Result must be freed.
 */
 static char* AddStrings(const char* str1, const char* str2) {
   size_t len = strlen(str1) + strlen(str2);
-  char* result = (char*)malloc(len + 1);
-  if (!result) exit(-1); /* Allocation failed. */
+  char* result = (char*)ZopfliRealloc(NULL, len + 1);
   strcpy(result, str1);
   strcat(result, str2);
   return result;
@@ -235,7 +230,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Saving to: %s\n", outfilename);
       }
       CompressFile(&options, output_type, filename, outfilename);
-      free(outfilename);
+      ZopfliRealloc(outfilename, 0);
     }
   }
 

--- a/src/zopfli/zopfli_lib.c
+++ b/src/zopfli/zopfli_lib.c
@@ -21,6 +21,7 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 
 #include "deflate.h"
 #include "gzip_container.h"
+#include "util.h"
 #include "zlib_container.h"
 
 #include <assert.h>
@@ -28,6 +29,13 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 void ZopfliCompress(const ZopfliOptions* options, ZopfliFormat output_type,
                     const uint8_t* in, size_t insize,
                     uint8_t** out, size_t* outsize) {
+  /* Ensure the allocator hook is set once, here, so the downstream code can call
+  it unconditionally. ZopfliInitOptions already installs it; this also covers a
+  caller who built ZopfliOptions without it. */
+  ZopfliOptions opts = *options;
+  if (!opts.zrealloc) opts.zrealloc = ZopfliDefaultRealloc;
+  options = &opts;
+
   if (output_type == ZOPFLI_FORMAT_GZIP) {
     ZopfliGzipCompress(options, in, insize, out, outsize);
   } else if (output_type == ZOPFLI_FORMAT_ZLIB) {

--- a/src/zopfli/zopfli_lib.c
+++ b/src/zopfli/zopfli_lib.c
@@ -26,14 +26,14 @@ Author: jyrki.alakuijala@gmail.com (Jyrki Alakuijala)
 #include <assert.h>
 
 void ZopfliCompress(const ZopfliOptions* options, ZopfliFormat output_type,
-                    const unsigned char* in, size_t insize,
-                    unsigned char** out, size_t* outsize) {
+                    const uint8_t* in, size_t insize,
+                    uint8_t** out, size_t* outsize) {
   if (output_type == ZOPFLI_FORMAT_GZIP) {
     ZopfliGzipCompress(options, in, insize, out, outsize);
   } else if (output_type == ZOPFLI_FORMAT_ZLIB) {
     ZopfliZlibCompress(options, in, insize, out, outsize);
   } else if (output_type == ZOPFLI_FORMAT_DEFLATE) {
-    unsigned char bp = 0;
+    uint8_t bp = 0;
     ZopfliDeflate(options, 2 /* Dynamic block */, 1,
                   in, insize, &bp, out, outsize);
   } else {

--- a/test/blocksplitter_test.cc
+++ b/test/blocksplitter_test.cc
@@ -54,7 +54,7 @@ TEST(BlockSplitter, SplitLZ77RespectsMaxBlocks) {
   EXPECT_LE(npoints, maxblocks - 1);
 
   free(splitpoints);
-  ZopfliCleanLZ77Store(NULL, &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
 }
 
 }  // namespace

--- a/test/blocksplitter_test.cc
+++ b/test/blocksplitter_test.cc
@@ -54,7 +54,7 @@ TEST(BlockSplitter, SplitLZ77RespectsMaxBlocks) {
   EXPECT_LE(npoints, maxblocks - 1);
 
   free(splitpoints);
-  ZopfliCleanLZ77Store(&store);
+  ZopfliCleanLZ77Store(NULL, &store);
 }
 
 }  // namespace

--- a/test/cache_test.cc
+++ b/test/cache_test.cc
@@ -6,15 +6,15 @@ namespace {
 
 TEST(Cache, EmptyHasNoCachedSublen) {
   ZopfliLongestMatchCache lmc;
-  ZopfliInitCache(16, &lmc);
+  ZopfliInitCache(NULL, 16, &lmc);
   EXPECT_EQ(ZopfliMaxCachedSublen(&lmc, 0, 0), 0u);
-  ZopfliCleanCache(&lmc);
+  ZopfliCleanCache(NULL, &lmc);
 }
 
 TEST(Cache, SublenRoundTrip) {
   const size_t blocksize = 8;
   ZopfliLongestMatchCache lmc;
-  ZopfliInitCache(blocksize, &lmc);
+  ZopfliInitCache(NULL, blocksize, &lmc);
 
   // Build a sublen where each length maps to a distinct distance.
   const unsigned short length = 40;
@@ -34,7 +34,7 @@ TEST(Cache, SublenRoundTrip) {
     EXPECT_EQ(got[i], sublen[i]) << "at length " << i;
   }
 
-  ZopfliCleanCache(&lmc);
+  ZopfliCleanCache(NULL, &lmc);
 }
 
 }  // namespace

--- a/test/cache_test.cc
+++ b/test/cache_test.cc
@@ -6,15 +6,15 @@ namespace {
 
 TEST(Cache, EmptyHasNoCachedSublen) {
   ZopfliLongestMatchCache lmc;
-  ZopfliInitCache(NULL, 16, &lmc);
+  ZopfliInitCache(ZopfliDefaultContext(), 16, &lmc);
   EXPECT_EQ(ZopfliMaxCachedSublen(&lmc, 0, 0), 0u);
-  ZopfliCleanCache(NULL, &lmc);
+  ZopfliCleanCache(ZopfliDefaultContext(), &lmc);
 }
 
 TEST(Cache, SublenRoundTrip) {
   const size_t blocksize = 8;
   ZopfliLongestMatchCache lmc;
-  ZopfliInitCache(NULL, blocksize, &lmc);
+  ZopfliInitCache(ZopfliDefaultContext(), blocksize, &lmc);
 
   // Build a sublen where each length maps to a distinct distance.
   const unsigned short length = 40;
@@ -34,7 +34,7 @@ TEST(Cache, SublenRoundTrip) {
     EXPECT_EQ(got[i], sublen[i]) << "at length " << i;
   }
 
-  ZopfliCleanCache(NULL, &lmc);
+  ZopfliCleanCache(ZopfliDefaultContext(), &lmc);
 }
 
 }  // namespace

--- a/test/custom_allocator_test.cc
+++ b/test/custom_allocator_test.cc
@@ -1,0 +1,81 @@
+#include "zopfli_c_api.h"
+
+#include <cstdlib>
+#include <cstring>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+// Tracks live allocations routed through the custom zrealloc hook. The hook
+// follows zopfli's allocator contract: size 0 frees (returns NULL), ptr NULL
+// allocates, otherwise resizes (one logical allocation, live count unchanged).
+struct Tracker {
+  size_t live = 0;         // outstanding allocations
+  size_t alloc_calls = 0;  // total non-free calls
+};
+
+void* TrackingRealloc(void* alloc_context, void* ptr, size_t size) {
+  Tracker* t = static_cast<Tracker*>(alloc_context);
+  if (size == 0) {
+    if (ptr) t->live--;
+    free(ptr);
+    return NULL;
+  }
+  if (!ptr) t->live++;
+  t->alloc_calls++;
+  return realloc(ptr, size);
+}
+
+std::vector<unsigned char> CompressDefault(ZopfliFormat fmt,
+                                           const std::vector<unsigned char>& in) {
+  ZopfliOptions options;
+  ZopfliInitOptions(&options);
+  unsigned char* out = nullptr;
+  size_t outsize = 0;
+  ZopfliCompress(&options, fmt, in.data(), in.size(), &out, &outsize);
+  std::vector<unsigned char> bytes(out, out + outsize);
+  free(out);
+  return bytes;
+}
+
+// Compresses with the tracking allocator, checks the output matches the
+// default-allocator output byte for byte, and that every allocation was routed
+// through the hook and freed (no leak) once the output is released.
+void CheckFormat(ZopfliFormat fmt, const std::vector<unsigned char>& in) {
+  std::vector<unsigned char> expected = CompressDefault(fmt, in);
+
+  Tracker tracker;
+  ZopfliOptions options;
+  ZopfliInitOptions(&options);
+  options.zrealloc = TrackingRealloc;
+  options.alloc_context = &tracker;
+
+  unsigned char* out = nullptr;
+  size_t outsize = 0;
+  ZopfliCompress(&options, fmt, in.data(), in.size(), &out, &outsize);
+
+  ASSERT_GT(tracker.alloc_calls, 0u);  // hook actually used
+  std::vector<unsigned char> got(out, out + outsize);
+  EXPECT_EQ(got, expected);  // byte-identical to the default allocator
+
+  // The output buffer is the only thing still live; free it through the hook.
+  TrackingRealloc(&tracker, out, 0);
+  EXPECT_EQ(tracker.live, 0u);  // every allocation routed and freed
+}
+
+TEST(CustomAllocator, GzipByteIdenticalNoLeak) {
+  CheckFormat(ZOPFLI_FORMAT_GZIP, zopfli_test::Bytes(
+      std::string(20000, 'a') + "the quick brown fox jumps over the lazy dog"));
+}
+
+TEST(CustomAllocator, ZlibByteIdenticalNoLeak) {
+  CheckFormat(ZOPFLI_FORMAT_ZLIB, zopfli_test::PseudoRandom(20000));
+}
+
+TEST(CustomAllocator, DeflateByteIdenticalNoLeak) {
+  CheckFormat(ZOPFLI_FORMAT_DEFLATE, zopfli_test::Bytes(
+      std::string(5000, 'x') + std::string(5000, 'y')));
+}
+
+}  // namespace

--- a/test/custom_allocator_test.cc
+++ b/test/custom_allocator_test.cc
@@ -27,8 +27,8 @@ void* TrackingRealloc(void* alloc_context, void* ptr, size_t size) {
   return realloc(ptr, size);
 }
 
-std::vector<unsigned char> CompressDefault(ZopfliFormat fmt,
-                                           const std::vector<unsigned char>& in) {
+std::vector<unsigned char> CompressDefault(
+    ZopfliFormat fmt, const std::vector<unsigned char>& in) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
   unsigned char* out = nullptr;

--- a/test/deflate_test.cc
+++ b/test/deflate_test.cc
@@ -41,7 +41,7 @@ TEST(Deflate, BlockSizeAutoTypePicksSmallest) {
   uint32_t min3 = std::min(s0, std::min(s1, s2));
   EXPECT_EQ(best, min3);
 
-  ZopfliCleanLZ77Store(&store);
+  ZopfliCleanLZ77Store(NULL, &store);
 }
 
 TEST(Deflate, UseExpensiveFixedHeuristic) {

--- a/test/deflate_test.cc
+++ b/test/deflate_test.cc
@@ -41,7 +41,7 @@ TEST(Deflate, BlockSizeAutoTypePicksSmallest) {
   uint32_t min3 = std::min(s0, std::min(s1, s2));
   EXPECT_EQ(best, min3);
 
-  ZopfliCleanLZ77Store(NULL, &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
 }
 
 TEST(Deflate, UseExpensiveFixedHeuristic) {

--- a/test/fixedpoint_range_test.cc
+++ b/test/fixedpoint_range_test.cc
@@ -54,22 +54,24 @@ TEST(FixedPointRange, CostShiftInvariant) {
 void CheckSqueezeCovers(const std::vector<unsigned char>& in, int iters) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
+  ZopfliContext ctx;
+  ctx.options = &options;
   ZopfliBlockState s;
-  ZopfliInitBlockState(&options, 0, in.size(), 1, &s);
+  ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
 
   ZopfliLZ77Store store;
   ZopfliInitLZ77Store(in.data(), &store);
   ZopfliLZ77Optimal(&s, in.data(), 0, in.size(), iters, &store);
   EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
   EXPECT_GT(store.size, 0u);
-  ZopfliCleanLZ77Store(&store);
+  ZopfliCleanLZ77Store(NULL, &store);
 
   ZopfliLZ77Store fixed_store;
   ZopfliInitLZ77Store(in.data(), &fixed_store);
   ZopfliLZ77OptimalFixed(&s, in.data(), 0, in.size(), &fixed_store);
   EXPECT_EQ(ZopfliLZ77GetByteRange(&fixed_store, 0, fixed_store.size),
             in.size());
-  ZopfliCleanLZ77Store(&fixed_store);
+  ZopfliCleanLZ77Store(NULL, &fixed_store);
 
   ZopfliCleanBlockState(&s);
 }

--- a/test/fixedpoint_range_test.cc
+++ b/test/fixedpoint_range_test.cc
@@ -55,7 +55,7 @@ void CheckSqueezeCovers(const std::vector<unsigned char>& in, int iters) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
   ZopfliContext ctx;
-  ctx.options = &options;
+  ctx.options = options;
   ZopfliBlockState s;
   ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
 
@@ -64,14 +64,14 @@ void CheckSqueezeCovers(const std::vector<unsigned char>& in, int iters) {
   ZopfliLZ77Optimal(&s, in.data(), 0, in.size(), iters, &store);
   EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
   EXPECT_GT(store.size, 0u);
-  ZopfliCleanLZ77Store(NULL, &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
 
   ZopfliLZ77Store fixed_store;
   ZopfliInitLZ77Store(in.data(), &fixed_store);
   ZopfliLZ77OptimalFixed(&s, in.data(), 0, in.size(), &fixed_store);
   EXPECT_EQ(ZopfliLZ77GetByteRange(&fixed_store, 0, fixed_store.size),
             in.size());
-  ZopfliCleanLZ77Store(NULL, &fixed_store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &fixed_store);
 
   ZopfliCleanBlockState(&s);
 }

--- a/test/hash_test.cc
+++ b/test/hash_test.cc
@@ -8,7 +8,7 @@ TEST(Hash, WarmupAndUpdateOverBuffer) {
   std::vector<unsigned char> data = zopfli_test::Bytes(
       "the quick brown fox the quick brown fox the quick brown fox");
   ZopfliHash h;
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(NULL, ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   ZopfliWarmupHash(data.data(), 0, data.size(), &h);
   for (size_t i = 0; i < data.size(); i++) {
@@ -22,16 +22,16 @@ TEST(Hash, WarmupAndUpdateOverBuffer) {
     if (h.prev[hpos] != hpos) { has_chain = true; break; }
   }
   EXPECT_TRUE(has_chain);
-  ZopfliCleanHash(&h);
+  ZopfliCleanHash(NULL, &h);
 }
 
 TEST(Hash, ResetIsIdempotent) {
   ZopfliHash h;
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(NULL, ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   EXPECT_EQ(h.val, 0);
-  ZopfliCleanHash(&h);
+  ZopfliCleanHash(NULL, &h);
 }
 
 }  // namespace

--- a/test/hash_test.cc
+++ b/test/hash_test.cc
@@ -8,7 +8,7 @@ TEST(Hash, WarmupAndUpdateOverBuffer) {
   std::vector<unsigned char> data = zopfli_test::Bytes(
       "the quick brown fox the quick brown fox the quick brown fox");
   ZopfliHash h;
-  ZopfliAllocHash(NULL, ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(ZopfliDefaultContext(), ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   ZopfliWarmupHash(data.data(), 0, data.size(), &h);
   for (size_t i = 0; i < data.size(); i++) {
@@ -22,16 +22,16 @@ TEST(Hash, WarmupAndUpdateOverBuffer) {
     if (h.prev[hpos] != hpos) { has_chain = true; break; }
   }
   EXPECT_TRUE(has_chain);
-  ZopfliCleanHash(NULL, &h);
+  ZopfliCleanHash(ZopfliDefaultContext(), &h);
 }
 
 TEST(Hash, ResetIsIdempotent) {
   ZopfliHash h;
-  ZopfliAllocHash(NULL, ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(ZopfliDefaultContext(), ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   EXPECT_EQ(h.val, 0);
-  ZopfliCleanHash(NULL, &h);
+  ZopfliCleanHash(ZopfliDefaultContext(), &h);
 }
 
 }  // namespace

--- a/test/katajainen_test.cc
+++ b/test/katajainen_test.cc
@@ -6,6 +6,8 @@
 
 namespace {
 
+const ZopfliContext* kCtx = ZopfliDefaultContext();
+
 double Kraft(const unsigned* bitlengths, const size_t* freqs, int n) {
   double sum = 0.0;
   for (int i = 0; i < n; i++) {
@@ -17,20 +19,23 @@ double Kraft(const unsigned* bitlengths, const size_t* freqs, int n) {
 
 TEST(Katajainen, ZeroSymbols) {
   unsigned bitlengths[1] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, nullptr, 0, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, nullptr, 0, 15, bitlengths),
+            0);
 }
 
 TEST(Katajainen, OneSymbolGetsLengthOne) {
   size_t freqs[1] = {5};
   unsigned bitlengths[1] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 1, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, freqs, 1, 15, bitlengths),
+            0);
   EXPECT_EQ(bitlengths[0], 1u);
 }
 
 TEST(Katajainen, TwoSymbols) {
   size_t freqs[2] = {1, 1};
   unsigned bitlengths[2] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 2, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, freqs, 2, 15, bitlengths),
+            0);
   EXPECT_EQ(bitlengths[0], 1u);
   EXPECT_EQ(bitlengths[1], 1u);
 }
@@ -38,7 +43,8 @@ TEST(Katajainen, TwoSymbols) {
 TEST(Katajainen, ManySymbolsSatisfyKraft) {
   size_t freqs[8] = {1, 2, 3, 5, 8, 13, 21, 34};
   unsigned bitlengths[8] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 8, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, freqs, 8, 15, bitlengths),
+            0);
   EXPECT_LE(Kraft(bitlengths, freqs, 8), 1.0 + 1e-9);
   for (int i = 0; i < 8; i++) EXPECT_LE(bitlengths[i], 15u);
 }
@@ -47,13 +53,15 @@ TEST(Katajainen, MaxBitsTooSmallIsError) {
   // 5 symbols cannot be coded with a max length of 2 bits.
   size_t freqs[5] = {1, 1, 1, 1, 1};
   unsigned bitlengths[5] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 5, 2, bitlengths), 1);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, freqs, 5, 2, bitlengths),
+            1);
 }
 
 TEST(Katajainen, ZeroFrequencySymbolsIgnored) {
   size_t freqs[5] = {0, 4, 0, 2, 1};
   unsigned bitlengths[5] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 5, 7, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, freqs, 5, 7, bitlengths),
+            0);
   EXPECT_EQ(bitlengths[0], 0u);
   EXPECT_EQ(bitlengths[2], 0u);
 }

--- a/test/katajainen_test.cc
+++ b/test/katajainen_test.cc
@@ -17,20 +17,20 @@ double Kraft(const unsigned* bitlengths, const size_t* freqs, int n) {
 
 TEST(Katajainen, ZeroSymbols) {
   unsigned bitlengths[1] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(nullptr, 0, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, nullptr, 0, 15, bitlengths), 0);
 }
 
 TEST(Katajainen, OneSymbolGetsLengthOne) {
   size_t freqs[1] = {5};
   unsigned bitlengths[1] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(freqs, 1, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 1, 15, bitlengths), 0);
   EXPECT_EQ(bitlengths[0], 1u);
 }
 
 TEST(Katajainen, TwoSymbols) {
   size_t freqs[2] = {1, 1};
   unsigned bitlengths[2] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(freqs, 2, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 2, 15, bitlengths), 0);
   EXPECT_EQ(bitlengths[0], 1u);
   EXPECT_EQ(bitlengths[1], 1u);
 }
@@ -38,7 +38,7 @@ TEST(Katajainen, TwoSymbols) {
 TEST(Katajainen, ManySymbolsSatisfyKraft) {
   size_t freqs[8] = {1, 2, 3, 5, 8, 13, 21, 34};
   unsigned bitlengths[8] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(freqs, 8, 15, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 8, 15, bitlengths), 0);
   EXPECT_LE(Kraft(bitlengths, freqs, 8), 1.0 + 1e-9);
   for (int i = 0; i < 8; i++) EXPECT_LE(bitlengths[i], 15u);
 }
@@ -47,13 +47,13 @@ TEST(Katajainen, MaxBitsTooSmallIsError) {
   // 5 symbols cannot be coded with a max length of 2 bits.
   size_t freqs[5] = {1, 1, 1, 1, 1};
   unsigned bitlengths[5] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(freqs, 5, 2, bitlengths), 1);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 5, 2, bitlengths), 1);
 }
 
 TEST(Katajainen, ZeroFrequencySymbolsIgnored) {
   size_t freqs[5] = {0, 4, 0, 2, 1};
   unsigned bitlengths[5] = {0};
-  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(freqs, 5, 7, bitlengths), 0);
+  EXPECT_EQ(ZopfliLengthLimitedCodeLengths(NULL, freqs, 5, 7, bitlengths), 0);
   EXPECT_EQ(bitlengths[0], 0u);
   EXPECT_EQ(bitlengths[2], 0u);
 }

--- a/test/lz77_test.cc
+++ b/test/lz77_test.cc
@@ -8,28 +8,28 @@ TEST(Lz77, StoreAppendCopyByteRange) {
   std::vector<unsigned char> data(64, 'a');
   ZopfliLZ77Store a;
   ZopfliInitLZ77Store(data.data(), &a);
-  ZopfliStoreLitLenDist('a', 0, 0, &a);     // literal
-  ZopfliStoreLitLenDist(5, 1, 1, &a);       // length/dist pair
+  ZopfliStoreLitLenDist(NULL, 'a', 0, 0, &a);     // literal
+  ZopfliStoreLitLenDist(NULL, 5, 1, 1, &a);       // length/dist pair
   EXPECT_EQ(a.size, 2u);
   // 1 literal byte + a length-5 match = 6 bytes.
   EXPECT_EQ(ZopfliLZ77GetByteRange(&a, 0, a.size), 6u);
 
   ZopfliLZ77Store b;
   ZopfliInitLZ77Store(data.data(), &b);
-  ZopfliAppendLZ77Store(&a, &b);
+  ZopfliAppendLZ77Store(NULL, &a, &b);
   EXPECT_EQ(b.size, 2u);
 
   // ZopfliCopyLZ77Store cleans the destination first, so it must be
   // initialized before copying into it.
   ZopfliLZ77Store c;
   ZopfliInitLZ77Store(data.data(), &c);
-  ZopfliCopyLZ77Store(&a, &c);
+  ZopfliCopyLZ77Store(NULL, &a, &c);
   EXPECT_EQ(c.size, a.size);
   EXPECT_EQ(c.dists[1], a.dists[1]);
 
-  ZopfliCleanLZ77Store(&a);
-  ZopfliCleanLZ77Store(&b);
-  ZopfliCleanLZ77Store(&c);
+  ZopfliCleanLZ77Store(NULL, &a);
+  ZopfliCleanLZ77Store(NULL, &b);
+  ZopfliCleanLZ77Store(NULL, &c);
 }
 
 TEST(Lz77, Histogram) {
@@ -47,7 +47,7 @@ TEST(Lz77, Histogram) {
   // End-of-block symbol (256) is not part of the store histogram.
   EXPECT_EQ(ll_total, store.size);
 
-  ZopfliCleanLZ77Store(&store);
+  ZopfliCleanLZ77Store(NULL, &store);
 }
 
 TEST(Lz77, FindLongestMatchFindsRepeat) {
@@ -56,10 +56,12 @@ TEST(Lz77, FindLongestMatchFindsRepeat) {
       "abcdefghabcdefghabcdefghabcdefghabcdefgh");
   ZopfliOptions options;
   ZopfliInitOptions(&options);
+  ZopfliContext ctx;
+  ctx.options = &options;
   ZopfliBlockState s;
-  ZopfliInitBlockState(&options, 0, in.size(), 1, &s);
+  ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliHash h;
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(NULL, ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   ZopfliWarmupHash(in.data(), 0, in.size(), &h);
 
@@ -75,7 +77,7 @@ TEST(Lz77, FindLongestMatchFindsRepeat) {
   EXPECT_GE(length, 8u);
   EXPECT_EQ(distance, 8u);
 
-  ZopfliCleanHash(&h);
+  ZopfliCleanHash(NULL, &h);
   ZopfliCleanBlockState(&s);
 }
 

--- a/test/lz77_test.cc
+++ b/test/lz77_test.cc
@@ -8,28 +8,28 @@ TEST(Lz77, StoreAppendCopyByteRange) {
   std::vector<unsigned char> data(64, 'a');
   ZopfliLZ77Store a;
   ZopfliInitLZ77Store(data.data(), &a);
-  ZopfliStoreLitLenDist(NULL, 'a', 0, 0, &a);     // literal
-  ZopfliStoreLitLenDist(NULL, 5, 1, 1, &a);       // length/dist pair
+  ZopfliStoreLitLenDist(ZopfliDefaultContext(), 'a', 0, 0, &a);  // literal
+  ZopfliStoreLitLenDist(ZopfliDefaultContext(), 5, 1, 1, &a);  // len/dist pair
   EXPECT_EQ(a.size, 2u);
   // 1 literal byte + a length-5 match = 6 bytes.
   EXPECT_EQ(ZopfliLZ77GetByteRange(&a, 0, a.size), 6u);
 
   ZopfliLZ77Store b;
   ZopfliInitLZ77Store(data.data(), &b);
-  ZopfliAppendLZ77Store(NULL, &a, &b);
+  ZopfliAppendLZ77Store(ZopfliDefaultContext(), &a, &b);
   EXPECT_EQ(b.size, 2u);
 
   // ZopfliCopyLZ77Store cleans the destination first, so it must be
   // initialized before copying into it.
   ZopfliLZ77Store c;
   ZopfliInitLZ77Store(data.data(), &c);
-  ZopfliCopyLZ77Store(NULL, &a, &c);
+  ZopfliCopyLZ77Store(ZopfliDefaultContext(), &a, &c);
   EXPECT_EQ(c.size, a.size);
   EXPECT_EQ(c.dists[1], a.dists[1]);
 
-  ZopfliCleanLZ77Store(NULL, &a);
-  ZopfliCleanLZ77Store(NULL, &b);
-  ZopfliCleanLZ77Store(NULL, &c);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &a);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &b);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &c);
 }
 
 TEST(Lz77, Histogram) {
@@ -47,7 +47,7 @@ TEST(Lz77, Histogram) {
   // End-of-block symbol (256) is not part of the store histogram.
   EXPECT_EQ(ll_total, store.size);
 
-  ZopfliCleanLZ77Store(NULL, &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
 }
 
 TEST(Lz77, FindLongestMatchFindsRepeat) {
@@ -57,11 +57,11 @@ TEST(Lz77, FindLongestMatchFindsRepeat) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
   ZopfliContext ctx;
-  ctx.options = &options;
+  ctx.options = options;
   ZopfliBlockState s;
   ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliHash h;
-  ZopfliAllocHash(NULL, ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(ZopfliDefaultContext(), ZOPFLI_WINDOW_SIZE, &h);
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, &h);
   ZopfliWarmupHash(in.data(), 0, in.size(), &h);
 
@@ -77,7 +77,7 @@ TEST(Lz77, FindLongestMatchFindsRepeat) {
   EXPECT_GE(length, 8u);
   EXPECT_EQ(distance, 8u);
 
-  ZopfliCleanHash(NULL, &h);
+  ZopfliCleanHash(ZopfliDefaultContext(), &h);
   ZopfliCleanBlockState(&s);
 }
 

--- a/test/squeeze_test.cc
+++ b/test/squeeze_test.cc
@@ -16,7 +16,7 @@ TEST(Squeeze, OptimalFixed) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
   ZopfliContext ctx;
-  ctx.options = &options;
+  ctx.options = options;
   ZopfliBlockState s;
   ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliLZ77Store store;
@@ -25,7 +25,7 @@ TEST(Squeeze, OptimalFixed) {
   EXPECT_GT(store.size, 0u);
   // The parse must reconstruct exactly the input byte length.
   EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
-  ZopfliCleanLZ77Store(NULL, &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
   ZopfliCleanBlockState(&s);
 }
 
@@ -34,7 +34,7 @@ TEST(Squeeze, OptimalWithIterations) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
   ZopfliContext ctx;
-  ctx.options = &options;
+  ctx.options = options;
   ZopfliBlockState s;
   ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliLZ77Store store;
@@ -42,7 +42,7 @@ TEST(Squeeze, OptimalWithIterations) {
   ZopfliLZ77Optimal(&s, in.data(), 0, in.size(), /*numiterations=*/3,
                     &store);
   EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
-  ZopfliCleanLZ77Store(NULL, &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
   ZopfliCleanBlockState(&s);
 }
 

--- a/test/squeeze_test.cc
+++ b/test/squeeze_test.cc
@@ -15,15 +15,17 @@ TEST(Squeeze, OptimalFixed) {
   std::vector<unsigned char> in = RunData();
   ZopfliOptions options;
   ZopfliInitOptions(&options);
+  ZopfliContext ctx;
+  ctx.options = &options;
   ZopfliBlockState s;
-  ZopfliInitBlockState(&options, 0, in.size(), 1, &s);
+  ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliLZ77Store store;
   ZopfliInitLZ77Store(in.data(), &store);
   ZopfliLZ77OptimalFixed(&s, in.data(), 0, in.size(), &store);
   EXPECT_GT(store.size, 0u);
   // The parse must reconstruct exactly the input byte length.
   EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
-  ZopfliCleanLZ77Store(&store);
+  ZopfliCleanLZ77Store(NULL, &store);
   ZopfliCleanBlockState(&s);
 }
 
@@ -31,14 +33,16 @@ TEST(Squeeze, OptimalWithIterations) {
   std::vector<unsigned char> in = RunData();
   ZopfliOptions options;
   ZopfliInitOptions(&options);
+  ZopfliContext ctx;
+  ctx.options = &options;
   ZopfliBlockState s;
-  ZopfliInitBlockState(&options, 0, in.size(), 1, &s);
+  ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliLZ77Store store;
   ZopfliInitLZ77Store(in.data(), &store);
   ZopfliLZ77Optimal(&s, in.data(), 0, in.size(), /*numiterations=*/3,
                     &store);
   EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), in.size());
-  ZopfliCleanLZ77Store(&store);
+  ZopfliCleanLZ77Store(NULL, &store);
   ZopfliCleanBlockState(&s);
 }
 

--- a/test/tree_test.cc
+++ b/test/tree_test.cc
@@ -9,7 +9,7 @@ namespace {
 TEST(Tree, BitLengthsRespectMaxAndKraft) {
   size_t counts[6] = {0, 1, 2, 4, 8, 16};
   unsigned bitlengths[6] = {0};
-  ZopfliCalculateBitLengths(counts, 6, 15, bitlengths);
+  ZopfliCalculateBitLengths(NULL, counts, 6, 15, bitlengths);
   double kraft = 0.0;
   for (int i = 0; i < 6; i++) {
     if (counts[i] == 0) continue;
@@ -24,7 +24,7 @@ TEST(Tree, LengthsToSymbolsAreCanonical) {
   // Two symbols of length 1: canonical codes are 0 and 1.
   const unsigned lengths[2] = {1, 1};
   unsigned symbols[2] = {0xffff, 0xffff};
-  ZopfliLengthsToSymbols(lengths, 2, 15, symbols);
+  ZopfliLengthsToSymbols(NULL, lengths, 2, 15, symbols);
   EXPECT_EQ(symbols[0], 0u);
   EXPECT_EQ(symbols[1], 1u);
 }
@@ -32,7 +32,7 @@ TEST(Tree, LengthsToSymbolsAreCanonical) {
 TEST(Tree, LengthsToSymbolsZeroLengthGetsNoCode) {
   const unsigned lengths[3] = {0, 1, 1};
   unsigned symbols[3] = {7, 7, 7};
-  ZopfliLengthsToSymbols(lengths, 3, 15, symbols);
+  ZopfliLengthsToSymbols(NULL, lengths, 3, 15, symbols);
   EXPECT_EQ(symbols[0], 0u);  // zero-length symbol assigned 0
 }
 

--- a/test/tree_test.cc
+++ b/test/tree_test.cc
@@ -9,7 +9,7 @@ namespace {
 TEST(Tree, BitLengthsRespectMaxAndKraft) {
   size_t counts[6] = {0, 1, 2, 4, 8, 16};
   unsigned bitlengths[6] = {0};
-  ZopfliCalculateBitLengths(NULL, counts, 6, 15, bitlengths);
+  ZopfliCalculateBitLengths(ZopfliDefaultContext(), counts, 6, 15, bitlengths);
   double kraft = 0.0;
   for (int i = 0; i < 6; i++) {
     if (counts[i] == 0) continue;
@@ -24,7 +24,7 @@ TEST(Tree, LengthsToSymbolsAreCanonical) {
   // Two symbols of length 1: canonical codes are 0 and 1.
   const unsigned lengths[2] = {1, 1};
   unsigned symbols[2] = {0xffff, 0xffff};
-  ZopfliLengthsToSymbols(NULL, lengths, 2, 15, symbols);
+  ZopfliLengthsToSymbols(ZopfliDefaultContext(), lengths, 2, 15, symbols);
   EXPECT_EQ(symbols[0], 0u);
   EXPECT_EQ(symbols[1], 1u);
 }
@@ -32,7 +32,7 @@ TEST(Tree, LengthsToSymbolsAreCanonical) {
 TEST(Tree, LengthsToSymbolsZeroLengthGetsNoCode) {
   const unsigned lengths[3] = {0, 1, 1};
   unsigned symbols[3] = {7, 7, 7};
-  ZopfliLengthsToSymbols(NULL, lengths, 3, 15, symbols);
+  ZopfliLengthsToSymbols(ZopfliDefaultContext(), lengths, 3, 15, symbols);
   EXPECT_EQ(symbols[0], 0u);  // zero-length symbol assigned 0
 }
 

--- a/test/zopfli_c_api.h
+++ b/test/zopfli_c_api.h
@@ -8,6 +8,7 @@
 extern "C" {
 #include "zopfli.h"
 #include "util.h"
+#include "context.h"
 #include "deflate.h"
 #include "lz77.h"
 #include "squeeze.h"
@@ -61,13 +62,15 @@ inline void GreedyStore(const std::vector<unsigned char>& in,
                         ZopfliLZ77Store* store) {
   ZopfliOptions options;
   ZopfliInitOptions(&options);
+  ZopfliContext ctx;
+  ctx.options = &options;
   ZopfliBlockState s;
-  ZopfliInitBlockState(&options, 0, in.size(), 1, &s);
+  ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliHash h;
-  ZopfliAllocHash(ZOPFLI_WINDOW_SIZE, &h);
+  ZopfliAllocHash(&ctx, ZOPFLI_WINDOW_SIZE, &h);
   ZopfliInitLZ77Store(in.data(), store);
   ZopfliLZ77Greedy(&s, in.data(), 0, in.size(), store, &h);
-  ZopfliCleanHash(&h);
+  ZopfliCleanHash(&ctx, &h);
   ZopfliCleanBlockState(&s);
 }
 

--- a/test/zopfli_c_api.h
+++ b/test/zopfli_c_api.h
@@ -63,7 +63,7 @@ inline void GreedyStore(const std::vector<unsigned char>& in,
   ZopfliOptions options;
   ZopfliInitOptions(&options);
   ZopfliContext ctx;
-  ctx.options = &options;
+  ctx.options = options;
   ZopfliBlockState s;
   ZopfliInitBlockState(&ctx, 0, in.size(), 1, &s);
   ZopfliHash h;


### PR DESCRIPTION
This pull request introduces a custom allocator interface to the Zopfli codebase, enabling users to provide their own memory allocation routines by setting `options.zrealloc` and `options.alloc_context`. The changes thread a new `ZopfliContext` structure throughout the code, which encapsulates allocation options and replaces direct calls to `malloc`/`free` with context-aware allocation functions. This allows for flexible memory management (e.g., arenas, pools) and is especially useful for embedded or specialized environments. The update also includes thorough refactoring of function signatures and internal data structures to support this feature, and updates documentation and tests accordingly.

The most important changes are:

### Custom allocator integration

* Added a new `ZopfliContext` struct (in `src/zopfli/context.h`) to carry allocation options and context throughout the codebase, allowing all allocations to be routed through a user-provided allocator (`zrealloc`).
* Updated all relevant allocation and deallocation code to use `ZopfliRealloc` with the context, replacing direct `malloc`/`free` calls (e.g., in `src/zopfli/blocksplitter.c`, `src/zopfli/cache.c`, and related headers). [[1]](diffhunk://#diff-8add4b38de10e0a69eb085f58b6c496708688cd914ef8c7abbbed1f9f2d24182R28) [[2]](diffhunk://#diff-8add4b38de10e0a69eb085f58b6c496708688cd914ef8c7abbbed1f9f2d24182L110-R141) [[3]](diffhunk://#diff-e38553b6bcad1d266b1b79db78b25724d90d94bbbb0be8ae7ff8cc49fb9ef58cL32-R47) [[4]](diffhunk://#diff-e38553b6bcad1d266b1b79db78b25724d90d94bbbb0be8ae7ff8cc49fb9ef58cL62-R70) [[5]](diffhunk://#diff-0db7efd8806544b150462104b6ad02c4ba53709487d8792ba563958b50753e54L43-R67)

### API and function signature changes

* Modified function signatures across the codebase to accept `const ZopfliContext* ctx` instead of relying on global or implicit state, ensuring all allocations are context-aware (e.g., `ZopfliInitCache`, `ZopfliCleanCache`, `ZopfliBlockSplit`, `ZopfliBlockSplitSimple`). [[1]](diffhunk://#diff-e14b22edaf8c83a52d2d377baf779093305809dff5fff68d2d3d430266c3ca02L61-R68) [[2]](diffhunk://#diff-0db7efd8806544b150462104b6ad02c4ba53709487d8792ba563958b50753e54L43-R67) [[3]](diffhunk://#diff-8add4b38de10e0a69eb085f58b6c496708688cd914ef8c7abbbed1f9f2d24182L279-R316)

### Documentation updates

* Updated `README.md` to document the new custom allocator interface, including usage instructions and code examples.
* Added repo-specific guidance in `CLAUDE.md` clarifying that upstream file structure does not need to be preserved, allowing for codebase improvements.

### Type consistency and cleanup

* Replaced instances of `unsigned char` and `unsigned short` with `uint8_t` and `uint16_t` for clarity and consistency in memory handling. [[1]](diffhunk://#diff-e38553b6bcad1d266b1b79db78b25724d90d94bbbb0be8ae7ff8cc49fb9ef58cL32-R47) [[2]](diffhunk://#diff-e38553b6bcad1d266b1b79db78b25724d90d94bbbb0be8ae7ff8cc49fb9ef58cL99-R97) [[3]](diffhunk://#diff-0db7efd8806544b150462104b6ad02c4ba53709487d8792ba563958b50753e54L43-R67) [[4]](diffhunk://#diff-8add4b38de10e0a69eb085f58b6c496708688cd914ef8c7abbbed1f9f2d24182L201-R206)

### Testing

* Added a new test file `test/custom_allocator_test.cc` to verify the behavior of the custom allocator integration.