### PR TITLE
updated reademe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,35 @@
 [![macOS](https://github.com/QVXLabs/zopfli/actions/workflows/macos.yml/badge.svg)](https://github.com/QVXLabs/zopfli/actions/workflows/macos.yml)
 [![Windows](https://github.com/QVXLabs/zopfli/actions/workflows/windows.yml/badge.svg)](https://github.com/QVXLabs/zopfli/actions/workflows/windows.yml)
 
-Zopfli Compression Algorithm is a compression library programmed in C to perform
-very good, but slow, deflate or zlib compression.
+An **actively maintained** fork of
+[google/zopfli](https://github.com/google/zopfli), which was archived (made
+read-only) in October 2025. Zopfli produces very good — but slow — DEFLATE /
+zlib / gzip compression; the output is standard and decompresses with any zlib
+or gzip library.
 
-The basic function to compress data is `ZopfliCompress` in `zopfli.h`. Use the
-`ZopfliOptions` object to set parameters that affect the speed and compression.
-Use the `ZopfliInitOptions` function to place the default values in the
-`ZopfliOptions` first.
+This fork is a **drop-in replacement** that is faster, leaner, and
+deterministic:
+
+- **~1.9× faster** on text and **~2.5–3.5× faster** on incompressible data at a
+  matched iteration count.
+- **34–38% lower** peak memory.
+- **Bit-identical output across every CPU, compiler, and floating-point mode**,
+  with no `libm`/FPU dependency — it runs on FPU-less microcontrollers. (Upstream
+  zopfli's output varies by platform.)
+
+Output is a valid DEFLATE/zlib/gzip stream but is **not** byte-identical to
+upstream zopfli — it defines a new, platform-independent canonical encoding. See
+[Modifications from Stock Zopfli](#modifications-from-stock-zopfli) for the full
+numbers and [Migrating from google/zopfli](#migrating-from-googlezopfli) before
+you switch.
+
+> **Maintenance status:** actively maintained following upstream's archival. Bug
+> reports, fixes, and PRs are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+The basic function to compress data is `ZopfliCompress` in `<zopfli/zopfli.h>`.
+Use the `ZopfliOptions` object to set parameters that affect the speed and
+compression. Use the `ZopfliInitOptions` function to place the default values in
+the `ZopfliOptions` first.
 
 `ZopfliCompress` supports deflate, gzip and zlib output format with a parameter.
 To support only one individual format, you can instead use `ZopfliDeflate`,
@@ -30,6 +52,26 @@ libraries can decompress the data.
 The source code of Zopfli is under `src/zopfli`. `zopfli_bin.c` is separate from
 the library and contains an example program to create very well compressed gzip
 files.
+
+## Migrating from google/zopfli
+
+Two things differ from upstream when you switch; nothing else in your pipeline
+needs to change.
+
+- **Include path.** Public headers install under `include/zopfli/`, so consumers
+  include `<zopfli/zopfli.h>` (was `<zopfli.h>`). The per-format entry points
+  (`ZopfliGzipCompress`, `ZopfliZlibCompress`, `ZopfliDeflate`,
+  `ZopfliDeflatePart`) are all declared there now — the separate
+  `gzip_container.h` / `zlib_container.h` headers were removed.
+- **Output is not byte-identical to upstream.** It is a valid DEFLATE/zlib/gzip
+  stream any decoder reads, and it is reproducible across platforms — but if you
+  compare against stored golden files produced by upstream zopfli, they will not
+  match. Regenerate any such fixtures from this fork. Compression ratio is within
+  ~0.02% of upstream (sometimes better).
+
+The CLI flags (`zopfli`, `zopflipng`) are unchanged, except the default
+iteration count is now `0` = auto (see the **Iterations** section below); pass
+`--i15` for upstream-like speed and pass count.
 
 ## Modifications from Stock Zopfli
 


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the project's status as an actively maintained fork of the original `google/zopfli`, and provides guidance on migrating from the upstream project. The new content highlights performance improvements, determinism, and maintenance details. It also documents differences in include paths and output compatibility for users switching to this fork.

**Project status and improvements:**
* Updated the introduction to state that this project is an actively maintained fork of `google/zopfli`, with details on improved speed (~1.9×–3.5× faster), reduced memory usage (34–38% lower), and deterministic, platform-independent output. Maintenance status and contribution guidelines are also clarified.

**Migration guidance:**
* Added a new section, "Migrating from google/zopfli", explaining the new header include paths (`<zopfli/zopfli.h>`), consolidation of per-format entry points, and the fact that output is not byte-identical to upstream (though it is fully compatible and reproducible). It also notes CLI flag differences and advises regenerating golden files if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/zopfli/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784838723&installation_id=141995922&pr_number=9&repository=QVXLabs%2Fzopfli&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fzopfli%2Fpull%2F9&signature=debb61680834ee9d11c9ceb3890e3fdcc1a3903d7e307fb3bcbaa8c4f63e8b7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->