### PR TITLE
Bug-hunt fixes (test-first) + behavior-preserving simplification pass

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           submodules: recursive
 
+      # zlib enables the round-trip (compress -> inflate -> compare) tests,
+      # which self-skip without it.
+      - name: Install zlib
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
+
       - name: Configure
         run: >
           cmake -S . -B build
@@ -39,7 +44,34 @@ jobs:
         run: cmake --build build --config ${{ matrix.build_type }} -j
 
       - name: Test
-        run: ./build/zopfli_tests
+        run: ctest --test-dir build --output-on-failure
 
       - name: Makefile build
         run: make
+
+  sanitize:
+    name: clang / Debug + ASan/UBSan
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install zlib
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
+          -DBUILD_TESTING=ON
+          -DZOPFLI_SANITIZE=ON
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ changes go under a new top section as they land.
 
 ## [Unreleased]
 
+### Fixed
+- Library: a negative `ZopfliOptions.numiterations` silently produced a
+  stream that inflates to less than the input in release builds (the
+  iteration loop never ran, emitting empty block bodies). Non-positive
+  values now select the auto default, matching the documented 0 semantics.
+- CLI: write failures (disk full, closed pipe) were ignored — truncated
+  output with exit status 0. `fwrite`/`fclose`/`fflush` are now checked and
+  any failure exits nonzero, as do missing input files and argument errors.
+- CLI: `--i` values are validated (`strtol`): junk suffixes like `--i5x`
+  (previously parsed as 5) and out-of-range counts (previously undefined
+  behavior via `atoi`, in practice an unbounded run) are rejected.
+- Internal: Huffman code-length construction errors are no longer swallowed
+  in release builds (they would encode an invalid all-zero code); the
+  encoder now fails loudly. Unreachable for valid inputs.
+
 ### Changed
+- Behavior-preserving simplifications (dead fields/conditions/temporaries,
+  deduplicated tree-combo selection and split-point conversion); output
+  verified bit-identical.
+- Tests: round-trip verification now runs in Linux CI (zlib installed); raw
+  DEFLATE round-trip coverage added; CLI error paths covered by a ctest
+  script; new `ZOPFLI_SANITIZE` CMake option and an ASan/UBSan CI job;
+  `enable_testing()` was missing, so `ctest` on a fresh clone ran nothing.
 - Memory reductions, output bit-identical. Peak RSS at `--i200` on 3 MB
   inputs (i9-8950HK): text 15.4 → 12.3 MB (−20%), incompressible binary
   63.7 → 45.6 MB (−28%). Internals: per-symbol LZ77 byte positions replaced

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,8 @@ if(BUILD_TESTING)
     test/fixedpoint_range_test.cc
     test/custom_allocator_test.cc
     test/version_test.cc
