### PR TITLE
Byte-identical hot-path optimizations (~9% -i15, ~8% --i200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). New
 changes go under a new top section as they land.
 
+## [Unreleased]
+
+### Changed
+- Further hot-path performance work; compressed output is bit-identical in
+  every configuration. Measured on an i9-8950HK: ~9% faster at the default
+  iteration count and ~8% at `--i200` on text, ~12% faster on incompressible
+  input, and ~21% lower peak memory at `--i200` on incompressible input.
+  Internals: packed length/distance array in the squeeze DP, inlined
+  longest-match-cache probe, shared tree-encoding preprocessing across the
+  RLE combos, repeated-parse block-size shortcut, lazily materialized store
+  histograms, and assorted match-finder/cache cleanups.
+
 ## [1.1.0] - 2026-06-23
 
 ### Added

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -26,9 +26,6 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
 
-/* run_off sentinel: this position has no full sublen stored (pool overflow). */
-#define LMC_NO_SUBLEN ((unsigned)-1)
-
 void ZopfliInitCache(const ZopfliContext* ctx, size_t blocksize,
                      ZopfliLongestMatchCache* lmc) {
   size_t i;
@@ -51,8 +48,10 @@ void ZopfliInitCache(const ZopfliContext* ctx, size_t blocksize,
   left uninitialized: ZopfliMaxCachedSublen keys off length == 0 (no match
   cached), and run_off is only read for a real match, always written by
   ZopfliSublenToCache before being read back. */
-  for (i = 0; i < blocksize; i++) lmc->length[i] = 1;
-  for (i = 0; i < blocksize; i++) lmc->dist[i] = 0;
+  for (i = 0; i < blocksize; i++) {
+    lmc->length[i] = 1;
+    lmc->dist[i] = 0;
+  }
 }
 
 void ZopfliCleanCache(const ZopfliContext* ctx, ZopfliLongestMatchCache* lmc) {
@@ -67,6 +66,7 @@ void ZopfliSublenToCache(const uint16_t* sublen,
                          ZopfliLongestMatchCache* lmc) {
   size_t i;
   size_t nruns = 0;
+  size_t avail;
   uint8_t* run;
 
 #if ZOPFLI_CACHE_LENGTH == 0
@@ -75,29 +75,29 @@ void ZopfliSublenToCache(const uint16_t* sublen,
 
   if (length < 3) return;
 
-  /* Count the distinct-distance runs this position needs. */
-  for (i = 3; i <= length; i++) {
-    if (i == length || sublen[i] != sublen[i + 1]) nruns++;
-  }
-
-  /* Overflow: keep within the pool budget. Mark incomplete and fall back to
-  recomputation for this position (as an over-cap position did before). */
-  if (lmc->pool_used + nruns > lmc->pool_cap) {
-    lmc->all_complete = 0;
-    lmc->run_off[pos] = LMC_NO_SUBLEN;
-    return;
-  }
-
-  lmc->run_off[pos] = (unsigned)lmc->pool_used;
+  /* Emit runs in a single sublen pass, straight into the pool's free space.
+  On overflow nothing is committed (pool_used is unchanged and free-slot
+  contents are never read), same as the position never fitting. */
+  avail = lmc->pool_cap - lmc->pool_used;
   run = &lmc->pool[lmc->pool_used * 3];
   for (i = 3; i <= length; i++) {
     if (i == length || sublen[i] != sublen[i + 1]) {
+      if (nruns == avail) {
+        /* Overflow: keep within the pool budget. Mark incomplete and fall back
+        to recomputation for this position (as an over-cap position did
+        before). */
+        lmc->all_complete = 0;
+        lmc->run_off[pos] = LMC_NO_SUBLEN;
+        return;
+      }
       run[0] = (uint8_t)(i - 3);
       run[1] = sublen[i] & 0xff;
       run[2] = (sublen[i] >> 8) & 0xff;
       run += 3;
+      nruns++;
     }
   }
+  lmc->run_off[pos] = (unsigned)lmc->pool_used;
   lmc->pool_used += nruns;
 }
 
@@ -123,22 +123,6 @@ void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
     prevlength = runlen + 1;
     run += 3;
   }
-}
-
-/*
-Returns the length up to which could be stored in the cache.
-*/
-unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,
-                               size_t pos, size_t length) {
-#if ZOPFLI_CACHE_LENGTH == 0
-  return 0;
-#endif
-  /* length == 0 means no match is cached; LMC_NO_SUBLEN means the position
-  overflowed the pool and has no full sublen. Otherwise the stored runs cover
-  the whole match, so the max cached sublen is exactly length. */
-  if (length == 0) return 0;
-  if (lmc->run_off[pos] == LMC_NO_SUBLEN) return 0;
-  return (unsigned)length;
 }
 
 #endif  /* ZOPFLI_LONGEST_MATCH_CACHE */

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -29,6 +29,9 @@ The cache that speeds up ZopfliFindLongestMatch of lz77.c.
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
 
