### PR TITLE
Byte-identical memory reductions (−20% text / −28% binary peak RSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ changes go under a new top section as they land.
 ## [Unreleased]
 
 ### Changed
+- Memory reductions, output bit-identical. Peak RSS at `--i200` on 3 MB
+  inputs (i9-8950HK): text 15.4 → 12.3 MB (−20%), incompressible binary
+  63.7 → 45.6 MB (−28%). Internals: per-symbol LZ77 byte positions replaced
+  by sparse chunk checkpoints (8 bytes per symbol saved per resident store),
+  cumulative store histograms allocated only on first use, the longest-match
+  cache's run pool grown on demand instead of allocated at its full budget
+  up front (also a large allocated-footprint cut for small devices), and no
+  longest-match cache for the single-pass fixed-tree squeeze (it was written
+  but never read). Costs ~1-2% speed on text at matched settings; measured
+  ~6% faster on incompressible input.
 - Further hot-path performance work; compressed output is bit-identical in
   every configuration. Measured on an i9-8950HK: ~9% faster at the default
   iteration count and ~8% at `--i200` on text, ~12% faster on incompressible

--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -34,11 +34,14 @@ void ZopfliInitCache(const ZopfliContext* ctx, size_t blocksize,
   lmc->dist = (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(uint16_t) * blocksize);
   lmc->run_off =
       (unsigned*)ZopfliRealloc(ctx, NULL, sizeof(unsigned) * blocksize);
-  /* Same byte budget as the old fixed cache, used now as a shared run pool. */
+  /* Same byte budget as the old fixed cache, used now as a shared run pool.
+  Only a small initial allocation is made; ZopfliSublenToCache grows it on
+  demand toward the budget. */
   lmc->pool_cap = (size_t)ZOPFLI_CACHE_LENGTH * blocksize;
   lmc->pool_used = 0;
+  lmc->pool_alloc = ZOPFLI_MIN(lmc->pool_cap, 1024);
   lmc->all_complete = 1;
-  lmc->pool = (uint8_t*)ZopfliRealloc(ctx, NULL, 3 * lmc->pool_cap);
+  lmc->pool = (uint8_t*)ZopfliRealloc(ctx, NULL, 3 * lmc->pool_alloc);
   /* For an empty block (blocksize 0) the arrays above are zero-size and stay
   NULL; nothing below reads them. Real allocation failures abort inside
   ZopfliRealloc, so no out-of-memory check is needed here. */
@@ -61,7 +64,8 @@ void ZopfliCleanCache(const ZopfliContext* ctx, ZopfliLongestMatchCache* lmc) {
   ZopfliRealloc(ctx, lmc->run_off, 0);
 }
 
-void ZopfliSublenToCache(const uint16_t* sublen,
+void ZopfliSublenToCache(const ZopfliContext* ctx,
+                         const uint16_t* sublen,
                          size_t pos, size_t length,
                          ZopfliLongestMatchCache* lmc) {
   size_t i;
@@ -76,8 +80,8 @@ void ZopfliSublenToCache(const uint16_t* sublen,
   if (length < 3) return;
 
   /* Emit runs in a single sublen pass, straight into the pool's free space.
-  On overflow nothing is committed (pool_used is unchanged and free-slot
-  contents are never read), same as the position never fitting. */
+  On overflow of the budget nothing is committed (pool_used is unchanged and
+  free-slot contents are never read), same as the position never fitting. */
   avail = lmc->pool_cap - lmc->pool_used;
   run = &lmc->pool[lmc->pool_used * 3];
   for (i = 3; i <= length; i++) {
@@ -89,6 +93,15 @@ void ZopfliSublenToCache(const uint16_t* sublen,
         lmc->all_complete = 0;
         lmc->run_off[pos] = LMC_NO_SUBLEN;
         return;
+      }
+      if (lmc->pool_used + nruns == lmc->pool_alloc) {
+        /* Grow the allocation toward the budget; the budget check above is
+        what decides overflow, so growth never changes behavior. */
+        size_t newalloc = ZOPFLI_GROW_CAP(lmc->pool_alloc);
+        if (newalloc > lmc->pool_cap) newalloc = lmc->pool_cap;
+        lmc->pool = (uint8_t*)ZopfliRealloc(ctx, lmc->pool, 3 * newalloc);
+        lmc->pool_alloc = newalloc;
+        run = &lmc->pool[(lmc->pool_used + nruns) * 3];
       }
       run[0] = (uint8_t)(i - 3);
       run[1] = sublen[i] & 0xff;

--- a/src/zopfli/cache.h
+++ b/src/zopfli/cache.h
@@ -48,7 +48,11 @@ typedef struct ZopfliLongestMatchCache {
   uint8_t* pool;  /* Shared run pool, 3 bytes per run. */
   unsigned* run_off;  /* Per pos: first run index in pool, or LMC_NO_SUBLEN. */
   size_t pool_used;  /* Next free run slot. */
-  size_t pool_cap;  /* Pool capacity in runs. */
+  size_t pool_alloc;  /* Allocated pool slots; grows on demand up to pool_cap
+      (typical blocks use ~1.5 runs/pos, far below the budget, so allocating
+      the full budget up front would waste most of it). */
+  size_t pool_cap;  /* Pool budget in runs; overflowing it disables caching
+      for the position (all_complete = 0). */
   int all_complete;  /* 1 while every cached position has its full sublen. */
 } ZopfliLongestMatchCache;
 
@@ -59,8 +63,10 @@ void ZopfliInitCache(const ZopfliContext* ctx, size_t blocksize,
 /* Frees up the memory of the ZopfliLongestMatchCache. */
 void ZopfliCleanCache(const ZopfliContext* ctx, ZopfliLongestMatchCache* lmc);
 
-/* Stores sublen array in the cache. */
-void ZopfliSublenToCache(const uint16_t* sublen,
+/* Stores sublen array in the cache. ctx is needed because the run pool grows
+on demand. */
+void ZopfliSublenToCache(const ZopfliContext* ctx,
+                         const uint16_t* sublen,
                          size_t pos, size_t length,
                          ZopfliLongestMatchCache* lmc);
 

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -437,7 +437,8 @@ static size_t CalculateBlockSymbolSizeGivenCounts(const size_t* ll_counts,
 /*
 Calculates size of the part after the header and tree of an LZ77 block, in bits.
 */
-static size_t CalculateBlockSymbolSize(const unsigned* ll_lengths,
+static size_t CalculateBlockSymbolSize(const ZopfliContext* ctx,
+                                       const unsigned* ll_lengths,
                                        const unsigned* d_lengths,
                                        const ZopfliLZ77Store* lz77,
                                        size_t lstart, size_t lend) {
@@ -447,7 +448,7 @@ static size_t CalculateBlockSymbolSize(const unsigned* ll_lengths,
   } else {
     size_t ll_counts[ZOPFLI_NUM_LL];
     size_t d_counts[ZOPFLI_NUM_D];
-    ZopfliLZ77GetHistogram(lz77, lstart, lend, ll_counts, d_counts);
+    ZopfliLZ77GetHistogram(ctx, lz77, lstart, lend, ll_counts, d_counts);
     return CalculateBlockSymbolSizeGivenCounts(
         ll_counts, d_counts, ll_lengths, d_lengths, lz77, lstart, lend);
   }
@@ -630,7 +631,7 @@ static uint32_t GetDynamicLengths(const ZopfliContext* ctx,
   size_t ll_counts[ZOPFLI_NUM_LL];
   size_t d_counts[ZOPFLI_NUM_D];
 
-  ZopfliLZ77GetHistogram(lz77, lstart, lend, ll_counts, d_counts);
+  ZopfliLZ77GetHistogram(ctx, lz77, lstart, lend, ll_counts, d_counts);
   ll_counts[256] = 1;  /* End symbol. */
   return GetDynamicLengthsGivenCounts(ctx, scratch, lz77, lstart, lend,
                                       ll_counts, d_counts,
@@ -671,7 +672,7 @@ uint32_t ZopfliCalculateBlockSizeScratch(const ZopfliContext* ctx,
   } if (btype == 1) {
     GetFixedTree(ll_lengths, d_lengths);
     result += (uint32_t)CalculateBlockSymbolSize(
-        ll_lengths, d_lengths, lz77, lstart, lend);
+        ctx, ll_lengths, d_lengths, lz77, lstart, lend);
   } else {
     result += GetDynamicLengths(ctx, scratch, lz77, lstart, lend,
                                 ll_lengths, d_lengths);
@@ -794,7 +795,7 @@ static void AddLZ77Block(const ZopfliContext* ctx,
   size_t i;
   if (btype == 0) {
     size_t length = ZopfliLZ77GetByteRange(lz77, lstart, lend);
-    size_t pos = lstart == lend ? 0 : lz77->pos[lstart];
+    size_t pos = lstart == lend ? 0 : ZopfliLZ77Pos(lz77, lstart);
     size_t end = pos + length;
     AddNonCompressedBlock(ctx, final,
                           lz77->data, pos, end, bp, buf);
@@ -871,11 +872,14 @@ static void AddLZ77BlockAutoType(const ZopfliContext* ctx,
   ZopfliInitLZ77Store(lz77->data, &fixedstore);
   if (expensivefixed) {
     /* Recalculate the LZ77 with ZopfliLZ77OptimalFixed */
-    size_t instart = lz77->pos[lstart];
+    size_t instart = ZopfliLZ77Pos(lz77, lstart);
     size_t inend = instart + ZopfliLZ77GetByteRange(lz77, lstart, lend);
 
     ZopfliBlockState s;
-    ZopfliInitBlockState(ctx, instart, inend, 1, &s);
+    /* No LMC: the fixed-tree squeeze is a single forward pass, so every
+    position is match-found exactly once and a cache would be written but
+    never read. Skipping it saves the cache's whole footprint. */
+    ZopfliInitBlockState(ctx, instart, inend, 0, &s);
     ZopfliLZ77OptimalFixed(&s, lz77->data, instart, inend, &fixedstore);
     fixedcost = ZopfliCalculateBlockSizeScratch(ctx, scratch, &fixedstore, 0,
                                                 fixedstore.size, 1);
@@ -934,7 +938,9 @@ static void DeflatePart(const ZopfliContext* ctx, int btype, int final,
     ZopfliLZ77Store store;
     ZopfliBlockState s;
     ZopfliInitLZ77Store(in, &store);
-    ZopfliInitBlockState(ctx, instart, inend, 1, &s);
+    /* No LMC, as in AddLZ77BlockAutoType's fixed path: a single forward pass
+    writes the cache but never reads it back. */
+    ZopfliInitBlockState(ctx, instart, inend, 0, &s);
 
     ZopfliLZ77OptimalFixed(&s, in, instart, inend, &store);
     AddLZ77Block(ctx, &s.katascratch, btype, final, &store, 0, store.size, 0,

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -217,8 +217,11 @@ void ZopfliAppendLZ77Store(const ZopfliContext* ctx,
 
 size_t ZopfliLZ77Pos(const ZopfliLZ77Store* lz77, size_t lpos) {
   size_t i = lpos - lpos % ZOPFLI_POS_CHUNK;
-  size_t pos = lz77->pos_chunks[lpos / ZOPFLI_POS_CHUNK];
+  size_t pos;
+  /* Check the precondition before pos_chunks is indexed with it, so a bad
+  lpos fails the assert instead of reading out of bounds. */
   assert(lpos < lz77->size);
+  pos = lz77->pos_chunks[lpos / ZOPFLI_POS_CHUNK];
   for (; i < lpos; i++) {
     pos += lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
   }

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -31,7 +31,7 @@ void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store) {
   store->cap = 0;
   store->litlens = 0;
   store->dists = 0;
-  store->pos = 0;
+  store->pos_chunks = 0;
   store->data = data;
   store->ll_counts = 0;
   store->d_counts = 0;
@@ -41,7 +41,7 @@ void ZopfliInitLZ77Store(const uint8_t* data, ZopfliLZ77Store* store) {
 void ZopfliCleanLZ77Store(const ZopfliContext* ctx, ZopfliLZ77Store* store) {
   ZopfliRealloc(ctx, store->litlens, 0);
   ZopfliRealloc(ctx, store->dists, 0);
-  ZopfliRealloc(ctx, store->pos, 0);
+  ZopfliRealloc(ctx, store->pos_chunks, 0);
   ZopfliRealloc(ctx, store->ll_counts, 0);
   ZopfliRealloc(ctx, store->d_counts, 0);
 }
@@ -68,12 +68,18 @@ static void ZopfliReserveLZ77Store(const ZopfliContext* ctx,
       ctx, store->litlens, sizeof(*store->litlens) * newcap);
   store->dists = (uint16_t*)ZopfliRealloc(
       ctx, store->dists, sizeof(*store->dists) * newcap);
-  store->pos =
-      (size_t*)ZopfliRealloc(ctx, store->pos, sizeof(*store->pos) * newcap);
-  store->ll_counts = (uint32_t*)ZopfliRealloc(
-      ctx, store->ll_counts, sizeof(*store->ll_counts) * llc);
-  store->d_counts = (uint32_t*)ZopfliRealloc(
-      ctx, store->d_counts, sizeof(*store->d_counts) * dc);
+  store->pos_chunks = (size_t*)ZopfliRealloc(
+      ctx, store->pos_chunks,
+      sizeof(*store->pos_chunks) * (newcap / ZOPFLI_POS_CHUNK + 1));
+  /* The cumulative histograms are allocated on first materialization
+  (EnsureCounts); a store that never serves histogram queries never allocates
+  them. Once allocated, they grow with the capacity here. */
+  if (store->ll_counts) {
+    store->ll_counts = (uint32_t*)ZopfliRealloc(
+        ctx, store->ll_counts, sizeof(*store->ll_counts) * llc);
+    store->d_counts = (uint32_t*)ZopfliRealloc(
+        ctx, store->d_counts, sizeof(*store->d_counts) * dc);
+  }
   store->cap = newcap;
 }
 
@@ -85,24 +91,15 @@ void ZopfliResetLZ77Store(ZopfliLZ77Store* store) {
 void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
     const ZopfliLZ77Store* source, ZopfliLZ77Store* dest) {
   size_t i;
-  size_t llsize = ZOPFLI_NUM_LL * CeilDiv(source->size, ZOPFLI_NUM_LL);
-  size_t dsize = ZOPFLI_NUM_D * CeilDiv(source->size, ZOPFLI_NUM_D);
-  /* Only the materialized prefix of the counts needs copying; the dest can
-  materialize the rest from its own symbols on demand. */
-  size_t llvalid = ZOPFLI_NUM_LL * CeilDiv(source->counts_size, ZOPFLI_NUM_LL);
-  size_t dvalid = ZOPFLI_NUM_D * CeilDiv(source->counts_size, ZOPFLI_NUM_D);
   ZopfliCleanLZ77Store(ctx, dest);
   ZopfliInitLZ77Store(source->data, dest);
   dest->litlens =
       (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->litlens) * source->size);
   dest->dists =
       (uint16_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->dists) * source->size);
-  dest->pos =
-      (size_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->pos) * source->size);
-  dest->ll_counts =
-      (uint32_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->ll_counts) * llsize);
-  dest->d_counts =
-      (uint32_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->d_counts) * dsize);
+  dest->pos_chunks = (size_t*)ZopfliRealloc(
+      ctx, NULL,
+      sizeof(*dest->pos_chunks) * (source->size / ZOPFLI_POS_CHUNK + 1));
 
   dest->size = source->size;
   dest->cap = source->size;
@@ -110,13 +107,29 @@ void ZopfliCopyLZ77Store(const ZopfliContext* ctx,
   for (i = 0; i < source->size; i++) {
     dest->litlens[i] = source->litlens[i];
     dest->dists[i] = source->dists[i];
-    dest->pos[i] = source->pos[i];
   }
-  for (i = 0; i < llvalid; i++) {
-    dest->ll_counts[i] = source->ll_counts[i];
+  for (i = 0; i < CeilDiv(source->size, ZOPFLI_POS_CHUNK); i++) {
+    dest->pos_chunks[i] = source->pos_chunks[i];
   }
-  for (i = 0; i < dvalid; i++) {
-    dest->d_counts[i] = source->d_counts[i];
+  /* Only the materialized prefix of the counts exists and needs copying; the
+  dest can materialize the rest from its own symbols on demand. A source with
+  nothing materialized leaves the dest's counts unallocated. */
+  if (source->counts_size > 0) {
+    size_t llsize = ZOPFLI_NUM_LL * CeilDiv(source->size, ZOPFLI_NUM_LL);
+    size_t dsize = ZOPFLI_NUM_D * CeilDiv(source->size, ZOPFLI_NUM_D);
+    size_t llvalid =
+        ZOPFLI_NUM_LL * CeilDiv(source->counts_size, ZOPFLI_NUM_LL);
+    size_t dvalid = ZOPFLI_NUM_D * CeilDiv(source->counts_size, ZOPFLI_NUM_D);
+    dest->ll_counts =
+        (uint32_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->ll_counts) * llsize);
+    dest->d_counts =
+        (uint32_t*)ZopfliRealloc(ctx, NULL, sizeof(*dest->d_counts) * dsize);
+    for (i = 0; i < llvalid; i++) {
+      dest->ll_counts[i] = source->ll_counts[i];
+    }
+    for (i = 0; i < dvalid; i++) {
+      dest->d_counts[i] = source->d_counts[i];
+    }
   }
 }
 
@@ -132,7 +145,9 @@ void ZopfliStoreLitLenDist(const ZopfliContext* ctx, uint16_t length,
 
   store->litlens[origsize] = length;
   store->dists[origsize] = dist;
-  store->pos[origsize] = pos;
+  if (origsize % ZOPFLI_POS_CHUNK == 0) {
+    store->pos_chunks[origsize / ZOPFLI_POS_CHUNK] = pos;
+  }
   assert(length < 259);
 
   /* The cumulative histograms are not maintained here; EnsureCounts
@@ -149,9 +164,18 @@ the first chunk). Maintenance is deferred so stores that never serve histogram
 queries (the per-iteration squeeze refills) never pay for it. The const cast
 is an internal-caching detail: every store object is writable.
 */
-static void EnsureCounts(const ZopfliLZ77Store* cstore) {
+static void EnsureCounts(const ZopfliContext* ctx,
+                         const ZopfliLZ77Store* cstore) {
   ZopfliLZ77Store* store = (ZopfliLZ77Store*)cstore;
   size_t i, j;
+  if (!store->ll_counts) {
+    size_t llc = ZOPFLI_NUM_LL * CeilDiv(store->cap, ZOPFLI_NUM_LL);
+    size_t dc = ZOPFLI_NUM_D * CeilDiv(store->cap, ZOPFLI_NUM_D);
+    store->ll_counts = (uint32_t*)ZopfliRealloc(
+        ctx, NULL, sizeof(*store->ll_counts) * llc);
+    store->d_counts = (uint32_t*)ZopfliRealloc(
+        ctx, NULL, sizeof(*store->d_counts) * dc);
+  }
   for (i = store->counts_size; i < store->size; i++) {
     size_t llstart = ZOPFLI_NUM_LL * (i / ZOPFLI_NUM_LL);
     size_t dstart = ZOPFLI_NUM_D * (i / ZOPFLI_NUM_D);
@@ -181,18 +205,32 @@ void ZopfliAppendLZ77Store(const ZopfliContext* ctx,
                            const ZopfliLZ77Store* store,
                            ZopfliLZ77Store* target) {
   size_t i;
+  /* Positions are derived incrementally: each command advances by its own
+  byte length. */
+  size_t pos = store->size == 0 ? 0 : store->pos_chunks[0];
   for (i = 0; i < store->size; i++) {
     ZopfliStoreLitLenDist(ctx, store->litlens[i], store->dists[i],
-                          store->pos[i], target);
+                          pos, target);
+    pos += store->dists[i] == 0 ? 1 : store->litlens[i];
   }
+}
+
+size_t ZopfliLZ77Pos(const ZopfliLZ77Store* lz77, size_t lpos) {
+  size_t i = lpos - lpos % ZOPFLI_POS_CHUNK;
+  size_t pos = lz77->pos_chunks[lpos / ZOPFLI_POS_CHUNK];
+  assert(lpos < lz77->size);
+  for (; i < lpos; i++) {
+    pos += lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
+  }
+  return pos;
 }
 
 size_t ZopfliLZ77GetByteRange(const ZopfliLZ77Store* lz77,
                               size_t lstart, size_t lend) {
   size_t l = lend - 1;
   if (lstart == lend) return 0;
-  return lz77->pos[l] + ((lz77->dists[l] == 0) ?
-      1 : lz77->litlens[l]) - lz77->pos[lstart];
+  return ZopfliLZ77Pos(lz77, l) + ((lz77->dists[l] == 0) ?
+      1 : lz77->litlens[l]) - ZopfliLZ77Pos(lz77, lstart);
 }
 
 /* Lit/len Huffman symbol at store position i, recomputed from litlens/dists
@@ -227,7 +265,8 @@ static void ZopfliLZ77GetHistogramAt(const ZopfliLZ77Store* lz77, size_t lpos,
   }
 }
 
-void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
+void ZopfliLZ77GetHistogram(const ZopfliContext* ctx,
+                           const ZopfliLZ77Store* lz77,
                            size_t lstart, size_t lend,
                            size_t* ll_counts, size_t* d_counts) {
   size_t i;
@@ -241,7 +280,7 @@ void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
   } else {
     /* Subtract the cumulative histograms at the end and the start to get the
     histogram for this range. */
-    EnsureCounts(lz77);
+    EnsureCounts(ctx, lz77);
     ZopfliLZ77GetHistogramAt(lz77, lend - 1, ll_counts, d_counts);
     if (lstart > 0) {
       size_t ll_counts2[ZOPFLI_NUM_LL];
@@ -496,7 +535,7 @@ static void StoreInLongestMatchCache(ZopfliBlockState* s,
     s->lmc->dist[lmcpos] = length < ZOPFLI_MIN_MATCH ? 0 : distance;
     s->lmc->length[lmcpos] = length < ZOPFLI_MIN_MATCH ? 0 : length;
     assert(!(s->lmc->length[lmcpos] == 1 && s->lmc->dist[lmcpos] == 0));
-    ZopfliSublenToCache(sublen, lmcpos, length, s->lmc);
+    ZopfliSublenToCache(s->ctx, sublen, lmcpos, length, s->lmc);
   }
 }
 #endif

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -44,6 +44,10 @@ The memory can best be managed by using ZopfliInitLZ77Store to initialize it,
 ZopfliCleanLZ77Store to destroy it, and ZopfliStoreLitLenDist to append values.
 
 */
+/* LZ77 symbols per byte-position checkpoint in ZopfliLZ77Store. Power of two
+so the index math is shifts; 256 keeps the in-chunk derivation scan short. */
+#define ZOPFLI_POS_CHUNK 256
+
 typedef struct ZopfliLZ77Store {
   uint16_t* litlens;  /* Lit or len. */
   uint16_t* dists;  /* If 0: indicates literal in corresponding litlens,
@@ -52,7 +56,12 @@ typedef struct ZopfliLZ77Store {
   size_t cap;  /* Allocated capacity in lz77 symbols, for reuse across runs. */
 
   const uint8_t* data;  /* original data */
-  size_t* pos;  /* position in data where this LZ77 command begins */
+  /* Byte position in data where every ZOPFLI_POS_CHUNKth LZ77 command begins.
+  Each command advances by its own byte length, so per-symbol positions are
+  derivable; storing sparse checkpoints instead of one size_t per symbol
+  (ZopfliLZ77Pos recovers any position by summing within a chunk) saves 8
+  bytes per symbol per resident store. */
+  size_t* pos_chunks;
 
   /* Cumulative histograms wrapping around per chunk. Each chunk has the amount
   of distinct symbols as length, so using 1 value per LZ77 symbol, we have a
@@ -116,10 +125,15 @@ void ZopfliAppendLZ77Store(const ZopfliContext* ctx,
 /* Gets the amount of raw bytes that this range of LZ77 symbols spans. */
 size_t ZopfliLZ77GetByteRange(const ZopfliLZ77Store* lz77,
                               size_t lstart, size_t lend);
+/* Byte position in the data where LZ77 command lpos (< size) begins, derived
+from the chunk checkpoints. */
+size_t ZopfliLZ77Pos(const ZopfliLZ77Store* lz77, size_t lpos);
 /* Gets the histogram of lit/len and dist symbols in the given range, using the
 cumulative histograms, so faster than adding one by one for large range. Does
-not add the one end symbol of value 256. */
-void ZopfliLZ77GetHistogram(const ZopfliLZ77Store* lz77,
+not add the one end symbol of value 256. ctx is needed because the store's
+cumulative histograms are allocated and materialized on first use. */
+void ZopfliLZ77GetHistogram(const ZopfliContext* ctx,
+                            const ZopfliLZ77Store* lz77,
                             size_t lstart, size_t lend,
                             size_t* ll_counts, size_t* d_counts);
 

--- a/test/cache_test.cc
+++ b/test/cache_test.cc
@@ -22,7 +22,8 @@ TEST(Cache, SublenRoundTrip) {
   for (unsigned short i = 3; i <= length; i++) sublen[i] = i * 2;
 
   const size_t pos = 2;
-  ZopfliSublenToCache(sublen.data(), pos, length, &lmc);
+  ZopfliSublenToCache(ZopfliDefaultContext(), sublen.data(), pos, length,
+                      &lmc);
 
   unsigned maxcached = ZopfliMaxCachedSublen(&lmc, pos, length);
   EXPECT_GE(maxcached, 3u);

--- a/test/lz77_test.cc
+++ b/test/lz77_test.cc
@@ -32,6 +32,66 @@ TEST(Lz77, StoreAppendCopyByteRange) {
   ZopfliCleanLZ77Store(ZopfliDefaultContext(), &c);
 }
 
+TEST(Lz77, PosCheckpointsAcrossChunkBoundaries) {
+  // Positions are stored as sparse checkpoints (one per ZOPFLI_POS_CHUNK
+  // symbols) and derived in between, so verify every index against
+  // independently tracked positions across several chunk boundaries, with a
+  // non-zero start position and varying symbol byte-lengths.
+  const size_t nsymbols = 2 * ZOPFLI_POS_CHUNK + 90;
+  const size_t start = 7;
+  std::vector<unsigned char> data(64, 'a');
+  std::vector<size_t> expected;
+  ZopfliLZ77Store store;
+  ZopfliInitLZ77Store(data.data(), &store);
+
+  size_t pos = start;
+  for (size_t i = 0; i < nsymbols; i++) {
+    expected.push_back(pos);
+    if (i % 3 == 0) {
+      // Literal: advances by 1 byte.
+      ZopfliStoreLitLenDist(ZopfliDefaultContext(),
+                            (unsigned short)(i % 256), 0, pos, &store);
+      pos += 1;
+    } else {
+      // Match: advances by its length.
+      unsigned short length = (unsigned short)(3 + i % 20);
+      unsigned short dist = (unsigned short)(1 + i % 30);
+      ZopfliStoreLitLenDist(ZopfliDefaultContext(), length, dist, pos, &store);
+      pos += length;
+    }
+  }
+  ASSERT_EQ(store.size, nsymbols);
+
+  for (size_t i = 0; i < nsymbols; i++) {
+    EXPECT_EQ(ZopfliLZ77Pos(&store, i), expected[i]) << "at symbol " << i;
+  }
+  // Byte ranges, including chunk-boundary-straddling and empty ones.
+  EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 0, store.size), pos - start);
+  EXPECT_EQ(ZopfliLZ77GetByteRange(&store, ZOPFLI_POS_CHUNK - 1,
+                                   ZOPFLI_POS_CHUNK + 1),
+            expected[ZOPFLI_POS_CHUNK + 1] - expected[ZOPFLI_POS_CHUNK - 1]);
+  EXPECT_EQ(ZopfliLZ77GetByteRange(&store, 10, 2 * ZOPFLI_POS_CHUNK + 1),
+            expected[2 * ZOPFLI_POS_CHUNK + 1] - expected[10]);
+  EXPECT_EQ(ZopfliLZ77GetByteRange(&store, ZOPFLI_POS_CHUNK,
+                                   ZOPFLI_POS_CHUNK), 0u);
+
+  // Checkpoints must survive a copy and an append (which re-derives them).
+  ZopfliLZ77Store copy;
+  ZopfliInitLZ77Store(data.data(), &copy);
+  ZopfliCopyLZ77Store(ZopfliDefaultContext(), &store, &copy);
+  ZopfliLZ77Store appended;
+  ZopfliInitLZ77Store(data.data(), &appended);
+  ZopfliAppendLZ77Store(ZopfliDefaultContext(), &store, &appended);
+  for (size_t i = 0; i < nsymbols; i += ZOPFLI_POS_CHUNK / 2) {
+    EXPECT_EQ(ZopfliLZ77Pos(&copy, i), expected[i]) << "copy at " << i;
+    EXPECT_EQ(ZopfliLZ77Pos(&appended, i), expected[i]) << "append at " << i;
+  }
+
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &store);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &copy);
+  ZopfliCleanLZ77Store(ZopfliDefaultContext(), &appended);
+}
+
 TEST(Lz77, Histogram) {
   std::vector<unsigned char> in = zopfli_test::Bytes(
       "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc");

--- a/test/lz77_test.cc
+++ b/test/lz77_test.cc
@@ -40,7 +40,8 @@ TEST(Lz77, Histogram) {
 
   std::vector<size_t> ll(ZOPFLI_NUM_LL, 0);
   std::vector<size_t> d(ZOPFLI_NUM_D, 0);
-  ZopfliLZ77GetHistogram(&store, 0, store.size, ll.data(), d.data());
+  ZopfliLZ77GetHistogram(ZopfliDefaultContext(), &store, 0, store.size,
+                         ll.data(), d.data());
 
   size_t ll_total = 0;
   for (size_t v : ll) ll_total += v;


### PR DESCRIPTION
Stacked on #11 (base branch `perf/byte-identical-pass`; retargets to `master` automatically when #11 merges).

Memory pass with **compressed output bit-identical** in every configuration — md5-verified at `-i15`, `--i50`, and `--i200` on text and incompressible-binary corpora, asserts-exercised runs clean, GoogleTest suite green. Allocation was attributed first with `MallocStackLogging` + `malloc_history` at peak, then reduced top-down.

## Measured (i9-8950HK, `/usr/bin/time -l`, `--i200`, 3 MB inputs)

| input | before | after | delta |
|---|---|---|---|
| text | 15.4 MB | 12.3 MB | **−20%** |
| incompressible binary | 63.7 MB | 45.6 MB | **−28%** |

## Changes

- **lz77**: the per-symbol `pos[]` array (8 B/symbol in every resident store; 17.5 MB live on the binary case) is replaced by sparse chunk checkpoints (`pos_chunks`, one `size_t` per 256 symbols). Positions are a prefix sum of symbol byte-lengths, so `ZopfliLZ77Pos` derives any position with a short in-chunk summation. Random access only occurs at block boundaries and in `ZopfliLZ77GetByteRange`, both cold.
- **lz77**: cumulative store histograms are allocated on first materialization (`EnsureCounts`); `ZopfliLZ77GetHistogram` gained a `ctx` parameter. Squeeze iteration stores never allocate them at all.
- **cache**: the longest-match cache's run pool grows geometrically on demand (`pool_alloc`) toward its `pool_cap` budget instead of eagerly allocating 24 B/position (typical blocks use ~1.5 runs/pos of the 8 budgeted). Overflow is still decided by the budget, so caching behavior — and output — is identical. Chiefly an allocated-footprint win for small-device targets without lazy page commit.
- **deflate**: `add_lmc=0` for both `ZopfliLZ77OptimalFixed` call sites — the fixed-tree squeeze is a single forward pass, so its cache was written but provably never read. This removes the actual peak-RSS spike on binary (a second full LMC alive at block-write time) and measures **~6% faster** on incompressible input.
- **CHANGELOG.md**: memory entry appended to `[Unreleased]`.

## Speed tradeoff, stated plainly

Text wall time at matched settings moved ~+2% (interleaved min-of-4, both `-i15` and `--i200`); profiling attributes only ~0.5% to touched code (`SublenToCache` pool-growth checks) with the rest inside this machine's documented ±2% code-layout noise band. Incompressible input is ~6% **faster**. Accepted for the memory win, consistent with the existing 16-bit-hash-table precedent.

## Validation

- md5 bit-identity vs baseline: text/binary × `-i15`/`--i200` after every change, plus `--i50` asserts-exercised cross-checks.
- `ctest` (Debug/GoogleTest) passes; release build is `-Werror`-clean; tests updated for the two internal signature changes (`ZopfliLZ77GetHistogram`, `ZopfliSublenToCache` now take `ctx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/zopfli/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785634329&installation_id=141995922&pr_number=12&repository=QVXLabs%2Fzopfli&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fzopfli%2Fpull%2F12&signature=a519a3af4ec7dade05cc3dd55ec47150f46b0230b78880de8cbf5f3cc93d2eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->