+    test/api_contract_test.cc
+    test/roundtrip_deflate_test.cc
   )
   target_link_libraries(zopfli_tests PRIVATE libzopfli GTest::gtest_main)
   set_target_properties(zopfli_tests PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ option(ZOPFLI_PIC "Build with position-independent code" OFF)
 # Line-coverage instrumentation (gcc/clang); use with the test suite.
 option(ZOPFLI_COVERAGE "Build with coverage instrumentation" OFF)
 
+# Address + undefined-behavior sanitizers (gcc/clang); use with a Debug build
+# so asserts stay live.
+option(ZOPFLI_SANITIZE "Build with ASan and UBSan" OFF)
+
 # Default ON; gtest is run directly, so include(CTest) is intentionally unused.
 if(NOT DEFINED BUILD_TESTING)
   set(BUILD_TESTING ON)
@@ -45,6 +49,10 @@ endif()
 if(ZOPFLI_COVERAGE)
   add_compile_options(--coverage -O0 -g)
   link_libraries(--coverage)
+endif()
+if(ZOPFLI_SANITIZE)
+  add_compile_options(-fsanitize=address,undefined -fno-sanitize-recover=all)
+  link_libraries(-fsanitize=address,undefined)
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,15 @@ if(BUILD_TESTING)
     target_link_libraries(zopfli_tests PRIVATE ZLIB::ZLIB)
     target_compile_definitions(zopfli_tests PRIVATE ZOPFLI_TEST_HAVE_ZLIB)
   endif()
+
+  # Register with ctest (CI also runs the gtest binary directly).
+  enable_testing()
+  add_test(NAME zopfli_tests COMMAND zopfli_tests)
+  if(UNIX)
+    add_test(NAME zopfli_cli
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test/cli_test.sh
+              $<TARGET_FILE:zopfli>)
+  endif()
 endif()
 
 #

--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -158,35 +158,21 @@ static void PrintBlockSplitPoints(const ZopfliContext* ctx,
                                   const ZopfliLZ77Store* lz77,
                                   const size_t* lz77splitpoints,
                                   size_t nlz77points) {
-  size_t* splitpoints = NULL;
-  size_t npoints = 0;
+  /* The input is given as lz77 indices; print the uncompressed byte offsets,
+  relative to the store's first symbol. */
+  size_t base = nlz77points > 0 ? ZopfliLZ77Pos(lz77, 0) : 0;
   size_t i;
-  /* The input is given as lz77 indices, but we want to see the uncompressed
-  index values. */
-  size_t pos = 0;
-  if (nlz77points > 0) {
-    for (i = 0; i < lz77->size; i++) {
-      size_t length = lz77->dists[i] == 0 ? 1 : lz77->litlens[i];
-      if (lz77splitpoints[npoints] == i) {
-        ZOPFLI_APPEND_DATA(ctx, pos, &splitpoints, &npoints);
-        if (npoints == nlz77points) break;
-      }
-      pos += length;
-    }
-  }
-  assert(npoints == nlz77points);
+  (void)ctx;
 
   fprintf(stderr, "block split points: ");
-  for (i = 0; i < npoints; i++) {
-    fprintf(stderr, "%zu ", splitpoints[i]);
+  for (i = 0; i < nlz77points; i++) {
+    fprintf(stderr, "%zu ", ZopfliLZ77Pos(lz77, lz77splitpoints[i]) - base);
   }
   fprintf(stderr, "(hex:");
-  for (i = 0; i < npoints; i++) {
-    fprintf(stderr, " %zx", splitpoints[i]);
+  for (i = 0; i < nlz77points; i++) {
+    fprintf(stderr, " %zx", ZopfliLZ77Pos(lz77, lz77splitpoints[i]) - base);
   }
   fprintf(stderr, ")\n");
-
-  ZopfliRealloc(ctx, splitpoints, 0);
 }
 
 /*
@@ -267,7 +253,8 @@ void ZopfliBlockSplitLZ77(const ZopfliOptions* options,
 
     origcost = EstimateCost(ctx, &scratch, lz77, lstart, lend);
 
-    if (splitcost > origcost || llpos == lstart + 1 || llpos == lend) {
+    /* FindMinimum returns a point in [lstart + 1, lend), per the asserts. */
+    if (splitcost > origcost || llpos == lstart + 1) {
       done[lstart] = 1;
     } else {
       AddSorted(ctx, llpos, splitpoints, npoints);
@@ -297,7 +284,6 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
                       size_t maxblocks, size_t** splitpoints, size_t* npoints) {
   ZopfliContext ctxv;
   const ZopfliContext* ctx = &ctxv;
-  size_t pos = 0;
   size_t i;
   ZopfliBlockState s;
   size_t* lz77splitpoints = NULL;
@@ -324,16 +310,9 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
                        &lz77splitpoints, &nlz77points);
 
   /* Convert LZ77 positions to positions in the uncompressed input. */
-  pos = instart;
-  if (nlz77points > 0) {
-    for (i = 0; i < store.size; i++) {
-      size_t length = store.dists[i] == 0 ? 1 : store.litlens[i];
-      if (lz77splitpoints[*npoints] == i) {
-        ZOPFLI_APPEND_DATA(ctx, pos, splitpoints, npoints);
-        if (*npoints == nlz77points) break;
-      }
-      pos += length;
-    }
+  for (i = 0; i < nlz77points; i++) {
+    ZOPFLI_APPEND_DATA(ctx, ZopfliLZ77Pos(&store, lz77splitpoints[i]),
+                       splitpoints, npoints);
   }
   assert(*npoints == nlz77points);
 

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -1058,9 +1058,8 @@ void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
   size_t offset = buf->size;
   ZopfliContext ctx;
   ctx.options = *options;
-  /* Any non-positive value selects the auto default. Without this guard a
-  negative count would run zero squeeze iterations, emitting blocks with an
-  empty body: a structurally valid stream that silently loses the data. */
+  /* <= 0 selects the auto default; a negative count would otherwise run zero
+  squeeze iterations and silently emit empty block bodies. */
   if (ctx.options.numiterations <= 0)
     ctx.options.numiterations = AutoIterations(insize);
   if (ctx.options.verbose && options->numiterations <= 0) {

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -1058,10 +1058,12 @@ void ZopfliDeflateBuf(const ZopfliOptions* options, int btype, int final,
   size_t offset = buf->size;
   ZopfliContext ctx;
   ctx.options = *options;
-  assert(ctx.options.numiterations >= 0);
-  if (ctx.options.numiterations == 0)
+  /* Any non-positive value selects the auto default. Without this guard a
+  negative count would run zero squeeze iterations, emitting blocks with an
+  empty body: a structurally valid stream that silently loses the data. */
+  if (ctx.options.numiterations <= 0)
     ctx.options.numiterations = AutoIterations(insize);
-  if (ctx.options.verbose && options->numiterations == 0) {
+  if (ctx.options.verbose && options->numiterations <= 0) {
     fprintf(stderr, "Auto iterations: %d (input %zu bytes)\n",
             ctx.options.numiterations, insize);
   }

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -272,27 +272,41 @@ static size_t EncodeTree(const ZopfliContext* ctx,
   return result_size;
 }
 
+/*
+Sizes all 8 use_16/17/18 RLE combos and returns the index of the smallest
+(first wins ties), with its size in *bestsize.
+*/
+static int SelectBestTreeCombo(const ZopfliContext* ctx,
+                               ZopfliKatajainenScratch* scratch,
+                               const TreeLens* t, size_t* bestsize) {
+  int i;
+  int best = 0;
+  size_t bs = 0;
+
+  for (i = 0; i < 8; i++) {
+    size_t size = EncodeTree(ctx, scratch, t,
+                             i & 1, i & 2, i & 4,
+                             0, NULL);
+    if (bs == 0 || size < bs) {
+      bs = size;
+      best = i;
+    }
+  }
+  *bestsize = bs;
+  return best;
+}
+
 static void AddDynamicTree(const ZopfliContext* ctx,
                            ZopfliKatajainenScratch* scratch,
                            const unsigned* ll_lengths,
                            const unsigned* d_lengths,
                            uint8_t* bp, ZopfliBuf* buf) {
   TreeLens t;
-  int i;
-  int best = 0;
-  size_t bestsize = 0;
+  int best;
+  size_t bestsize;
 
   BuildTreeLens(ll_lengths, d_lengths, &t);
-  for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(ctx, scratch, &t,
-                             i & 1, i & 2, i & 4,
-                             0, NULL);
-    if (bestsize == 0 || size < bestsize) {
-      bestsize = size;
-      best = i;
-    }
-  }
-
+  best = SelectBestTreeCombo(ctx, scratch, &t, &bestsize);
   EncodeTree(ctx, scratch, &t,
              best & 1, best & 2, best & 4,
              bp, buf);
@@ -306,17 +320,10 @@ static size_t CalculateTreeSize(const ZopfliContext* ctx,
                                 const unsigned* ll_lengths,
                                 const unsigned* d_lengths) {
   TreeLens t;
-  size_t result = 0;
-  int i;
+  size_t result;
 
   BuildTreeLens(ll_lengths, d_lengths, &t);
-  for(i = 0; i < 8; i++) {
-    size_t size = EncodeTree(ctx, scratch, &t,
-                             i & 1, i & 2, i & 4,
-                             0, NULL);
-    if (result == 0 || size < result) result = size;
-  }
-
+  SelectBestTreeCombo(ctx, scratch, &t, &result);
   return result;
 }
 
@@ -789,7 +796,7 @@ static void AddLZ77Block(const ZopfliContext* ctx,
   unsigned d_lengths[ZOPFLI_NUM_D];
   unsigned ll_symbols[ZOPFLI_NUM_LL];
   unsigned d_symbols[ZOPFLI_NUM_D];
-  size_t detect_block_size = buf->size;
+  size_t detect_block_size;
   size_t compressed_size;
   size_t uncompressed_size = 0;
   size_t i;

--- a/src/zopfli/katajainen.c
+++ b/src/zopfli/katajainen.c
@@ -290,7 +290,8 @@ int ZopfliLengthLimitedCodeLengthsScratch(
     ZopfliRealloc(ctx, scratch->lists, 0);
     scratch->lists =
         ZopfliRealloc(ctx, NULL, (size_t)maxbits * 2 * sizeof(Node*));
-    scratch->lists_cap = scratch->lists ? (size_t)maxbits : 0;
+    /* ZopfliRealloc aborts on failure, so the allocation always succeeded. */
+    scratch->lists_cap = (size_t)maxbits;
   }
   lists = (Node* (*)[2])scratch->lists;
   InitLists(&pool, leaves, maxbits, lists);

--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -305,7 +305,6 @@ void ZopfliInitBlockState(const ZopfliContext* ctx,
                           ZopfliBlockState* s) {
   s->ctx = ctx;
   s->blockstart = blockstart;
-  s->blockend = blockend;
   ZopfliInitKatajainenScratch(&s->katascratch);
   /* Squeeze working buffers; allocated lazily by ZopfliLZ77Optimal[Fixed]. */
   s->costs = NULL;
@@ -488,7 +487,7 @@ static int TryGetFromLongestMatchCache(ZopfliBlockState* s,
       (*limit == ZOPFLI_MAX_MATCH || lmclen <= *limit ||
       (sublen && maxsub >= *limit));
 
-  if (limit_ok_for_cache && cache_available) {
+  if (limit_ok_for_cache) {
     if (!sublen || lmclen <= maxsub) {
       *length = lmclen;
       if (*length > *limit) *length = (uint16_t)*limit;

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -88,9 +88,9 @@ typedef struct ZopfliBlockState {
   ZopfliLongestMatchCache* lmc;
 #endif
 
-  /* The start (inclusive) and end (not inclusive) of the current block. */
+  /* The start of the current block; the longest-match cache is indexed
+  relative to it. */
   size_t blockstart;
-  size_t blockend;
 
   /* Reused scratch for length-limited Huffman code construction, so the hot
   block-size evaluations don't malloc/free per call. Per block state, so

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -261,7 +261,6 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
   uint16_t sublen[259];
   size_t windowstart = instart > ZOPFLI_WINDOW_SIZE
       ? instart - ZOPFLI_WINDOW_SIZE : 0;
-  ZopfliCost result;
   ZopfliCost mincost = cache->mincost;
   ZopfliCost mincostaddcostj;
 
@@ -318,8 +317,8 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
     }
 #endif
 
-    /* Literal. */
-    if (i + 1 <= inend) {
+    /* Literal. i < inend here, so j + 1 <= blocksize stays in bounds. */
+    {
       ZopfliCost newCost = cache->lit_cost[in[i]] + costs[j];
       assert(newCost >= 0);
       if (newCost < costs[j + 1]) {
@@ -394,9 +393,7 @@ static ZopfliCost GetBestLengths(ZopfliBlockState *s,
   }
 
   assert(costs[blocksize] >= 0);
-  result = costs[blocksize];
-
-  return result;
+  return costs[blocksize];
 }
 
 /*
@@ -668,7 +665,6 @@ void ZopfliLZ77OptimalFixed(ZopfliBlockState *s,
   AllocBlockBuffers(s, blocksize);
 
   s->blockstart = instart;
-  s->blockend = inend;
 
   /* Shortest path for fixed tree This one should give the shortest possible
   result for fixed tree, no repeated runs are needed since the tree is known. */

--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -120,8 +120,14 @@ void ZopfliCalculateBitLengthsScratch(const ZopfliContext* ctx,
                                       unsigned* bitlengths) {
   int error = ZopfliLengthLimitedCodeLengthsScratch(
       ctx, scratch, count, (int)n, maxbits, bitlengths);
-  (void) error;
-  assert(!error);
+  /* No error channel here, and continuing would encode an all-zero (invalid)
+  Huffman code: fail loudly, like the allocator's out-of-memory policy.
+  Unreachable for in-tree inputs. */
+  if (error) {
+    fprintf(stderr, "zopfli: length-limited Huffman code construction "
+                    "failed (maxbits too small for symbol count)\n");
+    exit(EXIT_FAILURE);
+  }
 }
 
 void ZopfliCalculateBitLengths(const ZopfliContext* ctx, const size_t* count,

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -32,7 +32,7 @@ static unsigned adler32(const uint8_t* data, size_t size)
 {
   static const unsigned sums_overflow = 5550;
   unsigned s1 = 1;
-  unsigned s2 = 1 >> 16;
+  unsigned s2 = 0;
 
   while (size > 0) {
     size_t amount = ZOPFLI_MIN(size, sums_overflow);

--- a/src/zopfli/zopfli.h
+++ b/src/zopfli/zopfli.h
@@ -50,7 +50,8 @@ typedef struct ZopfliOptions {
 
   /*
   Times to rerun the LZ77 optimization pass. 0 (default) = auto: a size-
-  dependent count, larger for larger inputs. A value > 0 forces that fixed count.
+  dependent count, larger for larger inputs. A value > 0 forces that fixed
+  count. Negative values are treated as 0 (auto).
   */
   int numiterations;
 

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -31,6 +31,8 @@ decompressor.
 #endif
 
 #include <assert.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -80,7 +82,8 @@ static int LoadFile(const char* filename,
   it caps near 4 GB. */
   if ((unsigned long long)filesize > (unsigned long long)SIZE_MAX) {
     fprintf(stderr, "File too large to load into memory on this build.\n");
-    exit(EXIT_FAILURE);
+    fclose(file);
+    return 0;
   }
   *outsize = (size_t)filesize;
 
@@ -104,46 +107,61 @@ static int LoadFile(const char* filename,
 }
 
 /*
-Saves a file from a memory array, overwriting the file if it existed.
+Saves a file from a memory array, overwriting the file if it existed. Returns
+1 on success, 0 on any write error (the buffered data may only fail at
+fclose, so its result matters too).
 */
-static void SaveFile(const char* filename,
-                     const uint8_t* in, size_t insize) {
+static int SaveFile(const char* filename,
+                    const uint8_t* in, size_t insize) {
   FILE* file = fopen(filename, "wb" );
   if (file == NULL) {
-      fprintf(stderr,"Error: Cannot write to output file, terminating.\n");
-      exit (EXIT_FAILURE);
+    fprintf(stderr, "Error: Cannot write to output file %s\n", filename);
+    return 0;
   }
-  assert(file);
-  fwrite((char*)in, 1, insize, file);
-  fclose(file);
+  if (fwrite((char*)in, 1, insize, file) != insize) {
+    fprintf(stderr, "Error: Failed to write output file %s\n", filename);
+    fclose(file);
+    return 0;
+  }
+  if (fclose(file) != 0) {
+    fprintf(stderr, "Error: Failed to write output file %s\n", filename);
+    return 0;
+  }
+  return 1;
 }
 
 /*
-outfilename: filename to write output to, or 0 to write to stdout instead
+outfilename: filename to write output to, or 0 to write to stdout instead.
+Returns 1 on success, 0 on failure (input unreadable or output not fully
+written).
 */
-static void CompressFile(const ZopfliOptions* options,
-                         ZopfliFormat output_type,
-                         const char* infilename,
-                         const char* outfilename) {
+static int CompressFile(const ZopfliOptions* options,
+                        ZopfliFormat output_type,
+                        const char* infilename,
+                        const char* outfilename) {
   uint8_t* in;
   size_t insize;
   uint8_t* out = 0;
   size_t outsize = 0;
+  int ok = 1;
   if (!LoadFile(infilename, &in, &insize)) {
     fprintf(stderr, "Invalid filename: %s\n", infilename);
-    return;
+    return 0;
   }
 
   ZopfliCompress(options, output_type, in, insize, &out, &outsize);
 
   if (outfilename) {
-    SaveFile(outfilename, out, outsize);
+    ok = SaveFile(outfilename, out, outsize);
   } else {
 #if _WIN32
     /* Windows workaround for stdout output. */
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
-    fwrite(out, 1, outsize, stdout);
+    if (fwrite(out, 1, outsize, stdout) != outsize || fflush(stdout) != 0) {
+      fprintf(stderr, "Error: Failed to write output to stdout\n");
+      ok = 0;
+    }
   }
 
   /* out came from ZopfliCompress via options->zrealloc, so free it through the
@@ -154,6 +172,7 @@ static void CompressFile(const ZopfliOptions* options,
     free(out);
   }
   ZopfliRealloc(ZopfliDefaultContext(), in, 0);
+  return ok;
 }
 
 /*
@@ -176,6 +195,7 @@ int main(int argc, char* argv[]) {
   ZopfliFormat output_type = ZOPFLI_FORMAT_GZIP;
   const char* filename = 0;
   int output_to_stdout = 0;
+  int exit_status = EXIT_SUCCESS;
   int i;
 
   ZopfliInitOptions(&options);
@@ -192,7 +212,15 @@ int main(int argc, char* argv[]) {
     else if (StringsEqual(arg, "--splitlast"))  /* Ignore */;
     else if (arg[0] == '-' && arg[1] == '-' && arg[2] == 'i'
         && arg[3] >= '0' && arg[3] <= '9') {
-      options.numiterations = atoi(arg + 3);
+      char* end;
+      long value;
+      errno = 0;
+      value = strtol(arg + 3, &end, 10);
+      if (*end != '\0' || errno == ERANGE || value > INT_MAX) {
+        fprintf(stderr, "Error: invalid iteration count: %s\n", arg);
+        return EXIT_FAILURE;
+      }
+      options.numiterations = (int)value;
     }
     else if (StringsEqual(arg, "-h")) {
       fprintf(stderr,
@@ -213,11 +241,6 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  if (options.numiterations < 0) {
-    fprintf(stderr, "Error: number of iterations must be 0 (auto) or more\n");
-    return 0;
-  }
-
   for (i = 1; i < argc; i++) {
     if (argv[i][0] != '-') {
       char* outfilename;
@@ -235,7 +258,9 @@ int main(int argc, char* argv[]) {
       if (options.verbose && outfilename) {
         fprintf(stderr, "Saving to: %s\n", outfilename);
       }
-      CompressFile(&options, output_type, filename, outfilename);
+      if (!CompressFile(&options, output_type, filename, outfilename)) {
+        exit_status = EXIT_FAILURE;
+      }
       ZopfliRealloc(ZopfliDefaultContext(), outfilename, 0);
     }
   }
@@ -243,7 +268,8 @@ int main(int argc, char* argv[]) {
   if (!filename) {
     fprintf(stderr,
             "Please provide filename\nFor help, type: %s -h\n", argv[0]);
+    exit_status = EXIT_FAILURE;
   }
 
-  return 0;
+  return exit_status;
 }

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -107,9 +107,9 @@ static int LoadFile(const char* filename,
 }
 
 /*
-Saves a file from a memory array, overwriting the file if it existed. Returns
-1 on success, 0 on any write error (the buffered data may only fail at
-fclose, so its result matters too).
+Saves a file from a memory array, overwriting the file if it existed.
+Returns 1 on success, 0 on any write error (buffered writes can fail as
+late as fclose).
 */
 static int SaveFile(const char* filename,
                     const uint8_t* in, size_t insize) {

--- a/test/api_contract_test.cc
+++ b/test/api_contract_test.cc
@@ -1,0 +1,40 @@
+#include "zopfli_c_api.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+// A caller passing a negative numiterations (out of contract, but easy to
+// reach from the C API) must not lose data. Before the fix, the iteration
+// loop in ZopfliLZ77Optimal never ran, so blocks were emitted with an empty
+// body: a structurally valid stream that inflates to less than the input.
+// In assert-enabled builds the old code aborted instead.
+#ifdef ZOPFLI_TEST_HAVE_ZLIB
+TEST(ApiContract, NegativeIterationsRoundTrips) {
+  // Compressible content across a couple of blocks' worth of data.
+  std::vector<unsigned char> in;
+  for (int i = 0; i < 50000; i++) {
+    in.push_back((unsigned char)("zopfli data "[i % 12] + i / 5000));
+  }
+
+  ZopfliOptions options;
+  ZopfliInitOptions(&options);
+  options.numiterations = -1;
+
+  zopfli_test::Output gz;
+  ZopfliCompress(&options, ZOPFLI_FORMAT_GZIP,
+                 in.data(), in.size(), gz.out(), gz.size_ptr());
+  EXPECT_EQ(zopfli_test::Inflate(gz.bytes(), 31), in);
+
+  zopfli_test::Output zl;
+  ZopfliCompress(&options, ZOPFLI_FORMAT_ZLIB,
+                 in.data(), in.size(), zl.out(), zl.size_ptr());
+  EXPECT_EQ(zopfli_test::Inflate(zl.bytes(), 15), in);
+}
+#else
+TEST(ApiContract, NegativeIterationsRoundTrips) {
+  GTEST_SKIP() << "zlib not available";
+}
+#endif
+
+}  // namespace

--- a/test/api_contract_test.cc
+++ b/test/api_contract_test.cc
@@ -4,11 +4,9 @@
 
 namespace {
 
-// A caller passing a negative numiterations (out of contract, but easy to
-// reach from the C API) must not lose data. Before the fix, the iteration
-// loop in ZopfliLZ77Optimal never ran, so blocks were emitted with an empty
-// body: a structurally valid stream that inflates to less than the input.
-// In assert-enabled builds the old code aborted instead.
+// Negative numiterations must not lose data. It used to run zero squeeze
+// iterations, emitting valid-looking blocks with empty bodies (assert-enabled
+// builds aborted instead).
 #ifdef ZOPFLI_TEST_HAVE_ZLIB
 TEST(ApiContract, NegativeIterationsRoundTrips) {
   // Compressible content across a couple of blocks' worth of data.

--- a/test/cli_test.sh
+++ b/test/cli_test.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# CLI error-path tests. Usage: cli_test.sh /path/to/zopfli
+# Each case prints PASS/FAIL; exits nonzero if any case fails.
+# These cases expose (pre-fix) silently-ignored failures: junk/overflowing
+# --i values accepted, missing input files and write errors exiting 0.
+set -u
+
+ZOPFLI=$1
+TMPDIR_T=$(mktemp -d) || exit 2
+trap 'rm -rf "$TMPDIR_T"' EXIT
+status=0
+
+fail() { echo "FAIL: $1"; status=1; }
+pass() { echo "PASS: $1"; }
+
+# A compressible test input.
+i=0
+while [ $i -lt 200 ]; do
+  printf 'zopfli cli test data line %d\n' $i
+  i=$((i+1))
+done > "$TMPDIR_T/in.txt"
+
+# An incompressible input whose compressed size exceeds any pipe buffer, so
+# a closed pipe actually makes the output fwrite fail.
+dd if=/dev/urandom of="$TMPDIR_T/big.bin" bs=1024 count=300 2> /dev/null
+
+# 1. Junk suffix in --i must be rejected, not silently parsed as a prefix.
+if "$ZOPFLI" --i5x -c "$TMPDIR_T/in.txt" > /dev/null 2> "$TMPDIR_T/err1"; then
+  fail "--i5x accepted (exit 0)"
+else
+  pass "--i5x rejected"
+fi
+
+# 2. Out-of-range --i must be rejected, not overflow/hang.
+if "$ZOPFLI" --i9999999999999 -c "$TMPDIR_T/in.txt" \
+    > /dev/null 2> "$TMPDIR_T/err2"; then
+  fail "--i9999999999999 accepted (exit 0)"
+else
+  pass "--i9999999999999 rejected"
+fi
+
+# 3. --i0 (auto) stays valid.
+if "$ZOPFLI" --i0 -c "$TMPDIR_T/in.txt" > "$TMPDIR_T/out0.gz" \
+    2> /dev/null && [ -s "$TMPDIR_T/out0.gz" ]; then
+  pass "--i0 accepted"
+else
+  fail "--i0 rejected or empty output"
+fi
+
+# 4. Missing input file must yield a nonzero exit.
+if "$ZOPFLI" --i5 "$TMPDIR_T/no-such-file" > /dev/null 2>&1; then
+  fail "missing input file exited 0"
+else
+  pass "missing input file rejected"
+fi
+
+# 5. No filename at all must yield a nonzero exit.
+if "$ZOPFLI" --i5 > /dev/null 2>&1; then
+  fail "no-filename invocation exited 0"
+else
+  pass "no-filename invocation rejected"
+fi
+
+# 6. Write failure on stdout (EPIPE with SIGPIPE ignored) must be detected.
+# The subshell ignores SIGPIPE; the exec'd child inherits that disposition,
+# so fwrite fails with EPIPE instead of the process being killed. The reader
+# takes 1 byte and closes; the ~300 KB output cannot fit any pipe buffer, so
+# the write must fail. A fifo is used because POSIX sh has no PIPESTATUS to
+# read the left side of a pipeline.
+mkfifo "$TMPDIR_T/fifo"
+head -c 1 < "$TMPDIR_T/fifo" > /dev/null &
+headpid=$!
+( trap '' PIPE; exec "$ZOPFLI" --i1 -c "$TMPDIR_T/big.bin" 2> /dev/null ) \
+    > "$TMPDIR_T/fifo"
+zstatus=$?
+wait $headpid 2> /dev/null
+if [ "$zstatus" -eq 0 ]; then
+  fail "stdout write failure (EPIPE) exited 0"
+else
+  pass "stdout write failure detected (exit $zstatus)"
+fi
+
+# 7. Write failure to a full device (Linux only; /dev/full).
+if [ -w /dev/full ] 2> /dev/null; then
+  if "$ZOPFLI" --i1 -c "$TMPDIR_T/big.bin" > /dev/full 2> /dev/null; then
+    fail "write to /dev/full exited 0"
+  else
+    pass "write to /dev/full detected"
+  fi
+else
+  echo "SKIP: /dev/full not available"
+fi
+
+exit $status

--- a/test/cli_test.sh
+++ b/test/cli_test.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 # CLI error-path tests. Usage: cli_test.sh /path/to/zopfli
-# Each case prints PASS/FAIL; exits nonzero if any case fails.
-# These cases expose (pre-fix) silently-ignored failures: junk/overflowing
-# --i values accepted, missing input files and write errors exiting 0.
+# Prints PASS/FAIL per case; exits nonzero if any case fails.
 set -u
 
 ZOPFLI=$1
@@ -20,8 +18,8 @@ while [ $i -lt 200 ]; do
   i=$((i+1))
 done > "$TMPDIR_T/in.txt"
 
-# An incompressible input whose compressed size exceeds any pipe buffer, so
-# a closed pipe actually makes the output fwrite fail.
+# Incompressible input: output exceeds any pipe buffer, so a closed pipe
+# makes the output write fail.
 dd if=/dev/urandom of="$TMPDIR_T/big.bin" bs=1024 count=300 2> /dev/null
 
 # 1. Junk suffix in --i must be rejected, not silently parsed as a prefix.
@@ -61,12 +59,10 @@ else
   pass "no-filename invocation rejected"
 fi
 
-# 6. Write failure on stdout (EPIPE with SIGPIPE ignored) must be detected.
-# The subshell ignores SIGPIPE; the exec'd child inherits that disposition,
-# so fwrite fails with EPIPE instead of the process being killed. The reader
-# takes 1 byte and closes; the ~300 KB output cannot fit any pipe buffer, so
-# the write must fail. A fifo is used because POSIX sh has no PIPESTATUS to
-# read the left side of a pipeline.
+# 6. Write failure on stdout must be detected. The exec'd child inherits the
+# ignored SIGPIPE, so the write fails with EPIPE instead of killing the
+# process. A fifo captures the compressor's exit code (POSIX sh has no
+# PIPESTATUS).
 mkfifo "$TMPDIR_T/fifo"
 head -c 1 < "$TMPDIR_T/fifo" > /dev/null &
 headpid=$!

--- a/test/katajainen_test.cc
+++ b/test/katajainen_test.cc
@@ -52,9 +52,21 @@ TEST(Katajainen, ManySymbolsSatisfyKraft) {
 TEST(Katajainen, MaxBitsTooSmallIsError) {
   // 5 symbols cannot be coded with a max length of 2 bits.
   size_t freqs[5] = {1, 1, 1, 1, 1};
-  unsigned bitlengths[5] = {0};
+  unsigned bitlengths[5] = {1, 1, 1, 1, 1};
   EXPECT_EQ(ZopfliLengthLimitedCodeLengths(kCtx, freqs, 5, 2, bitlengths),
             1);
+  // The error contract: outputs are defined (all zero), never partial.
+  for (int i = 0; i < 5; i++) EXPECT_EQ(bitlengths[i], 0u);
+}
+
+TEST(KatajainenDeathTest, WrapperTerminatesOnError) {
+  // The wrapper has no error channel, so it must terminate loudly. Release
+  // builds used to swallow the error and encode an all-zero (invalid) code.
+  size_t freqs[19];
+  unsigned bitlengths[19];
+  for (int i = 0; i < 19; i++) freqs[i] = (size_t)(i + 1);
+  EXPECT_DEATH(ZopfliCalculateBitLengths(kCtx, freqs, 19, 3, bitlengths),
+               "");
 }
 
 TEST(Katajainen, ZeroFrequencySymbolsIgnored) {

--- a/test/roundtrip_deflate_test.cc
+++ b/test/roundtrip_deflate_test.cc
@@ -1,0 +1,40 @@
+#include "zopfli_c_api.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+#ifdef ZOPFLI_TEST_HAVE_ZLIB
+
+// Raw DEFLATE (window_bits -15) round-trips. gzip and zlib are covered by
+// FixedPointRange.CompressRoundTrip; the raw format shares the deflate body
+// but has no container framing to hide bit-level mistakes at the tail.
+TEST(RoundTrip, DeflateRawSizes) {
+  // Cross the stored-block chunk limit (65535) and the 1 MB master-block
+  // boundary; include the empty input.
+  const size_t sizes[] = {0, 1, 300, 65535, 65536, 1000000, 1000001};
+  for (size_t size : sizes) {
+    SCOPED_TRACE(size);
+    std::vector<unsigned char> random = zopfli_test::PseudoRandom(size);
+    std::vector<unsigned char> repetitive(size);
+    for (size_t i = 0; i < size; i++) {
+      repetitive[i] = (unsigned char)("abcdefgh"[(i / 3) % 8]);
+    }
+    for (const auto& in : {random, repetitive}) {
+      ZopfliOptions options;
+      ZopfliInitOptions(&options);
+      options.numiterations = 3;
+
+      zopfli_test::Output out;
+      ZopfliCompress(&options, ZOPFLI_FORMAT_DEFLATE,
+                     in.data(), in.size(), out.out(), out.size_ptr());
+      EXPECT_EQ(zopfli_test::Inflate(out.bytes(), -15), in);
+    }
+  }
+}
+
+#else
+TEST(RoundTrip, DeflateRawSizes) { GTEST_SKIP() << "zlib not available"; }
+#endif
+
+}  // namespace

--- a/test/roundtrip_deflate_test.cc
+++ b/test/roundtrip_deflate_test.cc
@@ -18,7 +18,10 @@ TEST(RoundTrip, DeflateRawSizes) {
     for (size_t i = 0; i < size; i++) {
       repetitive[i] = (unsigned char)("abcdefgh"[(i / 3) % 8]);
     }
-    for (const auto& in : {random, repetitive}) {
+    // Iterate by pointer: a braced list of the vectors themselves would
+    // copy them into the initializer_list's backing array.
+    for (const auto* inp : {&random, &repetitive}) {
+      const std::vector<unsigned char>& in = *inp;
       ZopfliOptions options;
       ZopfliInitOptions(&options);
       options.numiterations = 3;

--- a/test/roundtrip_deflate_test.cc
+++ b/test/roundtrip_deflate_test.cc
@@ -6,12 +6,10 @@ namespace {
 
 #ifdef ZOPFLI_TEST_HAVE_ZLIB
 
-// Raw DEFLATE (window_bits -15) round-trips. gzip and zlib are covered by
-// FixedPointRange.CompressRoundTrip; the raw format shares the deflate body
-// but has no container framing to hide bit-level mistakes at the tail.
+// Raw DEFLATE round-trips (gzip/zlib are covered elsewhere; the raw format
+// has no container framing to hide bit-level mistakes at the tail).
 TEST(RoundTrip, DeflateRawSizes) {
-  // Cross the stored-block chunk limit (65535) and the 1 MB master-block
-  // boundary; include the empty input.
+  // Crosses the 65535 stored-chunk limit and the 1 MB master-block boundary.
   const size_t sizes[] = {0, 1, 300, 65535, 65536, 1000000, 1000001};
   for (size_t size : sizes) {
     SCOPED_TRACE(size);


### PR DESCRIPTION
Two related passes in one stack: a bug hunt where **every fix is preceded by a test that demonstrably failed against the unfixed code**, followed by a simplification pass with output verified bit-identical.

## Bugs found and fixed (test-first)

| Bug | Severity | Pre-fix exposure (captured) | Fix |
|---|---|---|---|
| Negative `numiterations` via the C API silently loses data in release builds (iteration loop never runs → empty block bodies; only an NDEBUG-stripped assert guarded it) | **High** | NDEBUG repro: 50,000 bytes in → **9-byte** zlib stream; Debug: assert abort | `<= 0` selects the auto default; documented in `zopfli.h`. Test: `ApiContract.NegativeIterationsRoundTrips` |
| CLI ignores write failures — disk-full/EPIPE writes truncated output, exits 0 | Medium | Old binary exited 0 after a failed stdout write | `fwrite`/`fclose`/`fflush` checked; nonzero exit on any failed file. Test: `test/cli_test.sh` (new `zopfli_cli` ctest) |
| `--i#` parsed with `atoi`: `--i5x` silently = 5; huge values are UB | Low-Med | `--i5x` accepted (exit 0); `--i9999999999999` observed hanging | `strtol` with junk-suffix + range rejection |
| `LoadFile` `exit()`s the whole batch on an oversized file (contract says return 0) | Low | 32-bit-only path; untestable on 64-bit | Returns 0 like every other failure path |
| Huffman code-length errors swallowed (`(void)error; assert(!error)`) → release encodes an invalid all-zero code | Low (unreachable in-tree) | NDEBUG repro: bad args returned normally with 0/19 lengths set | Fails loudly (stderr + exit), matching the OOM policy. Death test + error-contract assertions |

## Test-infra defects fixed

- `enable_testing()`/`add_test` didn't exist — **ctest on a fresh clone ran nothing**. Both the gtest suite and the CLI script are now registered.
- Round-trip tests **never ran in CI** (no leg installs zlib). Linux CI now installs zlib, runs ctest, and gains a clang ASan/UBSan job (`ZOPFLI_SANITIZE` option).
- Raw `ZOPFLI_FORMAT_DEFLATE` was never round-trip verified anywhere — new test covers it (empty input, 65535 stored-chunk limit, 1 MB master boundary).

## Dynamic sweep (clean)

ASan/UBSan over: full suite (44/44), 12 edge inputs × 3 formats (0 B–16 MB runs), corpus at `-i15`/`--i50`, and 852 randomized compress→inflate→compare round-trips — zero reports, zero mismatches. The static sweeps traced the hot core and the deflate machinery without a confirmed defect.

## Simplification pass (net −18 lines, behavior frozen)

Dead `blockend` field; redundant `&& cache_available`; tautological DP literal guard; deduplicated 8-combo tree argmin (`SelectBestTreeCombo`); both LZ77-index→byte-offset walks replaced with `ZopfliLZ77Pos` checkpoint lookups; dead `|| llpos == lend`; never-NULL ternary; dead initializer; `1 >> 16` → 0. Each item carries its equivalence proof in the commit message.

## Validation

- Normal-input output **bit-identical** to master (md5 matrix: text/binary × `-i15`/`--i200`) after every commit; verbose split-point output diffed byte-for-byte where its code was rewritten.
- Interleaved speed check vs master-equivalent binary: no regression (−0.8%/−1.2%, within noise).
- ctest green throughout (now 2 registered tests); release build `-Werror`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/QVXLabs/codesmith/zopfli/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785641516&installation_id=141995922&pr_number=13&repository=QVXLabs%2Fzopfli&return_to=https%3A%2F%2Fgithub.com%2FQVXLabs%2Fzopfli%2Fpull%2F13&signature=0f7ab5b1f666de8d8759ae53a4f12096a7c410494dd80a097bee6848ba6e92f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->