+/* run_off sentinel: this position has no full sublen stored (pool overflow). */
+#define LMC_NO_SUBLEN ((unsigned)-1)
+
 /*
 Cache used by ZopfliFindLongestMatch to remember previously found length/dist
 values. The sublen (best distance per shorter-than-best length) is stored as
@@ -66,9 +69,20 @@ void ZopfliCacheToSublen(const ZopfliLongestMatchCache* lmc,
                          size_t pos, size_t length,
                          uint16_t* sublen);
 
-/* Returns the length up to which could be stored in the cache. */
-unsigned ZopfliMaxCachedSublen(const ZopfliLongestMatchCache* lmc,
-                               size_t pos, size_t length);
+/* Returns the length up to which could be stored in the cache. Inline: it sits
+on the squeeze DP's per-position fast-path trigger. */
+ZOPFLI_INLINE unsigned ZopfliMaxCachedSublen(
+    const ZopfliLongestMatchCache* lmc, size_t pos, size_t length) {
+#if ZOPFLI_CACHE_LENGTH == 0
+  return 0;
+#endif
+  /* length == 0 means no match is cached; LMC_NO_SUBLEN means the position
+  overflowed the pool and has no full sublen. Otherwise the stored runs cover
+  the whole match, so the max cached sublen is exactly length. */
+  if (length == 0) return 0;
+  if (lmc->run_off[pos] == LMC_NO_SUBLEN) return 0;
+  return (unsigned)length;
+}
 
 #endif  /* ZOPFLI_LONGEST_MATCH_CACHE */
 

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -102,25 +102,53 @@ static void PatchDistanceCodesForBuggyDecoders(unsigned* d_lengths) {
 }
 
 /*
+The lit/len + dist code lengths flattened into the single sequence DEFLATE
+encodes, with the hlit/hdist zero-trims already applied. Combo-independent, so
+the 8 EncodeTree RLE combos share one instance instead of re-deriving it.
+*/
+typedef struct TreeLens {
+  uint8_t lens[ZOPFLI_NUM_LL + ZOPFLI_NUM_D];
+  unsigned hlit;  /* 286 - 257 max */
+  unsigned hdist;  /* 32 - 1 max, but gzip does not like hdist > 29. */
+  unsigned lld_total;  /* Total amount of literal, length, distance codes. */
+} TreeLens;
+
+static void BuildTreeLens(const unsigned* ll_lengths, const unsigned* d_lengths,
+                          TreeLens* t) {
+  unsigned hlit = 29;
+  unsigned hdist = 29;
+  unsigned hlit2;
+  size_t i;
+
+  /* Trim zeros. */
+  while (hlit > 0 && ll_lengths[257 + hlit - 1] == 0) hlit--;
+  while (hdist > 0 && d_lengths[1 + hdist - 1] == 0) hdist--;
+  hlit2 = hlit + 257;
+
+  t->hlit = hlit;
+  t->hdist = hdist;
+  t->lld_total = hlit2 + hdist + 1;
+  for (i = 0; i < hlit2; i++) t->lens[i] = (uint8_t)ll_lengths[i];
+  for (i = 0; i <= hdist; i++) t->lens[hlit2 + i] = (uint8_t)d_lengths[i];
+}
+
+/*
 Encodes the Huffman tree and returns how many bits its encoding takes. If out
 is a null pointer, only returns the size and runs faster.
 */
 static size_t EncodeTree(const ZopfliContext* ctx,
                          ZopfliKatajainenScratch* scratch,
-                         const unsigned* ll_lengths,
-                         const unsigned* d_lengths,
+                         const TreeLens* t,
                          int use_16, int use_17, int use_18,
                          uint8_t* bp, ZopfliBuf* buf) {
-  unsigned lld_total;  /* Total amount of literal, length, distance codes. */
+  const uint8_t* lens = t->lens;
+  unsigned lld_total = t->lld_total;
   /* Runlength encoded version of lengths of litlen and dist trees. */
   unsigned* rle = NULL;
   unsigned* rle_bits = NULL;  /* Extra bits for rle values 16, 17 and 18. */
   size_t rle_size = 0;  /* Size of rle array. */
   size_t rle_bits_size = 0;  /* Should have same value as rle_size. */
-  unsigned hlit = 29;  /* 286 - 257 */
-  unsigned hdist = 29;  /* 32 - 1, but gzip does not like hdist > 29.*/
   unsigned hclen;
-  unsigned hlit2;
   size_t i, j;
   size_t clcounts[19];
   unsigned clcl[19];  /* Code length code lengths. */
@@ -134,20 +162,12 @@ static size_t EncodeTree(const ZopfliContext* ctx,
 
   for(i = 0; i < 19; i++) clcounts[i] = 0;
 
-  /* Trim zeros. */
-  while (hlit > 0 && ll_lengths[257 + hlit - 1] == 0) hlit--;
-  while (hdist > 0 && d_lengths[1 + hdist - 1] == 0) hdist--;
-  hlit2 = hlit + 257;
-
-  lld_total = hlit2 + hdist + 1;
-
   for (i = 0; i < lld_total; i++) {
     /* This is an encoding of a huffman tree, so now the length is a symbol */
-    uint8_t symbol = i < hlit2 ? ll_lengths[i] : d_lengths[i - hlit2];
+    uint8_t symbol = lens[i];
     unsigned count = 1;
     if(use_16 || (symbol == 0 && (use_17 || use_18))) {
-      for (j = i + 1; j < lld_total && symbol ==
-          (j < hlit2 ? ll_lengths[j] : d_lengths[j - hlit2]); j++) {
+      for (j = i + 1; j < lld_total && symbol == lens[j]; j++) {
         count++;
       }
     }
@@ -217,8 +237,8 @@ static size_t EncodeTree(const ZopfliContext* ctx,
   while (hclen > 0 && clcounts[order[hclen + 4 - 1]] == 0) hclen--;
 
   if (!size_only) {
-    AddBits(ctx, hlit, 5, bp, buf);
-    AddBits(ctx, hdist, 5, bp, buf);
+    AddBits(ctx, t->hlit, 5, bp, buf);
+    AddBits(ctx, t->hdist, 5, bp, buf);
     AddBits(ctx, hclen, 4, bp, buf);
 
     for (i = 0; i < hclen + 4; i++) {
@@ -257,12 +277,14 @@ static void AddDynamicTree(const ZopfliContext* ctx,
                            const unsigned* ll_lengths,
                            const unsigned* d_lengths,
                            uint8_t* bp, ZopfliBuf* buf) {
+  TreeLens t;
   int i;
   int best = 0;
   size_t bestsize = 0;
 
+  BuildTreeLens(ll_lengths, d_lengths, &t);
   for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(ctx, scratch, ll_lengths, d_lengths,
+    size_t size = EncodeTree(ctx, scratch, &t,
                              i & 1, i & 2, i & 4,
                              0, NULL);
     if (bestsize == 0 || size < bestsize) {
@@ -271,7 +293,7 @@ static void AddDynamicTree(const ZopfliContext* ctx,
     }
   }
 
-  EncodeTree(ctx, scratch, ll_lengths, d_lengths,
+  EncodeTree(ctx, scratch, &t,
              best & 1, best & 2, best & 4,
              bp, buf);
 }
@@ -283,11 +305,13 @@ static size_t CalculateTreeSize(const ZopfliContext* ctx,
                                 ZopfliKatajainenScratch* scratch,
                                 const unsigned* ll_lengths,
                                 const unsigned* d_lengths) {
+  TreeLens t;
   size_t result = 0;
   int i;
 
+  BuildTreeLens(ll_lengths, d_lengths, &t);
   for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(ctx, scratch, ll_lengths, d_lengths,
+    size_t size = EncodeTree(ctx, scratch, &t,
                              i & 1, i & 2, i & 4,
                              0, NULL);
     if (result == 0 || size < result) result = size;
@@ -554,6 +578,14 @@ static uint32_t TryOptimizeHuffmanForRle(
                                    d_lengths2);
   PatchDistanceCodesForBuggyDecoders(d_lengths2);
 
+  /* If the RLE optimization didn't change the code lengths, the second
+  evaluation would reproduce treesize/datasize exactly and the < below keeps
+  the original on ties, so skip it. */
+  if (memcmp(ll_lengths2, ll_lengths, sizeof(ll_lengths2)) == 0 &&
+      memcmp(d_lengths2, d_lengths, sizeof(d_lengths2)) == 0) {
+    return treesize + datasize;
+  }
+
   treesize2 = (uint32_t)CalculateTreeSize(ctx, scratch, ll_lengths2,
                                           d_lengths2);
   datasize2 = (uint32_t)CalculateBlockSymbolSizeGivenCounts(ll_counts, d_counts,
@@ -574,6 +606,22 @@ symbols to have smallest output size. This are not necessarily the ideal Huffman
 bit lengths. Returns size of encoded tree and data in bits, not including the
 3-bit block header.
 */
+static uint32_t GetDynamicLengthsGivenCounts(const ZopfliContext* ctx,
+                                ZopfliKatajainenScratch* scratch,
+                                const ZopfliLZ77Store* lz77,
+                                size_t lstart, size_t lend,
+                                const size_t* ll_counts,
+                                const size_t* d_counts,
+                                unsigned* ll_lengths, unsigned* d_lengths) {
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, ll_counts, ZOPFLI_NUM_LL, 15,
+                                   ll_lengths);
+  ZopfliCalculateBitLengthsScratch(ctx, scratch, d_counts, ZOPFLI_NUM_D, 15,
+                                   d_lengths);
+  PatchDistanceCodesForBuggyDecoders(d_lengths);
+  return TryOptimizeHuffmanForRle(ctx, scratch, lz77, lstart, lend, ll_counts,
+                                  d_counts, ll_lengths, d_lengths);
+}
+
 static uint32_t GetDynamicLengths(const ZopfliContext* ctx,
                                 ZopfliKatajainenScratch* scratch,
                                 const ZopfliLZ77Store* lz77,
@@ -584,13 +632,23 @@ static uint32_t GetDynamicLengths(const ZopfliContext* ctx,
 
   ZopfliLZ77GetHistogram(lz77, lstart, lend, ll_counts, d_counts);
   ll_counts[256] = 1;  /* End symbol. */
-  ZopfliCalculateBitLengthsScratch(ctx, scratch, ll_counts, ZOPFLI_NUM_LL, 15,
-                                   ll_lengths);
-  ZopfliCalculateBitLengthsScratch(ctx, scratch, d_counts, ZOPFLI_NUM_D, 15,
-                                   d_lengths);
-  PatchDistanceCodesForBuggyDecoders(d_lengths);
-  return TryOptimizeHuffmanForRle(ctx, scratch, lz77, lstart, lend, ll_counts,
-                                  d_counts, ll_lengths, d_lengths);
+  return GetDynamicLengthsGivenCounts(ctx, scratch, lz77, lstart, lend,
+                                      ll_counts, d_counts,
+                                      ll_lengths, d_lengths);
+}
+
+uint32_t ZopfliCalculateBlockSizeGivenCounts(const ZopfliContext* ctx,
+                                             ZopfliKatajainenScratch* scratch,
+                                             const ZopfliLZ77Store* lz77,
+                                             size_t lstart, size_t lend,
+                                             const size_t* ll_counts,
+                                             const size_t* d_counts) {
+  unsigned ll_lengths[ZOPFLI_NUM_LL];
+  unsigned d_lengths[ZOPFLI_NUM_D];
+  /* 3 header bits, as in ZopfliCalculateBlockSizeScratch. */
+  return 3 + GetDynamicLengthsGivenCounts(ctx, scratch, lz77, lstart, lend,
+                                          ll_counts, d_counts,
+                                          ll_lengths, d_lengths);
 }
 
 uint32_t ZopfliCalculateBlockSizeScratch(const ZopfliContext* ctx,

--- a/src/zopfli/deflate.h
+++ b/src/zopfli/deflate.h
@@ -66,6 +66,20 @@ uint32_t ZopfliCalculateBlockSizeScratch(const ZopfliContext* ctx,
                                          size_t lstart, size_t lend, int btype);
 
 /*
+Dynamic-tree (btype 2) block size in bits for [lstart, lend), given the
+range's precomputed symbol histogram (ll_counts[256] must already hold the end
+symbol). Identical result to ZopfliCalculateBlockSizeScratch(..., 2) but skips
+extracting the histogram from the store, so the store's cumulative counts need
+not be materialized.
+*/
+uint32_t ZopfliCalculateBlockSizeGivenCounts(const ZopfliContext* ctx,
+                                             ZopfliKatajainenScratch* scratch,
+                                             const ZopfliLZ77Store* lz77,
+                                             size_t lstart, size_t lend,
+                                             const size_t* ll_counts,
+                                             const size_t* d_counts);
+
+/*
 Calculates block size in bits, automatically using the best btype.
 */
 uint32_t ZopfliCalculateBlockSizeAutoType(const ZopfliLZ77Store* lz77,

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -436,11 +436,12 @@ static int TryGetFromLongestMatchCache(ZopfliBlockState* s,
 
   if (!lmc) return 0;
   lmclen = lmc->length[lmcpos];
-  maxsub = ZopfliMaxCachedSublen(lmc, lmcpos, lmclen);
 
   /* Length > 0 and dist 0 is invalid combination, which indicates on purpose
-     that this cache value is not filled in yet. */
+     that this cache value is not filled in yet. Only then is run_off[lmcpos]
+     defined, so ZopfliMaxCachedSublen must stay behind the check. */
   cache_available = lmclen == 0 || lmc->dist[lmcpos] != 0;
+  maxsub = cache_available ? ZopfliMaxCachedSublen(lmc, lmcpos, lmclen) : 0;
   limit_ok_for_cache = cache_available &&
       (*limit == ZOPFLI_MAX_MATCH || lmclen <= *limit ||
       (sublen && maxsub >= *limit));

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -35,6 +35,7 @@ void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store) {
   store->data = data;
   store->ll_counts = 0;
   store->d_counts = 0;
+  store->counts_size = 0;
 }
 
 void ZopfliCleanLZ77Store(const ZopfliContext* ctx, ZopfliLZ77Store* store) {
@@ -78,6 +79,7 @@ static void ZopfliReserveLZ77Store(const ZopfliContext* ctx,
 
 void ZopfliResetLZ77Store(ZopfliLZ77Store* store) {
   store->size = 0;
+  store->counts_size = 0;
 }
 
 void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
@@ -85,6 +87,10 @@ void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
   size_t i;
   size_t llsize = ZOPFLI_NUM_LL * CeilDiv(source->size, ZOPFLI_NUM_LL);
   size_t dsize = ZOPFLI_NUM_D * CeilDiv(source->size, ZOPFLI_NUM_D);
+  /* Only the materialized prefix of the counts needs copying; the dest can
+  materialize the rest from its own symbols on demand. */
+  size_t llvalid = ZOPFLI_NUM_LL * CeilDiv(source->counts_size, ZOPFLI_NUM_LL);
+  size_t dvalid = ZOPFLI_NUM_D * CeilDiv(source->counts_size, ZOPFLI_NUM_D);
   ZopfliCleanLZ77Store(ctx, dest);
   ZopfliInitLZ77Store(source->data, dest);
   dest->litlens =
@@ -100,15 +106,16 @@ void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
 
   dest->size = source->size;
   dest->cap = source->size;
+  dest->counts_size = source->counts_size;
   for (i = 0; i < source->size; i++) {
     dest->litlens[i] = source->litlens[i];
     dest->dists[i] = source->dists[i];
     dest->pos[i] = source->pos[i];
   }
-  for (i = 0; i < llsize; i++) {
+  for (i = 0; i < llvalid; i++) {
     dest->ll_counts[i] = source->ll_counts[i];
   }
-  for (i = 0; i < dsize; i++) {
+  for (i = 0; i < dvalid; i++) {
     dest->d_counts[i] = source->d_counts[i];
   }
 }
@@ -119,43 +126,55 @@ context must be a ZopfliLZ77Store*.
 */
 void ZopfliStoreLitLenDist(const ZopfliContext* ctx, uint16_t length,
                            uint16_t dist, size_t pos, ZopfliLZ77Store* store) {
-  size_t i;
   size_t origsize = store->size;
-  size_t llstart = ZOPFLI_NUM_LL * (origsize / ZOPFLI_NUM_LL);
-  size_t dstart = ZOPFLI_NUM_D * (origsize / ZOPFLI_NUM_D);
 
   ZopfliReserveLZ77Store(ctx, store, origsize + 1);
-
-  /* Everytime the index wraps around, a new cumulative histogram is made: we're
-  keeping one histogram value per LZ77 symbol rather than a full histogram for
-  each to save memory. The new chunk copies the previous chunk's totals (or
-  zeros for the first chunk). */
-  if (origsize % ZOPFLI_NUM_LL == 0) {
-    for (i = 0; i < ZOPFLI_NUM_LL; i++) {
-      store->ll_counts[origsize + i] =
-          origsize == 0 ? 0 : store->ll_counts[origsize - ZOPFLI_NUM_LL + i];
-    }
-  }
-  if (origsize % ZOPFLI_NUM_D == 0) {
-    for (i = 0; i < ZOPFLI_NUM_D; i++) {
-      store->d_counts[origsize + i] =
-          origsize == 0 ? 0 : store->d_counts[origsize - ZOPFLI_NUM_D + i];
-    }
-  }
 
   store->litlens[origsize] = length;
   store->dists[origsize] = dist;
   store->pos[origsize] = pos;
   assert(length < 259);
 
-  if (dist == 0) {
-    store->ll_counts[llstart + length]++;
-  } else {
-    store->ll_counts[llstart + ZopfliGetLengthSymbol(length)]++;
-    store->d_counts[dstart + ZopfliGetDistSymbol(dist)]++;
-  }
-
+  /* The cumulative histograms are not maintained here; EnsureCounts
+  materializes them on demand. */
   store->size = origsize + 1;
+}
+
+/*
+Materializes the cumulative chunk histograms for symbols [counts_size, size).
+Every time the index wraps around, a new cumulative histogram chunk is made:
+one histogram value per LZ77 symbol rather than a full histogram per symbol,
+to save memory; the new chunk copies the previous chunk's totals (or zeros for
+the first chunk). Maintenance is deferred so stores that never serve histogram
+queries (the per-iteration squeeze refills) never pay for it. The const cast
+is an internal-caching detail: every store object is writable.
+*/
+static void EnsureCounts(const ZopfliLZ77Store* cstore) {
+  ZopfliLZ77Store* store = (ZopfliLZ77Store*)cstore;
+  size_t i, j;
+  for (i = store->counts_size; i < store->size; i++) {
+    size_t llstart = ZOPFLI_NUM_LL * (i / ZOPFLI_NUM_LL);
+    size_t dstart = ZOPFLI_NUM_D * (i / ZOPFLI_NUM_D);
+    if (i % ZOPFLI_NUM_LL == 0) {
+      for (j = 0; j < ZOPFLI_NUM_LL; j++) {
+        store->ll_counts[i + j] =
+            i == 0 ? 0 : store->ll_counts[i - ZOPFLI_NUM_LL + j];
+      }
+    }
+    if (i % ZOPFLI_NUM_D == 0) {
+      for (j = 0; j < ZOPFLI_NUM_D; j++) {
+        store->d_counts[i + j] =
+            i == 0 ? 0 : store->d_counts[i - ZOPFLI_NUM_D + j];
+      }
+    }
+    if (store->dists[i] == 0) {
+      store->ll_counts[llstart + store->litlens[i]]++;
+    } else {
+      store->ll_counts[llstart + ZopfliGetLengthSymbol(store->litlens[i])]++;
+      store->d_counts[dstart + ZopfliGetDistSymbol(store->dists[i])]++;
+    }
+  }
+  store->counts_size = store->size;
 }
 
 void ZopfliAppendLZ77Store(const ZopfliContext* ctx,
@@ -222,6 +241,7 @@ void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
   } else {
     /* Subtract the cumulative histograms at the end and the start to get the
     histogram for this range. */
+    EnsureCounts(lz77);
     ZopfliLZ77GetHistogramAt(lz77, lend - 1, ll_counts, d_counts);
     if (lstart > 0) {
       size_t ll_counts2[ZOPFLI_NUM_LL];
@@ -247,8 +267,7 @@ void ZopfliInitBlockState(const ZopfliContext* ctx,
   ZopfliInitKatajainenScratch(&s->katascratch);
   /* Squeeze working buffers; allocated lazily by ZopfliLZ77Optimal[Fixed]. */
   s->costs = NULL;
-  s->length_array = NULL;
-  s->dist_array = NULL;
+  s->lendist_array = NULL;
   s->path = NULL;
   s->pathsize = 0;
   s->pathcap = 0;
@@ -302,14 +321,10 @@ static int GetLengthScore(int length, int distance) {
   return distance > 1024 ? length - 1 : length;
 }
 
+#ifndef NDEBUG
 void ZopfliVerifyLenDist(const uint8_t* data, size_t datasize, size_t pos,
                          uint16_t dist, uint16_t length) {
-
-  /* TODO(lode): make this only run in a debug compile, it's for assert only. */
   size_t i;
-
-  /* Read only by the assert below, which NDEBUG strips. */
-  (void)datasize;
 
   assert(pos + length <= datasize);
   for (i = 0; i < length; i++) {
@@ -319,6 +334,7 @@ void ZopfliVerifyLenDist(const uint8_t* data, size_t datasize, size_t pos,
     }
   }
 }
+#endif
 
 /*
 Selects the GetMatch implementation:
@@ -409,38 +425,44 @@ information from the cache.
 static int TryGetFromLongestMatchCache(ZopfliBlockState* s,
     size_t pos, size_t* limit,
     uint16_t* sublen, uint16_t* distance, uint16_t* length) {
+  const ZopfliLongestMatchCache* lmc = s->lmc;
   /* The LMC cache starts at the beginning of the block rather than the
      beginning of the whole array. */
   size_t lmcpos = pos - s->blockstart;
+  uint16_t lmclen;
+  unsigned maxsub;
+  uint8_t cache_available;
+  uint8_t limit_ok_for_cache;
+
+  if (!lmc) return 0;
+  lmclen = lmc->length[lmcpos];
+  maxsub = ZopfliMaxCachedSublen(lmc, lmcpos, lmclen);
 
   /* Length > 0 and dist 0 is invalid combination, which indicates on purpose
      that this cache value is not filled in yet. */
-  uint8_t cache_available = s->lmc && (s->lmc->length[lmcpos] == 0 ||
-      s->lmc->dist[lmcpos] != 0);
-  uint8_t limit_ok_for_cache = cache_available &&
-      (*limit == ZOPFLI_MAX_MATCH || s->lmc->length[lmcpos] <= *limit ||
-      (sublen && ZopfliMaxCachedSublen(s->lmc,
-          lmcpos, s->lmc->length[lmcpos]) >= *limit));
+  cache_available = lmclen == 0 || lmc->dist[lmcpos] != 0;
+  limit_ok_for_cache = cache_available &&
+      (*limit == ZOPFLI_MAX_MATCH || lmclen <= *limit ||
+      (sublen && maxsub >= *limit));
 
-  if (s->lmc && limit_ok_for_cache && cache_available) {
-    if (!sublen || s->lmc->length[lmcpos]
-        <= ZopfliMaxCachedSublen(s->lmc, lmcpos, s->lmc->length[lmcpos])) {
-      *length = s->lmc->length[lmcpos];
+  if (limit_ok_for_cache && cache_available) {
+    if (!sublen || lmclen <= maxsub) {
+      *length = lmclen;
       if (*length > *limit) *length = (uint16_t)*limit;
       if (sublen) {
-        ZopfliCacheToSublen(s->lmc, lmcpos, *length, sublen);
+        ZopfliCacheToSublen(lmc, lmcpos, *length, sublen);
         *distance = sublen[*length];
         if (*limit == ZOPFLI_MAX_MATCH && *length >= ZOPFLI_MIN_MATCH) {
-          assert(sublen[*length] == s->lmc->dist[lmcpos]);
+          assert(sublen[*length] == lmc->dist[lmcpos]);
         }
       } else {
-        *distance = s->lmc->dist[lmcpos];
+        *distance = lmc->dist[lmcpos];
       }
       return 1;
     }
     /* Can't use much of the cache, since the "sublens" need to be calculated,
        but at  least we already know when to stop. */
-    *limit = s->lmc->length[lmcpos];
+    *limit = lmclen;
   }
 
   return 0;
@@ -491,6 +513,12 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
 #if ZOPFLI_MAX_CHAIN_HITS < ZOPFLI_WINDOW_SIZE
   int chain_counter = ZOPFLI_MAX_CHAIN_HITS;  /* For quitting early. */
 #endif
+#ifdef ZOPFLI_HASH_SAME
+  /* Run length at pos and its limit clamp; the hash is fixed during the walk,
+  so both are loop-invariant. */
+  uint16_t same0;
+  uint16_t same0limit;
+#endif
 
   unsigned dist = 0;  /* Not uint16_t on purpose. */
 
@@ -529,6 +557,13 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
   }
   arrayend = &array[pos] + limit;
 
+#ifdef ZOPFLI_HASH_SAME
+  same0 = h->same[hpos];
+  /* limit >= ZOPFLI_MIN_MATCH here, so the clamp cannot change the > 2 gate
+  below. */
+  same0limit = (uint16_t)ZOPFLI_MIN(same0, limit);
+#endif
+
   assert(hval < 65536);
 
   pp = hhead[hval];  /* During the whole loop, p == hprev[pp]. */
@@ -557,11 +592,9 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
           || *(scan + bestlength) == *(match + bestlength)) {
 
 #ifdef ZOPFLI_HASH_SAME
-        uint16_t same0 = h->same[pos & ZOPFLI_WINDOW_MASK];
         if (same0 > 2 && *scan == *match) {
           uint16_t same1 = h->same[(pos - dist) & ZOPFLI_WINDOW_MASK];
-          uint16_t same = ZOPFLI_MIN(same0, same1);
-          same = (uint16_t)ZOPFLI_MIN(same, limit);
+          uint16_t same = ZOPFLI_MIN(same0limit, same1);
           scan += same;
           match += same;
         }
@@ -586,7 +619,7 @@ void ZopfliFindLongestMatch(ZopfliBlockState* s, const ZopfliHash* h,
 
 #ifdef ZOPFLI_HASH_SAME_HASH
     /* Switch to the other hash once this will be more efficient. */
-    if (hhead != h->head2 && bestlength >= h->same[hpos] &&
+    if (hhead != h->head2 && bestlength >= same0 &&
         h->val2 == h->hashval2[p]) {
       /* Now use the hash that encodes the length and first byte. */
       hhead = h->head2;

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -57,9 +57,13 @@ typedef struct ZopfliLZ77Store {
   /* Cumulative histograms wrapping around per chunk. Each chunk has the amount
   of distinct symbols as length, so using 1 value per LZ77 symbol, we have a
   precise histogram at every N symbols, and the rest can be calculated by
-  looping through the actual symbols of this chunk. */
+  looping through the actual symbols of this chunk. Maintained lazily: only the
+  first counts_size symbols are materialized; ZopfliLZ77GetHistogram fills the
+  rest on demand. Keeps the per-iteration squeeze refills, whose block sizes
+  are evaluated from a caller-side histogram, from paying for maintenance. */
   uint32_t* ll_counts;
   uint32_t* d_counts;
+  size_t counts_size;
 } ZopfliLZ77Store;
 
 /*
@@ -87,11 +91,11 @@ typedef struct ZopfliBlockState {
   /* Optimal-parse working buffers for the squeeze pass. Allocated once per
   ZopfliLZ77Optimal[Fixed] call and reused across its iterations; carried here
   so the DP helpers reach them via the block state instead of long parameter
-  lists. costs/length_array/dist_array are sized to the block (blocksize + 1);
-  path is the traced result, grown on demand. */
+  lists. costs/lendist_array are sized to the block (blocksize + 1); each
+  lendist entry packs (dist << 16) | length so the DP's improvement case is a
+  single store. path is the traced result, grown on demand. */
   ZopfliCost* costs;
-  uint16_t* length_array;
-  uint16_t* dist_array;
+  uint32_t* lendist_array;
   uint16_t* path;
   size_t pathsize;
   size_t pathcap;
@@ -146,10 +150,16 @@ void ZopfliFindLongestMatch(
     uint16_t* sublen, uint16_t* distance, uint16_t* length);
 
 /*
-Verifies if length and dist are indeed valid, only used for assertion.
+Verifies if length and dist are indeed valid, only used for assertion. Under
+NDEBUG the whole call (a per-match cross-TU call+ret on hot paths) compiles
+away, matching the asserts it carries.
 */
+#ifndef NDEBUG
 void ZopfliVerifyLenDist(const uint8_t* data, size_t datasize, size_t pos,
                          uint16_t dist, uint16_t length);
+#else
+#define ZopfliVerifyLenDist(data, datasize, pos, dist, length) ((void)0)
+#endif
 
 /*
 Does LZ77 using an algorithm similar to gzip, with lazy matching, rather than

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -23,6 +23,7 @@ Author: afalls@qvxlabs.com (Ardavon Falls)
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "context.h"
 #include "deflate.h"
@@ -130,12 +131,6 @@ static void RandomizeStatFreqs(RanState* state, SymbolStats* stats) {
   stats->litlens[256] = 1;  /* End symbol. */
 }
 
-static void ClearStatFreqs(SymbolStats* stats) {
-  size_t i;
-  for (i = 0; i < ZOPFLI_NUM_LL; i++) stats->litlens[i] = 0;
-  for (i = 0; i < ZOPFLI_NUM_D; i++) stats->dists[i] = 0;
-}
-
 int ZopfliGetCostShift(size_t blocksize) {
   /* A single position costs at most ~32 bits, so a whole block costs less than
   32 * blocksize bits. Pick the largest shift keeping the scaled total <= 2^29,
@@ -221,17 +216,20 @@ static void UpdateCostForRange(ZopfliBlockState* s, size_t j, size_t klo,
     size_t khi, uint16_t dist, ZopfliCost dcost, const CostCache* cache,
     ZopfliCost costsj, ZopfliCost mincostaddcostj) {
   ZopfliCost* costs = s->costs;
+  uint32_t* lendist = s->lendist_array;
+  ZopfliCost base = dcost + costsj;
+  uint32_t distpacked = (uint32_t)dist << 16;
   size_t k;
   for (k = klo; k <= khi; k++) {
+    ZopfliCost oldCost = costs[j + k];
     ZopfliCost newCost;
-    if (costs[j + k] <= mincostaddcostj) continue;
-    newCost = cache->ll_cost[k] + dcost + costsj;
+    if (oldCost <= mincostaddcostj) continue;
+    newCost = cache->ll_cost[k] + base;
     assert(newCost >= 0);
-    if (newCost < costs[j + k]) {
+    if (newCost < oldCost) {
       assert(k <= ZOPFLI_MAX_MATCH);
       costs[j + k] = newCost;
-      s->length_array[j + k] = (uint16_t)k;
-      s->dist_array[j + k] = dist;
+      lendist[j + k] = distpacked | (uint32_t)k;
     }
   }
 }
@@ -244,8 +242,8 @@ in: the input data array
 instart: where to start
 inend: where to stop (not inclusive)
 cache: precomputed fixed-point costs of each lit/len/dist symbol.
-length_array: output array of size (inend - instart) which will receive the best
-    length to reach this byte from a previous byte.
+The block state's lendist_array (size inend - instart + 1) receives, per byte,
+the best (dist << 16) | length to reach it from a previous byte.
 returns the cost that was, according to the cost model, needed to get to the end.
 */
 static ZopfliCost GetBestLengths(ZopfliBlockState *s,
@@ -255,8 +253,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
                                     ZopfliHash* h, int build_hash) {
   /* Best cost to get here so far. */
   ZopfliCost* costs = s->costs;
-  uint16_t* length_array = s->length_array;
-  uint16_t* dist_array = s->dist_array;
+  uint32_t* lendist_array = s->lendist_array;
   size_t blocksize = inend - instart;
   size_t i = 0, k, kend;
   uint16_t leng;
@@ -284,11 +281,10 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
 
   for (i = 1; i < blocksize + 1; i++) costs[i] = ZOPFLI_COST_SENTINEL;
   costs[0] = 0;  /* Because it's the start. */
-  length_array[0] = 0;
-  dist_array[0] = 0;
+  lendist_array[0] = 0;
 
   for (i = instart; i < inend; i++) {
-    size_t j = i - instart;  /* Index in the costs array and length_array. */
+    size_t j = i - instart;  /* Index in the costs and lendist arrays. */
     if (build_hash) ZopfliUpdateHash(in, i, inend, h);
 
 #ifdef ZOPFLI_SHORTCUT_LONG_REPETITIONS
@@ -312,8 +308,9 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       ZOPFLI_MAX_MATCH values to avoid calling ZopfliFindLongestMatch. */
       for (k = 0; k < ZOPFLI_MAX_MATCH; k++) {
         costs[j + ZOPFLI_MAX_MATCH] = costs[j] + symbolcost;
-        length_array[j + ZOPFLI_MAX_MATCH] = ZOPFLI_MAX_MATCH;
-        dist_array[j + ZOPFLI_MAX_MATCH] = 1;  /* Dist-1 repetition. */
+        /* Dist-1 repetition of length ZOPFLI_MAX_MATCH. */
+        lendist_array[j + ZOPFLI_MAX_MATCH] =
+            ((uint32_t)1 << 16) | ZOPFLI_MAX_MATCH;
         i++;
         j++;
         ZopfliUpdateHash(in, i, inend, h);
@@ -327,8 +324,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
       assert(newCost >= 0);
       if (newCost < costs[j + 1]) {
         costs[j + 1] = newCost;
-        length_array[j + 1] = 1;
-        dist_array[j + 1] = 0;  /* Literal. */
+        lendist_array[j + 1] = 1;  /* Literal: length 1, dist 0. */
       }
     }
     mincostaddcostj = mincost + costs[j];
@@ -405,26 +401,27 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
 
 /*
 Calculates the optimal path of lz77 lengths to use from the calculated
-length_array. The length_array must contain the optimal length to reach that
+lendist_array, whose low half must contain the optimal length to reach that
 byte. The path will be filled with the lengths to use, so its data size will be
 the number of lz77 symbols.
 */
 static void TraceBackwards(ZopfliBlockState* s, size_t size) {
-  const uint16_t* length_array = s->length_array;
+  const uint32_t* lendist_array = s->lendist_array;
   size_t index = size;
   s->pathsize = 0;  /* Reuse the buffer (kept allocated) across iterations. */
   if (size == 0) return;
   for (;;) {
+    uint16_t length = (uint16_t)(lendist_array[index] & 0xffff);
     if (s->pathsize == s->pathcap) {
       s->pathcap = s->pathcap ? ZOPFLI_GROW_CAP(s->pathcap) : 16;
       s->path = (uint16_t*)ZopfliRealloc(s->ctx, s->path,
                                          s->pathcap * sizeof(*s->path));
     }
-    s->path[s->pathsize++] = length_array[index];
-    assert(length_array[index] <= index);
-    assert(length_array[index] <= ZOPFLI_MAX_MATCH);
-    assert(length_array[index] != 0);
-    index -= length_array[index];
+    s->path[s->pathsize++] = length;
+    assert(length <= index);
+    assert(length <= ZOPFLI_MAX_MATCH);
+    assert(length != 0);
+    index -= length;
     if (index == 0) break;
   }
 
@@ -438,13 +435,13 @@ static void TraceBackwards(ZopfliBlockState* s, size_t size) {
 
 /*
 Outputs the lz77 symbols for the chosen path. Distances were already computed
-during GetBestLengths (dist_array, parallel to length_array), so unlike the
-forward pass, this needs no hash and no match recalculation.
+during GetBestLengths (packed into lendist_array), so unlike the forward pass,
+this needs no hash and no match recalculation.
 */
 static void FollowPath(ZopfliBlockState* s,
                        const uint8_t* in, size_t instart, size_t inend,
                        ZopfliLZ77Store* store) {
-  const uint16_t* dist_array = s->dist_array;
+  const uint32_t* lendist_array = s->lendist_array;
   size_t i, pos = instart;
   size_t cur = 0;  /* Position within the block, i.e. pos - instart. */
 
@@ -454,7 +451,7 @@ static void FollowPath(ZopfliBlockState* s,
     uint16_t length = s->path[i];
     assert(pos < inend);
     if (length >= ZOPFLI_MIN_MATCH) {
-      uint16_t dist = dist_array[cur + length];
+      uint16_t dist = (uint16_t)(lendist_array[cur + length] >> 16);
       ZopfliVerifyLenDist(in, inend, pos, dist, length);
       ZopfliStoreLitLenDist(s->ctx, length, dist, pos, store);
     } else {
@@ -474,20 +471,28 @@ static void CalculateStatistics(SymbolStats* stats, int shift) {
   ZopfliCalculateEntropy(stats->dists, ZOPFLI_NUM_D, stats->d_symbols, shift);
 }
 
-/* Appends the symbol statistics from the store. */
-static void GetStatistics(const ZopfliLZ77Store* store, SymbolStats* stats,
-                          int shift) {
+/* Computes the store's symbol histogram (including the end symbol). The
+btype-2 block size is a pure function of this histogram. */
+static void StoreHistogram(const ZopfliLZ77Store* store,
+                           size_t* ll_freqs, size_t* d_freqs) {
   size_t i;
+  for (i = 0; i < ZOPFLI_NUM_LL; i++) ll_freqs[i] = 0;
+  for (i = 0; i < ZOPFLI_NUM_D; i++) d_freqs[i] = 0;
   for (i = 0; i < store->size; i++) {
     if (store->dists[i] == 0) {
-      stats->litlens[store->litlens[i]]++;
+      ll_freqs[store->litlens[i]]++;
     } else {
-      stats->litlens[ZopfliGetLengthSymbol(store->litlens[i])]++;
-      stats->dists[ZopfliGetDistSymbol(store->dists[i])]++;
+      ll_freqs[ZopfliGetLengthSymbol(store->litlens[i])]++;
+      d_freqs[ZopfliGetDistSymbol(store->dists[i])]++;
     }
   }
-  stats->litlens[256] = 1;  /* End symbol. */
+  ll_freqs[256] = 1;  /* End symbol. */
+}
 
+/* Computes the symbol statistics from the store. */
+static void GetStatistics(const ZopfliLZ77Store* store, SymbolStats* stats,
+                          int shift) {
+  StoreHistogram(store, stats->litlens, stats->dists);
   CalculateStatistics(stats, shift);
 }
 
@@ -500,7 +505,7 @@ instart: where to start
 inend: where to stop (not inclusive)
 cache: precomputed fixed-point cost model for this squeeze run
 store: place to output the LZ77 data
-The working buffers (costs/length_array/dist_array/path) live in the block state.
+The working buffers (costs/lendist_array/path) live in the block state.
 returns the cost that was, according to the cost model, needed to get to the end.
     This is not the actual cost.
 */
@@ -521,10 +526,8 @@ at the end of the squeeze call. */
 static void AllocBlockBuffers(ZopfliBlockState* s, size_t blocksize) {
   s->costs = (ZopfliCost*)ZopfliRealloc(
       s->ctx, NULL, sizeof(*s->costs) * (blocksize + 1));
-  s->length_array = (uint16_t*)ZopfliRealloc(
-      s->ctx, NULL, sizeof(*s->length_array) * (blocksize + 1));
-  s->dist_array = (uint16_t*)ZopfliRealloc(
-      s->ctx, NULL, sizeof(*s->dist_array) * (blocksize + 1));
+  s->lendist_array = (uint32_t*)ZopfliRealloc(
+      s->ctx, NULL, sizeof(*s->lendist_array) * (blocksize + 1));
   s->path = NULL;
   s->pathsize = 0;
   s->pathcap = 0;
@@ -532,12 +535,10 @@ static void AllocBlockBuffers(ZopfliBlockState* s, size_t blocksize) {
 
 static void FreeBlockBuffers(ZopfliBlockState* s) {
   ZopfliRealloc(s->ctx, s->costs, 0);
-  ZopfliRealloc(s->ctx, s->length_array, 0);
-  ZopfliRealloc(s->ctx, s->dist_array, 0);
+  ZopfliRealloc(s->ctx, s->lendist_array, 0);
   ZopfliRealloc(s->ctx, s->path, 0);
   s->costs = NULL;
-  s->length_array = NULL;
-  s->dist_array = NULL;
+  s->lendist_array = NULL;
   s->path = NULL;
 }
 
@@ -551,6 +552,11 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   ZopfliHash hash;
   ZopfliHash* h = &hash;
   SymbolStats stats, beststats, laststats;
+  /* Fresh-parse histogram and the previous iteration's, for the repeated-parse
+  block-size shortcut. Heap-allocated: growing this frame moves the stack the
+  DP helpers run on, which measurably perturbs the hot loop. */
+  size_t* hists;
+  size_t *hist_ll, *hist_d, *prev_ll, *prev_d;
   int i;
   int shift = ZopfliGetCostShift(blocksize);
   CostCache cache;
@@ -567,6 +573,12 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   ZopfliInitLZ77Store(in, &currentstore);
   ZopfliAllocHash(s->ctx, ZOPFLI_WINDOW_SIZE, h);
   AllocBlockBuffers(s, blocksize);
+  hists = (size_t*)ZopfliRealloc(
+      s->ctx, NULL, sizeof(*hists) * 2 * (ZOPFLI_NUM_LL + ZOPFLI_NUM_D));
+  hist_ll = hists;
+  hist_d = hist_ll + ZOPFLI_NUM_LL;
+  prev_ll = hist_d + ZOPFLI_NUM_D;
+  prev_d = prev_ll + ZOPFLI_NUM_LL;
 
   /* Do regular deflate, then loop multiple shortest path runs, each time using
   the statistics of the previous run. */
@@ -584,9 +596,26 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     BuildStatCostCache(&stats, shift, &cache);
     LZ77OptimalRun(s, in, instart, inend, &cache, &currentstore, h, build_hash);
     if (i == 0) build_hash = !(s->lmc && s->lmc->all_complete);
-    cost = ZopfliCalculateBlockSizeScratch(s->ctx, &s->katascratch,
-                                           &currentstore, 0,
-                                           currentstore.size, 2);
+    /* The parse's histogram, computed once: it decides the repeated-parse
+    shortcut below and then becomes the next model's frequencies. */
+    StoreHistogram(&currentstore, hist_ll, hist_d);
+    if (i > 0 &&
+        memcmp(hist_ll, prev_ll, ZOPFLI_NUM_LL * sizeof(*hist_ll)) == 0 &&
+        memcmp(hist_d, prev_d, ZOPFLI_NUM_D * sizeof(*hist_d)) == 0) {
+      /* The block size is a pure function of the histogram, so a repeat of the
+      previous iteration's histogram must cost exactly the same. */
+      cost = lastcost;
+    } else {
+      /* The freshly computed histogram equals what the store would serve;
+      passing it in keeps currentstore's cumulative counts unmaterialized
+      across the whole iteration loop. */
+      cost = ZopfliCalculateBlockSizeGivenCounts(s->ctx, &s->katascratch,
+                                                 &currentstore, 0,
+                                                 currentstore.size,
+                                                 hist_ll, hist_d);
+    }
+    memcpy(prev_ll, hist_ll, ZOPFLI_NUM_LL * sizeof(*prev_ll));
+    memcpy(prev_d, hist_d, ZOPFLI_NUM_D * sizeof(*prev_d));
     if (s->ctx->options.verbose_more
         || (s->ctx->options.verbose && cost < bestcost)) {
       fprintf(stderr, "Iteration %d: %d bit\n", i, (int) cost);
@@ -598,8 +627,10 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
       bestcost = cost;
     }
     CopyStats(&stats, &laststats);
-    ClearStatFreqs(&stats);
-    GetStatistics(&currentstore, &stats, shift);
+    /* Reuse the already-computed histogram as the next model's frequencies. */
+    memcpy(stats.litlens, hist_ll, sizeof(stats.litlens));
+    memcpy(stats.dists, hist_d, sizeof(stats.dists));
+    CalculateStatistics(&stats, shift);
     if (lastrandomstep != -1) {
       /* This makes it converge slower but better. Do it only once the
       randomness kicks in so that if the user does few iterations, it gives a
@@ -616,6 +647,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     lastcost = cost;
   }
 
+  ZopfliRealloc(s->ctx, hists, 0);
   FreeBlockBuffers(s);
   ZopfliCleanLZ77Store(s->ctx, &currentstore);
   ZopfliCleanHash(s->ctx, h);


### PR DESCRIPTION
Performance pass with **compressed output bit-identical** in every configuration — verified by md5 of the outputs at `-i15`, `--i50`, and `--i200` on text and incompressible-binary corpora after every change, plus asserts-on (`-UNDEBUG`) runs and the GoogleTest suite.

## Measured (i9-8950HK, interleaved min-of-N, session-start baseline vs branch)

| workload | before | after | delta |
|---|---|---|---|
| 10 MB text, `--i15` | 13.97 s | 12.71 s | **−9.0%** |
| 3 MB text, `--i200` | 29.42 s | 27.01 s | **−8.2%** |
| 3 MB incompressible, `--i15` | 1.37 s | 1.20 s | **−12.4%** |
| peak RSS, 3 MB incompressible, `--i200` | 81.4 MB | 63.9 MB | **−21%** |

Peak RSS on 3 MB text: 15.9 → 15.3 MB.

## Changes

- **squeeze**: `length_array`+`dist_array` merged into one packed `uint32_t` `lendist_array` (`(dist << 16) | length`) so the DP improvement case is a single store; loop-invariant add hoisted in `UpdateCostForRange`.
- **cache**: `ZopfliMaxCachedSublen` → `ZOPFLI_INLINE` — it sits on the DP's per-position fast-path trigger and was a cross-TU call (~2% of `--i200`).
- **deflate**: `TryOptimizeHuffmanForRle` skips the second tree evaluation when the RLE-optimized code lengths are unchanged; the 8 `EncodeTree` RLE combos share one precomputed `TreeLens` (hlit/hdist trim + flattened length sequence).
- **squeeze**: repeated-parse shortcut — the btype-2 block size is a pure function of the symbol histogram, which is computed anyway for the next model; on a repeat, `lastcost` is reused and the tree evaluation skipped. Histogram buffers are heap-allocated (stack-frame growth above the DP measurably perturbs it).
- **lz77/cache**: `same0`/limit clamp hoisted out of the match-finder chain loop; LMC probe de-duplicated; single-pass `ZopfliSublenToCache`; fused `ZopfliInitCache` loops.
- **lz77**: `ZopfliVerifyLenDist` call sites compile away under `NDEBUG` (body was already dead; the per-match cross-TU call remained). Asserts-on builds keep the full check.
- **lz77**: lazily materialized cumulative store histograms (`counts_size` + `EnsureCounts`); `ZopfliCalculateBlockSizeGivenCounts` lets the per-iteration squeeze eval reuse its own histogram, so iteration refills never pay for histogram bookkeeping — also the source of the −21% RSS on incompressible input (copied stores no longer fault their count pages).
- **CHANGELOG.md**: `[Unreleased]` entry.

## Validation

- md5 bit-identity vs pre-change baseline: text/binary × `-i15`/`--i200` after every kept change, plus `--i50` asserts-on cross-checks.
- `make CFLAGS=-UNDEBUG` (asserts on, `ZopfliVerifyLenDist` active) runs the corpus cleanly.
- `ctest` (Debug, GoogleTest) passes; release build is `-Werror`-clean.
- Single-threaded only; no build-flag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/zopfli/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785632336&installation_id=141995922&pr_number=11&repository=QVXLabs%2Fzopfli&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fzopfli%2Fpull%2F11&signature=ed3a51a253136e71249d8e7e4d93cf2cad9328043bd9bd04d7a4cc6e6ea01af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->