### PR TITLE
cmake: expose libzopfli headers as <zopfli/...>; readme -lm fixup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,10 @@ target_include_directories(libzopfli
   PUBLIC
     $<BUILD_INTERFACE:${ZOPFLI_GENERATED_DIR}>
   INTERFACE
+    # src/zopfli exposes <zopfli.h> (used by the in-tree tests); src exposes
+    # <zopfli/zopfli.h> to match the installed/conan layout (include/zopfli/).
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/zopfli>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 set_target_properties(libzopfli PROPERTIES

--- a/README.md
+++ b/README.md
@@ -284,10 +284,10 @@ The makefile does not build the test suite; use CMake for that.
 ### Compiling directly
 
 To build zopfli by hand, compile all `.c` source files under `src/zopfli` to a
-single binary and link to the standard C math library, e.g.:
+single binary — the library is integer-only, so no `-lm` is needed, e.g.:
 
 ```sh
-gcc src/zopfli/*.c -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -lm -o zopfli
+gcc src/zopfli/*.c -O2 -W -Wall -Wextra -Wno-unused-function -std=gnu99 -pedantic -o zopfli
 ```
 
 ## Running the tests


### PR DESCRIPTION
Brings the `1.1.0` release line into `master`.

## Changes
- **cmake:** add `src/` to `libzopfli`'s build interface so subproject
  consumers can `#include <zopfli/zopfli.h>`, matching the installed/conan
  layout (`include/zopfli/`). The existing `src/zopfli` entry stays so the
  in-tree tests' `"zopfli.h"` includes keep resolving.
- **docs:** drop `-lm` from the build-by-hand instructions (libzopfli is
  integer-only).

The `1.1.0` tag points at the tip of this branch (`46f3a15`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/zopfli/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784867413&installation_id=141995922&pr_number=10&repository=QVXLabs%2Fzopfli&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fzopfli%2Fpull%2F10&signature=87d97a74886b1f9e085df43ceb828e6d0965122a664f1f4e1c62d4844911648a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->